### PR TITLE
Correcting example in routing doc.

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -37,7 +37,7 @@ var dashboard = {
 		this.id = m.route.param("userID");
 	},
 	view: function(controller) {
-		m.render("body", controller.id);
+		return m("div", controller.id);
 	}
 }
 


### PR DESCRIPTION
The existing code doesn't work. I suspect this is what you intended. It does highlight that `m.route` calls `m.module(document.body, dashboard)` "under the hood."

Also possible is `m.render(document, controller.id);`.
