### PR TITLE
typeof is much faster than {}.toString()

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -153,7 +153,7 @@ Mithril = m = new function app(window, undefined) {
 				cached.nodes.intact = true
 				if (shouldReattach === true) parentElement.insertBefore(node, parentElement.childNodes[index] || null)
 			}
-			if (type.call(data.attrs["config"]) == "[object Function]") {
+			if (typeof data.attrs["config"] === "function") {
 				configs.push(data.attrs["config"].bind(window, node, !isNew, cached.configContext = cached.configContext || {}, cached))
 			}
 		}


### PR DESCRIPTION
Proof: http://jsperf.com/typeof-vs-instanceof-vs-object-prototype-tostring
