### PR TITLE
Updating typescript redraw definition to allow m.redraw.strategy

### DIFF
--- a/mithril.d.ts
+++ b/mithril.d.ts
@@ -9,7 +9,10 @@ interface MithrilStatic {
 	trust(html: string): String;
 	render(rootElement: Element, children?: any): void;
 	render(rootElement: HTMLDocument, children?: any): void;
-	redraw(): void;
+	redraw: {
+		(): void;
+		strategy(key: string);
+	};
 	route: {
 		(rootElement:Element, defaultRoute:string, routes:{ [key: string]: MithrilModule }): void
 		(element: Element, isInitialized: boolean): void;


### PR DESCRIPTION
Allow modifying the redraw strategy in typescript.

``` javascript
m.redraw.strategy('all');
m.redraw.strategy('none');
```
