### PR TITLE
Update all repo references after the great migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ install:
 - npm install @alrra/travis-scripts@^3.0.1 gh-pages@^0.12.0
 
 # Bundle before running tests so the bundle is always up-to-date
-before_script: npm run build
+before_script: npm run build --silent
 
 # Run tests, lint, and then check for perf regressions
 script:
-- npm test
-- npm run perf
+- npm test --silent
+- npm run perf --silent
 
 # After a successful build commit changes back to repo
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ after_success:
     # this doesn't have the built-in branch protection like commit-changes
     if [ "$TRAVIS_EVENT_TYPE" == "push" ] && \
        [ "$TRAVIS_BRANCH" == "master" ] && \
-       [ "$TRAVIS_REPO_SLUG" == "lhorie/mithril.js" ]
+       [ "$TRAVIS_REPO_SLUG" == "MithrilJS/mithril.js" ]
     then
       # Generate docs
       npm run gendocs
@@ -59,7 +59,7 @@ after_success:
       $(npm bin)/gh-pages \
         --dist ./dist \
         --add \
-        --repo "git@github.com:lhorie/mithril.js.git" \
+        --repo "git@github.com:MithrilJS/mithril.js.git" \
         --message "Generated docs for commit $TRAVIS_COMMIT [skip ci]"
     else
       echo "Not submitting documentation updates"
@@ -83,7 +83,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      repo: lhorie/mithril.js
+      repo: MithrilJS/mithril.js
       branch: master
   
   - provider: npm
@@ -93,5 +93,5 @@ deploy:
       secure: ADElvD1oxn9GfEG7dDOggX96b36A/cGEybovAc0221CCKzv5kWCavMrtxneiJYI6N/n24abSlbM90vMfU84FEzH0Ev28dGVokRP4ad6VRkISszKlYVEP8Lds4QxfKh78jZlUxmxM0B3vmQ1kYJbTBqp3ICtaJ5ptEQHWhrLtxnc=
     on:
       tags: true
-      repo: lhorie/mithril.js
+      repo: MithrilJS/mithril.js
       branch: master

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -12,8 +12,8 @@
 
 #### Bug fixes
 
-- hyperscript: Allow `0` as the second argument to `m()` - [#1752](https://github.com/lhorie/mithril.js/issues/1752) / [#1753](https://github.com/lhorie/mithril.js/pull/1753) ([@StephanHoyer](https://github.com/StephanHoyer))
-- hyperscript: restore `attrs.class` handling to what it was in v1.0.1 - [#1764](https://github.com/lhorie/mithril.js/issues/1764) / [#1769](https://github.com/lhorie/mithril.js/pull/1769)
+- hyperscript: Allow `0` as the second argument to `m()` - [#1752](https://github.com/MithrilJS/mithril.js/issues/1752) / [#1753](https://github.com/MithrilJS/mithril.js/pull/1753) ([@StephanHoyer](https://github.com/StephanHoyer))
+- hyperscript: restore `attrs.class` handling to what it was in v1.0.1 - [#1764](https://github.com/MithrilJS/mithril.js/issues/1764) / [#1769](https://github.com/MithrilJS/mithril.js/pull/1769)
 - documentation improvements ([@JAForbes](https://github.com/JAForbes), [@smuemd](https://github.com/smuemd), [@hankeypancake](https://github.com/hankeypancake))
 
 ### v1.1.0
@@ -26,10 +26,10 @@
 
 #### Bug fixes
 
-- fix IE11 input[type] error - [#1610](https://github.com/lhorie/mithril.js/issues/1610)
-- apply [#1609](https://github.com/lhorie/mithril.js/issues/1609) to unkeyed children case
-- fix abort detection [#1612](https://github.com/lhorie/mithril.js/issues/1612)
-- fix input value focus issue when value is loosely equal to old value [#1593](https://github.com/lhorie/mithril.js/issues/1593)
+- fix IE11 input[type] error - [#1610](https://github.com/MithrilJS/mithril.js/issues/1610)
+- apply [#1609](https://github.com/MithrilJS/mithril.js/issues/1609) to unkeyed children case
+- fix abort detection [#1612](https://github.com/MithrilJS/mithril.js/issues/1612)
+- fix input value focus issue when value is loosely equal to old value [#1593](https://github.com/MithrilJS/mithril.js/issues/1593)
 
 ---
 
@@ -37,12 +37,12 @@
 
 #### News
 
-- performance improvements in IE [#1598](https://github.com/lhorie/mithril.js/pull/1598)
+- performance improvements in IE [#1598](https://github.com/MithrilJS/mithril.js/pull/1598)
 
 #### Bug fixes
 
-- prevent infinite loop in non-existent default route - [#1579](https://github.com/lhorie/mithril.js/issues/1579)
-- call correct lifecycle methods on children of recycled keyed vnodes - [#1609](https://github.com/lhorie/mithril.js/issues/1609)
+- prevent infinite loop in non-existent default route - [#1579](https://github.com/MithrilJS/mithril.js/issues/1579)
+- call correct lifecycle methods on children of recycled keyed vnodes - [#1609](https://github.com/MithrilJS/mithril.js/issues/1609)
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,7 @@
 
 ## How do I go about contributing ideas or new features?
 
-Create an [issue thread on Github](https://github.com/lhorie/mithril.js/issues/new) to suggest your idea so the community can discuss it.
+Create an [issue thread on Github](https://github.com/MithrilJS/mithril.js/issues/new) to suggest your idea so the community can discuss it.
 
 If the consensus is that it's a good idea, the fastest way to get it into a release is to send a pull request. Without a PR, the time to implement the feature will depend on the bandwidth of the development team and its list of priorities.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,10 +2,10 @@
 
 Here are some examples of Mithril in action
 
-- [Animation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/animation/mosaic.html)
-- [DBMonster](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/mithril/index.html)
-- [Markdown Editor](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/editor/index.html)
-- SVG: [Clock](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/svg/clock.html), [Ring](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/svg/ring.html), [Tiger](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/svg/tiger.html)
-- [ThreadItJS](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/threaditjs/index.html)
-- [TodoMVC](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/todomvc/index.html)
+- [Animation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/animation/mosaic.html)
+- [DBMonster](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/mithril/index.html)
+- [Markdown Editor](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/editor/index.html)
+- SVG: [Clock](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/svg/clock.html), [Ring](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/svg/ring.html), [Tiger](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/svg/tiger.html)
+- [ThreadItJS](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/threaditjs/index.html)
+- [TodoMVC](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/todomvc/index.html)
 

--- a/docs/framework-comparison.md
+++ b/docs/framework-comparison.md
@@ -74,7 +74,7 @@ What these numbers show is that not only does Mithril initializes significantly 
 
 Update performance can be even more important than first-render performance, since updates can happen many times while a Single Page Application is running.
 
-A useful tool to benchmark update performance is a tool developed by the Ember team called DbMonster. It updates a table as fast as it can and measures frames per second (FPS) and Javascript times (min, max and mean). The FPS count can be difficult to evaluate since it also includes browser repaint times and `setTimeout` clamping delay, so the most meaningful number to look at is the mean render time. You can compare a [React implementation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/react/index.html) and a [Mithril implementation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/mithril/index.html). Sample results are shown below:
+A useful tool to benchmark update performance is a tool developed by the Ember team called DbMonster. It updates a table as fast as it can and measures frames per second (FPS) and Javascript times (min, max and mean). The FPS count can be difficult to evaluate since it also includes browser repaint times and `setTimeout` clamping delay, so the most meaningful number to look at is the mean render time. You can compare a [React implementation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/react/index.html) and a [Mithril implementation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/mithril/index.html). Sample results are shown below:
 
 React   | Mithril
 ------- | -------
@@ -139,7 +139,7 @@ Also, remember that frameworks like Angular and Mithril are designed for non-tri
 
 ##### Update performance
 
-A useful tool to benchmark update performance is a tool developed by the Ember team called DbMonster. It updates a table as fast as it can and measures frames per second (FPS) and Javascript times (min, max and mean). The FPS count can be difficult to evaluate since it also includes browser repaint times and `setTimeout` clamping delay, so the most meaningful number to look at is the mean render time. You can compare an [Angular implementation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/angular/index.html) and a [Mithril implementation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/mithril/index.html). Both implementations are naive (i.e. no optimizations). Sample results are shown below:
+A useful tool to benchmark update performance is a tool developed by the Ember team called DbMonster. It updates a table as fast as it can and measures frames per second (FPS) and Javascript times (min, max and mean). The FPS count can be difficult to evaluate since it also includes browser repaint times and `setTimeout` clamping delay, so the most meaningful number to look at is the mean render time. You can compare an [Angular implementation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/angular/index.html) and a [Mithril implementation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/mithril/index.html). Both implementations are naive (i.e. no optimizations). Sample results are shown below:
 
 Angular | Mithril
 ------- | -------
@@ -193,7 +193,7 @@ Library load times matter in applications that don't stay open for long periods 
 
 ##### Update performance
 
-A useful tool to benchmark update performance is a tool developed by the Ember team called DbMonster. It updates a table as fast as it can and measures frames per second (FPS) and Javascript times (min, max and mean). The FPS count can be difficult to evaluate since it also includes browser repaint times and `setTimeout` clamping delay, so the most meaningful number to look at is the mean render time. You can compare a [Vue implementation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/vue/index.html) and a [Mithril implementation](http://cdn.rawgit.com/lhorie/mithril.js/rewrite/examples/dbmonster/mithril/index.html). Both implementations are naive (i.e. no optimizations). Sample results are shown below:
+A useful tool to benchmark update performance is a tool developed by the Ember team called DbMonster. It updates a table as fast as it can and measures frames per second (FPS) and Javascript times (min, max and mean). The FPS count can be difficult to evaluate since it also includes browser repaint times and `setTimeout` clamping delay, so the most meaningful number to look at is the mean render time. You can compare a [Vue implementation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/vue/index.html) and a [Mithril implementation](http://cdn.rawgit.com/MithrilJS/mithril.js/master/examples/dbmonster/mithril/index.html). Both implementations are naive (i.e. no optimizations). Sample results are shown below:
 
 Vue    | Mithril
 ------ | -------

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -219,7 +219,7 @@ If you don't have the ability to run a bundler script due to company security po
     <title>Hello world</title>
   </head>
   <body>
-    <script src="https://cdn.rawgit.com/lhorie/mithril.js/rewrite/mithril.js"></script>
+    <script src="https://cdn.rawgit.com/MithrilJS/mithril.js/master/mithril.js"></script>
     <script src="index.js"></script>
   </body>
 </html>

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -14,8 +14,8 @@
 				<nav>
 					<a href="index.html">Guide</a>
 					<a href="api.html">API</a>
-					<a href="https://gitter.im/lhorie/mithril.js">Chat</a>
-					<a href="https://github.com/lhorie/mithril.js">Github</a>
+					<a href="https://gitter.im/MithrilJS/mithril.js">Chat</a>
+					<a href="https://github.com/MithrilJS/mithril.js">Github</a>
 				</nav>
 			</section>
 		</header>

--- a/docs/nav-guides.md
+++ b/docs/nav-guides.md
@@ -16,7 +16,7 @@
 	- [Keys](keys.md)
 	- [Autoredraw system](autoredraw.md)
 - Social
-	- [Mithril Jobs](https://github.com/lhorie/mithril.js/wiki/JOBS)
+	- [Mithril Jobs](https://github.com/MithrilJS/mithril.js/wiki/JOBS)
 	- [How to contribute](contributing.md)
 	- [Credits](credits.md)
 	- [Code of Conduct](code-of-conduct.md)

--- a/docs/nav-methods.md
+++ b/docs/nav-methods.md
@@ -16,4 +16,4 @@
 - Optional
 	- [Stream](stream.md)
 - Tooling
-	- [Ospec](https://github.com/lhorie/mithril.js/blob/rewrite/ospec)
+	- [Ospec](https://github.com/MithrilJS/mithril.js/blob/master/ospec)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,5 +1,7 @@
 # Mithril Release Processes
 
+**Note** These steps all assume that `MithrilJS/mithril.js` is a git remote named `mithriljs`, adjust accordingly if that doesn't match your setup.
+
 ## Releasing a new Mithril version
 
 ### Prepare the release
@@ -8,7 +10,7 @@
 
 ```bash
 $ git co next
-$ git pull --rebase lhorie next
+$ git pull --rebase mithriljs next
 ```
 
 2. Determine patch level of the change
@@ -22,8 +24,8 @@ $ git commit -m "Preparing for release"
 # Push to your branch
 $ git push
 
-# Push to lhorie/mithril.js
-$ git push lhorie next
+# Push to MithrilJS/mithril.js
+$ git push mithriljs next
 ```
 
 ### Merge from `next` to `master`
@@ -32,7 +34,7 @@ $ git push lhorie next
 
 ```bash
 $ git co master
-$ git pull --rebase lhorie master
+$ git pull --rebase mithriljs master
 ```
 
 6. merge `next` on top of it
@@ -53,10 +55,10 @@ $ npm test
 
 8. `npm run release <major|minor|patch|semver>`, see the docs for [`npm version`](https://docs.npmjs.com/cli/version)
 9. The changes will be automatically pushed to your fork
-10. Push the changes to `lhorie/mithril.js`
+10. Push the changes to `MithrilJS/mithril.js`
 
 ```bash
-$ git push lhorie master
+$ git push mithriljs master
 ```
 
 11. Travis will push the new release to npm & create a GitHub release
@@ -69,7 +71,7 @@ This helps to ensure that the `version` field of `package.json` doesn't get out 
 
 ```bash
 $ git co next
-$ git pull --rebase lhorie next
+$ git pull --rebase mithriljs next
 ```
 
 13. Merge `master` back onto `next`
@@ -78,11 +80,11 @@ $ git pull --rebase lhorie next
 $ git merge master
 ```
 
-14. Push the changes to your fork & `lhorie/mithril.js`
+14. Push the changes to your fork & `MithrilJS/mithril.js`
 
 ```bash
 $ git push
-$ git push lhorie next
+$ git push mithriljs next
 ```
 
 ### Update the GitHub release
@@ -94,11 +96,11 @@ $ git push lhorie next
 Fixes to documentation can land whenever, updates to the site are published via Travis.
 
 ```bash
-# These steps assume that lhorie/mithril.js is a git remote named "lhorie"
+# These steps assume that MithrilJS/mithril.js is a git remote named "mithriljs"
 
 # Ensure your next branch is up to date
 $ git co next
-$ git pull lhorie next
+$ git pull mithriljs next
 
 # Splat the docs folder from next onto master
 $ git co master
@@ -106,7 +108,7 @@ $ git co next -- ./docs
 
 # Manually ensure that no new feature docs were added
 
-$ git push lhorie
+$ git push mithriljs
 ```
 
 After the Travis build completes the updated docs should appear on https://mithril.js.org in a few minutes.

--- a/docs/simple-application.md
+++ b/docs/simple-application.md
@@ -616,4 +616,4 @@ This concludes the tutorial.
 
 In this tutorial, we went through the process of creating a very simple application where we can list users from a server and edit them individually. As an extra exercise, try to implement user creation and deletion on your own.
 
-If you want to see more examples of Mithril code, check the [examples](examples.md) page. If you have questions, feel free to drop by the [Mithril chat room](https://gitter.im/lhorie/mithril.js).
+If you want to see more examples of Mithril code, check the [examples](examples.md) page. If you have questions, feel free to drop by the [Mithril chat room](https://gitter.im/MithrilJS/mithril.js).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Mithril comes with a testing framework called [ospec](https://github.com/lhorie/mithril.js/tree/rewrite/ospec). What makes it different from most test frameworks is that it avoids all configurability for the sake of avoiding [yak shaving](http://catb.org/jargon/html/Y/yak-shaving.html) and [analysis paralysis](https://en.wikipedia.org/wiki/Analysis_paralysis).
+Mithril comes with a testing framework called [ospec](https://github.com/MithrilJS/mithril.js/tree/master/ospec). What makes it different from most test frameworks is that it avoids all configurability for the sake of avoiding [yak shaving](http://catb.org/jargon/html/Y/yak-shaving.html) and [analysis paralysis](https://en.wikipedia.org/wiki/Analysis_paralysis).
 
 The easist way to setup the test runner is to create an NPM script for it. Open your project's `package.json` file and edit the `test` line under the `scripts` section:
 

--- a/ospec/package.json
+++ b/ospec/package.json
@@ -12,5 +12,5 @@
   "bin": {
     "ospec": "./bin/ospec"
   },
-  "repository": "lhorie/mithril.js#rewrite"
+  "repository": "MithrilJS/mithril.js"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Leo Horie",
   "license": "MIT",
   "main": "mithril.js",
-  "repository": "lhorie/mithril.js",
+  "repository": "MithrilJS/mithril.js",
   "scripts": {
     "dev": "node bundler/cli browser.js -o mithril.js -w",
     "build": "npm run build-browser & npm run build-min",

--- a/stream/package.json
+++ b/stream/package.json
@@ -9,5 +9,5 @@
   "keywords": [ "stream", "reactive", "data" ],
   "author": "Leo Horie <lhorie@hotmail.com>",
   "license": "MIT",
-  "repository": "lhorie/mithril.js"
+  "repository": "MithrilJS/mithril.js"
 }


### PR DESCRIPTION
Did a pass to convert all `lhorie/mithril.js` refs into `MithrilJS/mithril.js`. Also all `rewrite` branch references to `master`.