### PR TITLE
Fix error when running tests in Firefox

### DIFF
--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -907,4 +907,4 @@ function testMithril(mock) {
 //mocks
 testMithril(mock.window)
 
-test.print(console.log)
+test.print(console.log.bind(console))


### PR DESCRIPTION
Without this fix, Firefox displays the following error when running tests:

```
TypeError: 'log' called on an object that does not implement interface Console.
```
