### PR TITLE
Add a main script in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"scripts": {
 		"test": "grunt test"
 	},
+	"main": "mithril.js",
 	"devDependencies": {
 		"grunt-cli": "*",
 		"grunt-contrib-copy": "*",


### PR DESCRIPTION
This allows to `require('mithril')` rather than `require('mithril/mithril')` with Browserify.
