### PR TITLE
Possible correction to web services sample code

### DIFF
--- a/docs/web-services.md
+++ b/docs/web-services.md
@@ -143,7 +143,7 @@ var users = m.request({method: "GET", url: "/user"})
 		//add one more user to the response
 		return users.concat({name: "Jane"})
 	})
-
+	
 function log(load) {
     console.log(load)
     return load


### PR DESCRIPTION
`m.request(...).then(console.log)` produces '''Uncaught TypeError: Illegal invocation at mithril.js:413```. That's a shame as this syntax would be elegant.

This avoids the issue in the sample code.
