### PR TITLE
m.sync: Also use result index when creating failure callback

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -443,7 +443,7 @@ Mithril = m = new function app(window) {
 		var outstanding = args.length
 		var results = new Array(outstanding)
 		for (var i = 0; i < args.length; i++) {
-			args[i].then(synchronizer(i, true), synchronizer(false))
+			args[i].then(synchronizer(i, true), synchronizer(i, false))
 		}
 		return deferred.promise
 	}


### PR DESCRIPTION
I missed this case in #102, as @Raynos [spotted](https://github.com/lhorie/mithril.js/pull/102/files#r13113486) -- sorry!
