### PR TITLE
Performance tuning: Array.push instead of Array.concat

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -194,7 +194,11 @@ Mithril = m = new function app(window, undefined) {
 
 				//update the list of DOM nodes by collecting the nodes from each item
 				for (var i = 0; i < data.length; i++) {
-					if (cached[i] != null) nodes = nodes.concat(cached[i].nodes)
+					if (cached[i] != null) {
+						for (var j = 0; j < cached[i].nodes.length; j++) {
+							nodes.push(cached[i].nodes[j]);
+						}
+					}
 				}
 				//remove items from the end of the array if the new array is shorter than the old one
 				//if errors ever happen here, the issue is most likely a bug in the construction of the `cached` data structure somewhere earlier in the program


### PR DESCRIPTION
This simple change provides a massive speed up in Firefox (See  http://i171.photobucket.com/albums/u320/boubiyeah/ScreenShot2014-11-13at161151_zps32244a0b.png)

concat creates a new Array everytime and it quickly made the GC choke. Strangely, while chrome do get a small performance boost, it's nowhere near as dramatic as in FF (they either have a better gc or concat implementation).

I dislike that imperative style compared to the previous functional style but I think the style/perf tradeoff is worth it. 
