### PR TITLE
Alternative (smaller/simpler) impl for xhr-abort code

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -56,12 +56,12 @@ module.exports = function($window, Promise) {
 			else args.url = assemble(args.url, args.data)
 
 			var xhr = new $window.XMLHttpRequest(),
-				aborted = false,
 				_abort = xhr.abort
 
 
 			xhr.abort = function abort() {
-				aborted = true
+				// Don't throw errors on xhr.abort().
+				xhr.onreadystatechange = null
 				_abort.call(xhr)
 			}
 
@@ -82,9 +82,6 @@ module.exports = function($window, Promise) {
 			if (typeof args.config === "function") xhr = args.config(xhr, args) || xhr
 
 			xhr.onreadystatechange = function() {
-				// Don't throw errors on xhr.abort().
-				if(aborted) return
-
 				if (xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))

--- a/request/request.js
+++ b/request/request.js
@@ -83,7 +83,7 @@ module.exports = function($window, Promise) {
 				if (xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
-						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || /^file:\/\//.test(args.url)) {
+						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || /^file:\/\//i.test(args.url)) {
 							resolve(cast(args.type, response))
 						}
 						else {

--- a/request/request.js
+++ b/request/request.js
@@ -2,8 +2,6 @@
 
 var buildQueryString = require("../querystring/build")
 
-var FILE_PROTOCOL_REGEX = /^file:\/\//i
-
 module.exports = function($window, Promise) {
 	var callbackCount = 0
 
@@ -85,7 +83,7 @@ module.exports = function($window, Promise) {
 				if (xhr.readyState === 4) {
 					try {
 						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
-						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || FILE_PROTOCOL_REGEX.test(args.url)) {
+						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || /^file:\/\//.test(args.url)) {
 							resolve(cast(args.type, response))
 						}
 						else {

--- a/request/request.js
+++ b/request/request.js
@@ -2,7 +2,7 @@
 
 var buildQueryString = require("../querystring/build")
 
-var FILE_PROTOCOL_REGEX = new RegExp("^file://", "i")
+var FILE_PROTOCOL_REGEX = /^file:\/\//i
 
 module.exports = function($window, Promise) {
 	var callbackCount = 0


### PR DESCRIPTION
As per comments from @simov and @pypy; this is a simpler xhr-abort implementation (although the test becomes a little more convoluted).

And it converts the regex to a literal.

Saving the bytes :-)

(I originally didn't create a PR for this because I thought the change may not be worth the "risk" -- so entirely happy if this isn't merged. It also makes the test a bit more convoluted.)