### PR TITLE
Fix custom `TodoList` implementation API

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -474,15 +474,15 @@ In order to deal with that type of refactoring, one can explicitly decide to sup
 Given the code above, the replacement class would only need to implement the `.push()` and `.map()` methods. By freezing APIs and swapping implementations, the developer can completely avoid touching other layers in the application while refactoring.
 
 ```javascript
-todo.Todo = Array;
+todo.TodoList = Array;
 ```
 
 becomes:
 
 ```javascript
-todo.Todo = {
-	push: function() { /*...*/ },
-	map: function() { /*...*/ }
+todo.TodoList = function () {
+	this.push = function() { /*...*/ },
+	this.map = function() { /*...*/ }
 };
 ```
 


### PR DESCRIPTION
The example custom implementation of `TodoList` doesn't take into account that the `TodoList` is created with `new`.  This change implements it as a function instead of an object to remedy this.
