### PR TITLE
Updating typescript route definition to allow m.route.mode and m.route.param(key).

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -10,11 +10,15 @@ interface MithrilStatic {
 	render(rootElement: Element, children?: any): void;
 	render(rootElement: HTMLDocument, children?: any): void;
 	redraw(): void;
-	route(rootElement: Element, defaultRoute: string, routes: { [key: string]: MithrilModule }): void;
-	route(rootElement: HTMLDocument, defaultRoute: string, routes: { [key: string]: MithrilModule }): void;
-	route(path: string, params?: any, shouldReplaceHistory?: boolean): void;
-	route(): string;
-	route(element: Element, isInitialized: boolean): void;
+	route: {
+		(rootElement:Element, defaultRoute:string, routes:{ [key: string]: MithrilModule }): void
+		(element: Element, isInitialized: boolean): void;
+		(rootElement:HTMLDocument, defaultRoute:string, routes:{ [key: string]: MithrilModule }): void;
+		(path:string, params?:any, shouldReplaceHistory?:boolean): void;
+		(): string;
+		param(key:string): string;
+		mode: string;
+	};
 	request(options: MithrilXHROptions): MithrilPromise;
 	deferred(): MithrilDeferred;
 	sync(promises: MithrilPromise[]): MithrilPromise;
@@ -65,5 +69,5 @@ declare var Mithril: MithrilStatic;
 declare var m: MithrilStatic;
 
 declare module 'mithril' {
-    export = MithrilStatic;
+	export = MithrilStatic;
 }


### PR DESCRIPTION
updated typescript interfaces routes, so you can now use

``` javascript
    m.route.param('filter') 
    m.route.mode
```

without the  typescript compiler complaining.
