### PR TITLE
Allow m.prop to be JSON.stringify-ed

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -313,10 +313,14 @@ new function(window) {
 	
 	//model
 	m.prop = function(store) {
-		return function() {
+		var f = function() {
 			if (arguments.length) store = arguments[0]
 			return store
 		}
+		f.toJSON = function() {
+			return store
+		}
+		return f
 	}
 
 	m.deferred = function() {

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -389,6 +389,14 @@ function testMithril(mock) {
 		prop("foo")
 		return prop() == "foo"
 	})
+	test(function() {
+		var prop = m.prop("test")
+		return JSON.stringify(prop) == "\"test\""
+	})
+	test(function() {
+		var obj = { prop: m.prop("test") }
+		return JSON.stringify(obj) == "{\"prop\":\"test\"}"
+	})
 
 	//m.request
 	test(function() {


### PR DESCRIPTION
The main use case for this is when storing an object containing props such as

```
var model = {
    name: m.prop(""),
    age: m.prop("")
}
```

And then passing that off to `m.request`. Normally, it would be converted to an empty object because functions don't get serialized. Adding a `toJSON` method allows us to override that and return the actual value.

I do think it's inefficient to assign the function every time, but I can't think of a better way to do it.
