### PR TITLE
m.request: don't append interpolated data to query

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -124,13 +124,12 @@ module.exports = function($window, Promise) {
 	}
 
 	function interpolate(url, data) {
-		if (data == null) return url
-
 		var tokens = url.match(/:[^\/]+/gi) || []
 		for (var i = 0; i < tokens.length; i++) {
 			var key = tokens[i].slice(1)
 			if (data[key] != null) {
 				url = url.replace(tokens[i], data[key])
+				delete data[key]
 			}
 		}
 		return url

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -123,7 +123,7 @@ o.spec("xhr", function() {
 				}
 			})
 			xhr({method: "GET", url: "/item/:x", data: {x: "y"}}).then(function(data) {
-				o(data).deepEquals({a: "/item/y", b: "?x=y"})
+				o(data).deepEquals({a: "/item/y"})
 			}).then(done)
 		})
 		o("works w/ parameterized url via POST", function(done) {
@@ -133,7 +133,7 @@ o.spec("xhr", function() {
 				}
 			})
 			xhr({method: "POST", url: "/item/:x", data: {x: "y"}}).then(function(data) {
-				o(data).deepEquals({a: "/item/y", b: {x: "y"}})
+				o(data).deepEquals({a: "/item/y"})
 			}).then(done)
 		})
 		o("works w/ array", function(done) {


### PR DESCRIPTION
As raised by @fuintis on [February 21, 2017 12:02 AM](https://gitter.im/lhorie/mithril.js?at=58ab83b07ceae5376a18113a):

> when i use m.request with a dynamic url and i assign an object to the "data" XHROptions attrib, the url is correctly interpolated, but the "data" object is appended like query string
> //url/:id -> //url/wrong?id=wrong
> tested only with GET method, and mithril 1.0.2
> is this an issue or there is an option to alter this behavior?

This patch ensures interpolated keys are deleted from the `data` object.

Bug case: https://jsbin.com/meqiyi/edit?js,output
Fix case: https://jsbin.com/gisiqu/edit?js,output