### PR TITLE
Give m.prop toString and valueOf methods

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -432,8 +432,16 @@ Mithril = m = new function app(window, undefined) {
 			return store
 		}
 
-		prop.toJSON = prop.valueOf = function() {
+		prop.toJSON = function() {
 			return store
+		}
+
+		prop.toString = function(){
+			return store.toString();
+		}
+
+		prop.valueOf = function(){
+			return store.valueOf();
 		}
 
 		return prop


### PR DESCRIPTION
Edging precariously closer to emulating native get/set, this fork gives `m.prop`s `toString` and `valueOf` methods which alias those of the stored value. Basically it saves you typing `()` in situations where the value will be coerced.

Convenient when models need to be passed off to arbitrary code which doesn't expect `m.prop` syntax: in this way it performs a similar job to `toJSON` in enabling content transparency without serialisation, the advantage being you can adopt a more modular and functional style where discrete modules parsing primitive data need not be aware of the `m.prop` convention. 

One major caveat is that careless reliance on silent type coercion could lead to believe the `m.prop` itself was a primitive and attempt to assign data back to it. Good practice according to the functional programming mindset would urge you not to mutate data passed in by reference from an unknown source (but then functional programming good practice forbids reliance on side-effects too).

[In the simplest use case](http://jsbin.com/heyehe/1/edit?html,js,output), it makes the canonical DOM data-binding 2 characters shorter by removing the need for explicit invocation:

``` javascript
var query = m.prop( '' );

m( 'input', {
  value    : query,
  oninput  : m.withAttr( 'value', query )
} );
```
