### PR TITLE
Adding support for custom elements that derive from a native element

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -212,7 +212,7 @@ Mithril = m = new function app(window, undefined) {
 			else if (data.tag === "svg") namespace = "http://www.w3.org/2000/svg"
 			else if (data.tag === "math") namespace = "http://www.w3.org/1998/Math/MathML"
 			if (isNew) {
-				node = namespace === undefined ? window.document.createElement(data.tag) : window.document.createElementNS(namespace, data.tag)
+				node = namespace === undefined ? window.document.createElement(data.tag, data.attrs.is) : window.document.createElementNS(namespace, data.tag, data.attrs.is)
 				cached = {
 					tag: data.tag,
 					//set attributes first, then create children


### PR DESCRIPTION
When using createElement to construct a custom element that derives from a native element (i.e. `<button is="my-button">`), the custom type should be passed as the second argument.
