### PR TITLE
Add factory method - allow to run separate mithril instances

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -939,7 +939,7 @@ Mithril = m = new function app(window, undefined) {
 	//testing API
 	m.deps = function(mock) {return window = mock}
 	//for internal testing only, do not use `m.deps.factory`
-	m.deps.factory = app
+	m.factory = m.deps.factory = app
 
 	return m
 }(typeof window != "undefined" ? window : {})


### PR DESCRIPTION
Usecase:
App built with angular using multiple mithril components.

``` javascript
function mithrilDatePicker(element){ 
  return ((function Component(m){
   // implementation
  })(m.factory())) // separate mithril instance
}
```

Reasoning:
-  m.render() updates only the needed component 
-  components can always get initial m instance - not altered by other components
-  decreased risk of memory leaks (as mithril instance resides in closure, it would be gc'd when the component is removed - no risk of accidentally leaving detached DOM nodes that m.render() would want to update) 
-  each component is a separate app
-  each component is updated by the angular app
-  components don't have to know about each other

This also opens a field for discussion on triggering global render
