### PR TITLE
Remove url interpolation from tutorial app

### DIFF
--- a/docs/simple-application.md
+++ b/docs/simple-application.md
@@ -392,8 +392,7 @@ var User = {
 	load: function(id) {
 		return m.request({
 			method: "GET",
-			url: "https://rem-rest-api.herokuapp.com/api/users/:id",
-			data: {id: id},
+			url: "https://rem-rest-api.herokuapp.com/api/users/" + id,
 			withCredentials: true,
 		})
 		.then(function(result) {
@@ -508,8 +507,7 @@ var User = {
 	load: function(id) {
 		return m.request({
 			method: "GET",
-			url: "https://rem-rest-api.herokuapp.com/api/users/:id",
-			data: {id: id},
+			url: "https://rem-rest-api.herokuapp.com/api/users/" + id,
 			withCredentials: true,
 		})
 		.then(function(result) {
@@ -520,7 +518,7 @@ var User = {
 	save: function() {
 		return m.request({
 			method: "PUT",
-			url: "https://rem-rest-api.herokuapp.com/api/users/:id",
+			url: "https://rem-rest-api.herokuapp.com/api/users/" + User.current.id,
 			data: User.current,
 			withCredentials: true,
 		})


### PR DESCRIPTION
`m.request` examples in the simple app tutorial use the URL interpolation feature. This PR removes it so an an extraneous query string isn't appended to the get user request URL . I've also removed it from the save user for consistency. Follows up on: https://github.com/lhorie/mithril.js/issues/1788