### PR TITLE
Added declaration for TypeScript external module support

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -63,3 +63,7 @@ interface MithrilXHROptions {
 
 declare var Mithril: MithrilStatic;
 declare var m: MithrilStatic;
+
+declare module 'mithril' {
+    export = MithrilStatic;
+}


### PR DESCRIPTION
I added a declaration for a TypeScript external module, so this:

```
import m = require('mithril');
```

now works (e.g. for people using node or browserify).
