### PR TITLE
added ability to specify data for URL-interpolation

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -34,6 +34,12 @@ module.exports = function($window, Promise) {
 			args = extra || {}
 			if (args.url == null) args.url = url
 		}
+		if (typeof args.url === "object") {
+			var rawUrl = args.url.rawurl
+			var urldata = args.url.urldata
+			args.url = rawUrl
+			if (args.urldata == null) args.urldata = urldata
+		}
 		return args
 	}
 
@@ -51,7 +57,7 @@ module.exports = function($window, Promise) {
 			if (typeof args.deserialize !== "function") args.deserialize = deserialize
 			if (typeof args.extract !== "function") args.extract = extract
 
-			args.url = interpolate(args.url, args.data)
+			args.url = interpolate(args.url, args.data, args.urldata)
 			if (useBody) args.data = args.serialize(args.data)
 			else args.url = assemble(args.url, args.data)
 
@@ -127,7 +133,7 @@ module.exports = function($window, Promise) {
 				delete $window[callbackName]
 			}
 			if (args.data == null) args.data = {}
-			args.url = interpolate(args.url, args.data)
+			args.url = interpolate(args.url, args.data, args.urldata)
 			args.data[args.callbackKey || "callback"] = callbackName
 			script.src = assemble(args.url, args.data)
 			$window.document.documentElement.appendChild(script)
@@ -135,12 +141,17 @@ module.exports = function($window, Promise) {
 		return args.background === true? promise : finalize(promise)
 	}
 
-	function interpolate(url, data) {
+	function interpolate(url, data, urldata) {
 		if (data == null) return url
 
 		var tokens = url.match(/:[^\/]+/gi) || []
 		for (var i = 0; i < tokens.length; i++) {
 			var key = tokens[i].slice(1)
+			if (urldata != null) {
+				if (urldata[key] != null) {
+					url = url.replace(tokens[i], urldata[key])
+				}
+			}
 			if (data[key] != null) {
 				url = url.replace(tokens[i], data[key])
 			}


### PR DESCRIPTION
Current implementation of `m.request` uses the data provided via `options.data` and replaces every found token which starts with a colon from that data. This commit adds a way to provide that data via `options.url.urldata`. To provide a backward compatible way the URL has to be provided as `options.url.rawurl`.

The idea is to separate request-body data from URL-interpolation data.

This is intended as a "discussion"-start for issue https://github.com/lhorie/mithril.js/issues/1699

Something like this would be possible (in addition to current implementation with URL as normal string):
```js
var REST_URLS = {
    someMethod: "/some/path/:id/add"
};

m.request({
    method: "POST",
    url: {
        rawurl: REST_URLS.someMethod,
        urldata: {
            id: 123
        }
    },
    data: {
        id: 456
    }
})
.then(function(result) {
    console.log(result)
})
```