### PR TITLE
Allowing content-type to be set on m.request

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -51,7 +51,7 @@ Mithril = m = new function app(window) {
 
 		if (dataType == "[object Array]") {
 			var nodes = [], intact = cached.length === data.length, subArrayCount = 0
-			
+
 			var DELETION = 1, INSERTION = 2 , MOVE = 3
 			var existing = {}, shouldMaintainIdentities = false
 			for (var i = 0; i < cached.length; i++) {
@@ -71,7 +71,7 @@ Mithril = m = new function app(window) {
 				var actions = Object.keys(existing).map(function(key) {return existing[key]})
 				var changes = actions.sort(function(a, b) {return a.action - b.action || b.index - a.index})
 				var newCached = new Array(cached.length)
-				
+
 				for (var i = 0, change; change = changes[i]; i++) {
 					if (change.action == DELETION) {
 						clear(cached[change.index].nodes)
@@ -83,7 +83,7 @@ Mithril = m = new function app(window) {
 						parentElement.insertBefore(dummy, parentElement.childNodes[change.index])
 						newCached.splice(change.index, 0, {attrs: {key: data[change.index].attrs.key}, nodes: [dummy]})
 					}
-					
+
 					if (change.action == MOVE) {
 						if (parentElement.childNodes[change.index] !== change.element) {
 							parentElement.insertBefore(change.element, parentElement.childNodes[change.index])
@@ -95,7 +95,7 @@ Mithril = m = new function app(window) {
 				cached.nodes = []
 				for (var i = 0, child; child = parentElement.childNodes[i]; i++) cached.nodes.push(child)
 			}
-			
+
 			for (var i = 0, cacheCount = 0; i < data.length; i++) {
 				var item = build(parentElement, parentTag, cached, index, data[i], cached[cacheCount], shouldReattach, index + subArrayCount || subArrayCount, editable, namespace, configs)
 				if (item === undefined) continue
@@ -116,7 +116,7 @@ Mithril = m = new function app(window) {
 				if (data.length < cached.length) cached.length = data.length
 				cached.nodes = nodes
 			}
-			
+
 		}
 		else if (dataType == "[object Object]") {
 			if (data.tag != cached.tag || Object.keys(data.attrs).join() != Object.keys(cached.attrs).join() || data.attrs.id != cached.attrs.id) clear(cached.nodes)
@@ -540,6 +540,7 @@ Mithril = m = new function app(window) {
 	function ajax(options) {
 		var xhr = new window.XMLHttpRequest
 		xhr.open(options.method, options.url, true, options.user, options.password)
+    if (options.contentType) xhr.setRequestHeader('Content-type',options.contentType)
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState === 4) {
 				if (xhr.status >= 200 && xhr.status < 300) options.onload({type: "load", target: xhr})


### PR DESCRIPTION
Node's popular Express server, for example, doesn't correctly parse the JSON body on m.request's POST request without a Content-type header of `application/json`.

This patch permits a contentType option, but it may be better for Mithril to default a header on non-GET requests. 
