### PR TITLE
Don't insert blank text node into every tag (yet another IE8 issue)

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -29,7 +29,8 @@ Mithril = m = new function app(window) {
 		return cell
 	}
 	function build(parentElement, parentTag, parentCache, parentIndex, data, cached, shouldReattach, index, editable, namespace, configs) {
-		if (data === null || data === undefined) data = ""
+		if (data === undefined) return undefined
+		if (data === null) data = ""
 		if (data.subtree === "retain") return cached
 
 		var cachedType = type.call(cached), dataType = type.call(data)


### PR DESCRIPTION
Actually Mithril calls build() with data undefined for m("tag",{...}) [calls without third argument].
The changing undefined to "" causes build() insert a TextNode into current tag (on line 169).
But in IE8 it isn't allowed to insert a TextNode into any tag.
For example, m("input",{...}) fails here.

With this simple patch undefined is not chaged to "" anymore.
(And no empty TextNode's added to every mentioned tag.)
