### PR TITLE
currentTarget issue in IE8

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -384,7 +384,8 @@ Mithril = m = new function app(window) {
 	m.withAttr = function(prop, withAttrCallback) {
 		return function(e) {
 			e = e || event
-			withAttrCallback(prop in e.currentTarget ? e.currentTarget[prop] : e.currentTarget.getAttribute(prop))
+			var currentTarget = e.currentTarget || this
+			withAttrCallback(prop in currentTarget ? currentTarget[prop] : currentTarget.getAttribute(prop))
 		}
 	}
 


### PR DESCRIPTION
There is no currentTarget in IE8. So withAttr() fails in it.
But 'this' is binded to that already. It's Ok.

More info:
http://stackoverflow.com/questions/857439/internet-explorer-and-javascript-event-currenttarget
http://www.brainjar.com/dhtml/events/default3.asp
