### PR TITLE
Fix typo

### DIFF
--- a/docs/mithril.computation.md
+++ b/docs/mithril.computation.md
@@ -2,7 +2,7 @@
 
 ---
 
-- [How auto-redrawing-works](#how-auto-redrawing-works)
+- [How auto-redrawing works](#how-auto-redrawing-works)
 - [Integrating multiple execution threads](#integrating-multiple-execution-threads)
 - [Integrating to legacy code](#integrating-to-legacy-code)
 - [Signature](#signature)


### PR DESCRIPTION
In the TOC link title, "auto-redrawing-works" -> "auto-redrawing works"
