### PR TITLE
Correcting web services unwrapping code doc

### DIFF
--- a/docs/web-services.md
+++ b/docs/web-services.md
@@ -195,7 +195,7 @@ var users = m.request({
 		return response.data;
 	},
 	unwrapError: function(response) {
-		return response.error;
+		return JSON.parse(response).error;
 	}
 });
 


### PR DESCRIPTION
`response` in `unwrapError: function(response) {...}` is a string, unless `extract` modifies the response beforehand.
