### PR TITLE
Collection.length is read-only, isn't it?

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -237,7 +237,6 @@ Mithril = m = new function app(window) {
 				if (cached[i]) unload(cached[i])
 			}
 		}
-		nodes.length = 0
 	}
 	function unload(cached) {
 		if (cached.configContext && typeof cached.configContext.onunload == "function") cached.configContext.onunload()


### PR DESCRIPTION
Opera fires an Uncaught exception: DOMException: NO_MODIFICATION_ALLOWED_ERR
when Mithril tries to set nodes.length = 0
