### PR TITLE
Created common functions for typeof

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -22,7 +22,8 @@ Mithril = m = new function app(window, undefined) {
 	 *
 	 */
 	function m() {
-		var args = Array.prototype.slice.call(arguments, 0)
+		var arrSlice = Array.prototype.slice;
+		var args = arrSlice.call(arguments, 0)
 		var hasAttrs = args[1] != null && isObj(args[1]) && !("tag" in args[1]) && !("subtree" in args[1])
 		var attrs = hasAttrs ? args[1] : {}
 		var classAttrName = "class" in attrs ? "class" : "className"
@@ -41,8 +42,8 @@ Mithril = m = new function app(window, undefined) {
 
 
 		var children = hasAttrs ? args[2] : args[1]
-		if (children instanceof Array) {
-			cell.children = children
+		if (isArr(children) || type(children) == "[object Arguments]") {
+			cell.children = arrSlice.call(children, 0)
 		}
 		else {
 			cell.children = hasAttrs ? args.slice(2) : args.slice(1)

--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -784,6 +784,15 @@ function testMithril(mock) {
 		m.render(root, [m("div.green", [m("div")]), m("div.blue")])
 		return root.childNodes.length == 2
 	})
+	test(function() {
+		var root = mock.document.createElement("div")
+		m.render(root, m("ul", [m("li")]))
+		var change = function() {
+			m.render(root, m("ul", arguments))
+		}
+		change(m("b"));
+		return root.childNodes[0].childNodes[0].nodeName == "B"
+	})
 	//end m.render
 
 	//m.redraw


### PR DESCRIPTION
As I mentioned in #251 I'd been thinking about some refactoring of the type functions, and a little code golf.
This PR moves most of the type checking to separate functions, and pulls out the "[object Object]" and "[object Array]" constants.

Code size savings (not sure why the compression isn't as good):

| File | Before | After | Savings |
| --- | --- | --- | --- |
| mithril.js | 33028 | 32811 | 217 |
| mithril.min.js | 14515 | 14230 | 285 |
| mithril.min.js + xz | 5712 | 5708 | 4 |
| mithril.min.js + gzip | 5813 | 5821 | -8 |
| mithril.min.js + zip | 5939 | 5947 | -8 |
| mithril.min.js + bzip | 5716 | 5730 | -14 |
