### PR TITLE
Refactor type fn for readability/brevity

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -1,5 +1,5 @@
 Mithril = m = new function app(window, undefined) {
-	var type = {}.toString
+	var type = function(obj) {return {}.toString.call(obj)}
 	var parser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[.+?\])/g, attrParser = /\[(.+?)(?:=("|'|)(.*?)\2)?\]/
 	var voidElements = /AREA|BASE|BR|COL|COMMAND|EMBED|HR|IMG|INPUT|KEYGEN|LINK|META|PARAM|SOURCE|TR‌​ACK|WBR/
 
@@ -18,7 +18,7 @@ Mithril = m = new function app(window, undefined) {
 	 */
 	function m() {
 		var args = Array.prototype.slice.call(arguments, 0)
-		var hasAttrs = args[1] != null && type.call(args[1]) == "[object Object]" && !("tag" in args[1]) && !("subtree" in args[1])
+		var hasAttrs = args[1] != null && type(args[1]) == "[object Object]" && !("tag" in args[1]) && !("subtree" in args[1])
 		var attrs = hasAttrs ? args[1] : {}
 		var classAttrName = "class" in attrs ? "class" : "className"
 		var cell = {tag: "div", attrs: {}}
@@ -78,7 +78,7 @@ Mithril = m = new function app(window, undefined) {
 		if (data == null) data = ""
 		if (data.subtree === "retain") return cached
 
-		var cachedType = type.call(cached), dataType = type.call(data)
+		var cachedType = type(cached), dataType = type(data)
 		if (cached == null || cachedType != dataType) {
 			if (cached != null) {
 				if (parentCache && parentCache.nodes) {
@@ -160,7 +160,7 @@ Mithril = m = new function app(window, undefined) {
 				var item = build(parentElement, parentTag, cached, index, data[i], cached[cacheCount], shouldReattach, index + subArrayCount || subArrayCount, editable, namespace, configs)
 				if (item === undefined) continue
 				if (!item.nodes.intact) intact = false
-				var isArray = type.call(item) == "[object Array]"
+				var isArray = type(item) == "[object Array]"
 				subArrayCount += isArray ? item.length : 1
 				cached[cacheCount++] = item
 			}
@@ -324,7 +324,7 @@ Mithril = m = new function app(window, undefined) {
 	function unload(cached) {
 		if (cached.configContext && typeof cached.configContext.onunload == "function") cached.configContext.onunload()
 		if (cached.children) {
-			if (type.call(cached.children) == "[object Array]") {
+			if (type(cached.children) == "[object Array]") {
 				for (var i = 0; i < cached.children.length; i++) unload(cached.children[i])
 			}
 			else if (cached.children.tag) unload(cached.children)
@@ -354,7 +354,7 @@ Mithril = m = new function app(window, undefined) {
 		var flattened = []
 		for (var i = 0; i < data.length; i++) {
 			var item = data[i]
-			if (type.call(item) == "[object Array]") flattened.push.apply(flattened, flatten(item))
+			if (type(item) == "[object Array]") flattened.push.apply(flattened, flatten(item))
 			else flattened.push(item)
 		}
 		return flattened
@@ -889,7 +889,7 @@ Mithril = m = new function app(window, undefined) {
 				var unwrap = (e.type == "load" ? xhrOptions.unwrapSuccess : xhrOptions.unwrapError) || identity
 				var response = unwrap(deserialize(extract(e.target, xhrOptions)))
 				if (e.type == "load") {
-					if (type.call(response) == "[object Array]" && xhrOptions.type) {
+					if (type(response) == "[object Array]" && xhrOptions.type) {
 						for (var i = 0; i < response.length; i++) response[i] = new xhrOptions.type(response[i])
 					}
 					else if (xhrOptions.type) response = new xhrOptions.type(response)
@@ -898,7 +898,7 @@ Mithril = m = new function app(window, undefined) {
 			}
 			catch (e) {
 				if (e instanceof SyntaxError) throw new SyntaxError("Could not parse HTTP response. See http://lhorie.github.io/mithril/mithril.request.html#using-variable-data-formats")
-				else if (type.call(e) == "[object Error]" && e.constructor !== Error) throw e
+				else if (type(e) == "[object Error]" && e.constructor !== Error) throw e
 				else deferred.reject(e)
 			}
 			if (xhrOptions.background !== true) m.endComputation()


### PR DESCRIPTION
This replaces the helper function `var type = {}.toString` with `var type = function(obj) {return {}.toString.call(obj)}`.
This allows it to be called more ergonomically.

It replaces invocations (previously, `type.call(obj)`) with `type(obj)`.

Incidentally, it reduces mithril.js by 7 bytes

---

All tests still pass, as run with `grunt`'s default.
