### PR TITLE
Allow capturing a postfix "rest of path" as route parameter

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -305,12 +305,12 @@ Mithril = m = new function app(window) {
 		for (var route in router) {
 			if (route == path) return !void m.module(root, router[route])
 			
-			var matcher = new RegExp("^" + route.replace(/:[^\/]+/g, "([^\\/]+)") + "$")
+			var matcher = new RegExp("^" + route.replace(/::.+$/g, "(.*)").replace(/:[^\/]+/g, "([^\\/]+)") + "$")
 			if (matcher.test(path)) {
 				return !void path.replace(matcher, function() {
-					var keys = route.match(/:[^\/]+/g)
+					var keys = route.match(/:?:[^\/]+/g)
 					var values = [].slice.call(arguments, 1, -2)
-					for (var i = 0; i < keys.length; i++) routeParams[keys[i].slice(1)] = values[i]
+					for (var i = 0; i < keys.length; i++) routeParams[keys[i].replace(/^::?/, "")] = values[i]
 					m.module(root, router[route])
 				})
 			}

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -489,6 +489,19 @@ function testMithril(mock) {
 		mock.performance.$elapse(50) //teardown
 		return routeValueBefore === "/test7/foo" && routeValueAfter === "/"
 	})
+	test(function() {
+		mock.performance.$elapse(50) //setup
+		mock.location.search = "?"
+		
+		var root = mock.document.createElement("div")
+		m.route.mode = "search"
+		m.route(root, "/test8/foo/SEP/bar/baz", {
+			"/test8/:test/SEP/::path": {controller: function() {}, view: function() {
+				return m.route.param("test") + "_" + m.route.param("path") }}
+		})
+		mock.performance.$elapse(50) //teardown
+		return mock.location.search == "?/test8/foo/SEP/bar/baz" && root.childNodes[0].nodeValue === "foo_bar/baz"
+	})
 
 	//m.prop
 	test(function() {


### PR DESCRIPTION
Allows the following syntax for route strings:
   "/users/:userid/files/::path"

A ::-prefixed name may be supplied last in the string, and in the
example above this allows matching on strings like this:
   "/users/123/files/Pictures/Summer2012"
where userid="123" and path="Pictures/Summer1012"
or
   "/users/123/files/"
where userid="123" and path="".
(so unlike other parameters, this one can be empty)
