### PR TITLE
Simplify redraw logic to always be async

### DIFF
--- a/tests/mithril-tests.js
+++ b/tests/mithril-tests.js
@@ -801,13 +801,11 @@ function testMithril(mock) {
 			}
 		})
 		mock.requestAnimationFrame.$resolve() //teardown
-		m.redraw() //should run synchronously
-
-		m.redraw() //rest should run asynchronously since they're spamming
+		m.redraw() //should run asynchronously since they're spamming
 		m.redraw()
 		m.redraw()
 		mock.requestAnimationFrame.$resolve() //teardown
-		return count === 3
+		return count === 2
 	})
 	test(function() {
 		mock.requestAnimationFrame.$resolve() //setup
@@ -1453,6 +1451,7 @@ function testMithril(mock) {
 				}
 			}
 		})
+		mock.requestAnimationFrame.$resolve()
 		root.childNodes[0].onclick({})
 		mock.requestAnimationFrame.$resolve() //teardown
 		return strategy == "diff" && root.childNodes[0].childNodes[0].nodeValue == "1"
@@ -1475,6 +1474,7 @@ function testMithril(mock) {
 				}
 			}
 		})
+		mock.requestAnimationFrame.$resolve()
 		root.childNodes[0].onclick({})
 		mock.requestAnimationFrame.$resolve() //teardown
 		return count == 2


### PR DESCRIPTION
The redraw logic seemed to be getting a little complicated and difficult to know if it would redraw async or synchronously. 

I changed the logic to always be async. It makes it simpler and behave consistently.

This will also help fix https://github.com/lhorie/mithril.js/issues/214. I will create another pull request for that fix, but it depends upon this change.
