### PR TITLE
Prevent creating property on global object

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -643,7 +643,7 @@ Mithril = m = new function app(window, undefined) {
 		return deferred
 	}
 	function propify(promise) {
-		prop = m.prop()
+		var prop = m.prop()
 		promise.then(prop)
 		prop.then = function(resolve, reject) {
 			return propify(promise.then(resolve, reject))


### PR DESCRIPTION
I noticed this while having a read through the code. You can reproduce it by simply calling `m.deferred`. If you use ES5 strict mode this sort of thing won't crop up again, but you may have reasons for not using strict mode so I'll leave that up to you to change.
