### PR TITLE
selector [value=""] is mishandled

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -17,7 +17,7 @@ function compileSelector(selector) {
 			var attrValue = match[6]
 			if (attrValue) attrValue = attrValue.replace(/\\(["'])/g, "$1").replace(/\\\\/g, "\\")
 			if (match[4] === "class") classes.push(attrValue)
-			else attrs[match[4]] = attrValue || true
+			else attrs[match[4]] = attrValue === "" ? attrValue : attrValue || true
 		}
 	}
 	if (classes.length > 0) attrs.className = classes.join(" ")

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -218,6 +218,18 @@ o.spec("hyperscript", function() {
 			o(vnode.tag).equals("div")
 			o(vnode.attrs.a).equals(true)
 		})
+		o("handles explicit empty string value for input", function() {
+			var vnode = m('input[value=""]')
+
+			o(vnode.tag).equals("input")
+			o(vnode.attrs.value).equals("")
+		})
+		o("handles explicit empty string value for option", function() {
+			var vnode = m('option[value=""]')
+
+			o(vnode.tag).equals("option")
+			o(vnode.attrs.value).equals("")
+		})
 	})
 	o.spec("attrs", function() {
 		o("handles string attr", function() {


### PR DESCRIPTION
Sending the empty string as the value of an input or option in a selector passed to m() yields a tag with value="true"

e.g.
```m('input[value=""]')``` becomes ```<input value="true">```
and
```m('option[value=""]')``` becomes ```<option value="true">```
