### PR TITLE
Added support for trailing slashes in routes

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -310,11 +310,11 @@ Mithril = m = new function app(window) {
 		for (var route in router) {
 			if (route == path) return !void m.module(root, router[route])
 			
-			var matcher = new RegExp("^" + route.replace(/:[^\/]+?\.{3}/g, "(.*?)").replace(/:[^\/]+/g, "([^\\/]+)") + "$")
+			var matcher = new RegExp("^" + route.replace(/:[^\/]+?\.{3}/g, "(.*?)").replace(/:[^\/]+/g, "([^\\/]+)") + "\/?$")
 			
 			if (matcher.test(path)) {
 				return !void path.replace(matcher, function() {
-					var keys = route.match(/:[^\/]+/g)
+					var keys = route.match(/:[^\/]+/g) || []
 					var values = [].slice.call(arguments, 1, -2)
 					for (var i = 0; i < keys.length; i++) routeParams[keys[i].replace(/:|\./g, "")] = decodeURIComponent(values[i])
 					m.module(root, router[route])

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -573,6 +573,21 @@ function testMithril(mock) {
 		mock.performance.$elapse(50) //teardown
 		return root.childNodes[0].nodeValue === "foo bar"
 	})
+	test(function() {
+		mock.performance.$elapse(50) //setup
+		mock.location.search = "?"
+
+		var root = mock.document.createElement("div")
+		m.route.mode = "search"
+		m.route(root, "/", {
+			"/": {controller: function() {}, view: function() {return "foo"}},
+			"/test11": {controller: function() {}, view: function() {return "bar"}}
+		})
+		mock.performance.$elapse(50)
+		m.route("/test11/")
+		mock.performance.$elapse(50) //teardown
+		return mock.location.search == "?/test11/" && root.childNodes[0].nodeValue === "bar"
+	})
 	//end m.route
 
 	//m.prop


### PR DESCRIPTION
First: Thx a lot for your very inspiring work on mithril, keep it going!

I just added support for ignoring the trailing slash on a path when matched against the routes.

I solved it with the regexp-matcher for the params. Would be much clearer/cleaner to just add the line

```
if(path != "/") path = path.replace(/\/$/, "")
```

to the top of `routeByValue`, but in the spirit of 3k...
