### PR TITLE
"name" gives me error - use a_name instead

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,16 +65,16 @@ todo.TodoList = Array;
 
 ```javascript
 //define a getter-setter with initial value `John`
-var name = m.prop("John");
+var a_name = m.prop("John");
 
 //read the value
-var a = name(); //a == "John"
+var a = a_name(); //a == "John"
 
 //set the value to `Mary`
-name("Mary"); //Mary
+a_name("Mary"); //Mary
 
 //read the value
-var b = name(); //b == "Mary"
+var b = a_name(); //b == "Mary"
 ```
 
 Note that the `Todo` and `TodoList` classes we defined above are plain vanilla Javascript constructors. They can be initialized and used like this:


### PR DESCRIPTION
I have noticed that one of the initial examples gives a error in my browser debugger (Safari). 
According to this page: http://www.w3schools.com/js/js_reserved.asp, "You should also avoid using the name of JavaScript built-in objects, properties, and method" (and name is listed).
In my case, if I change name to something else, I no longer get the error.
Thanks for Mithril!
