### PR TITLE
fixed routing issue when no 'HTML' or 'BODY' tags are available.

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -290,9 +290,9 @@ Mithril = m = new function app(window) {
 			if (html === undefined) html = window.document.createElement("html")
 			if (node.nodeName == "HTML") html = node
 			else html.appendChild(node)
-			if (window.document.documentElement !== html) {
+			if (window.document.documentElement && window.document.documentElement !== html) {
 				window.document.replaceChild(html, window.document.documentElement)
-			}
+			} else window.document.appendChild(html)
 		},
 		insertBefore: function(node) {
 			this.appendChild(node)


### PR DESCRIPTION
When experimenting with routing I noticed that you need `HTML` and `BODY` tags so using the [`johndoe` routing example](http://lhorie.github.io/mithril/mithril.route.html#defining-routes) I found the problem. `window.document.documentElement` is `null`. Which doesn't allow the `replaceChild` method to work properly. 

I only tested on the example code as I wasn't sure how your tests worked.

So the below code didn't work before but with the PR it should work now:

``` javascript
<!doctype html>
<script src="mithril.js"></script>
<script>
//a sample module
var dashboard = {
    controller: function() {
        this.id = m.route.param("userID");
    },
    view: function(controller) {
        return m('body', [m("div", controller.id)])
    }
}

//define a route
m.route(document, "/dashboard/johndoe", {
    "/dashboard/:userID": dashboard
});

//setup routes to start w/ the `#` symbol
m.route.mode = "hash";
</script>
```

The original error in the console was:

`Uncaught NotFoundError: Failed to execute 'replaceChild' on 'Node': The node to be replaced is null.`
