### PR TITLE
Clarifying babel/webpack docs

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -98,7 +98,7 @@ npm install babel-core babel-loader babel-preset-es2015 babel-plugin-transform-r
 
 Create a `.babelrc` file:
 
-```
+```json
 {
 	"presets": ["es2015"],
 	"plugins": [
@@ -127,6 +127,8 @@ module.exports = {
 	}
 }
 ```
+
+For those familiar with Webpack already, please note that adding the Babel options to the `babel-loader` section of your `webpack.config.js` will throw an error, so you need to include them in the separate `.babelrc` file.
 
 This configuration assumes the source code file for the application entry point is in `src/index.js`, and this will output the bundle to `bin/app.js`.
 


### PR DESCRIPTION
Adding clarification that babel options can't be included in the `babel-loader` object of your `webpack.config.js`, for silly people like me who sometimes don't follow directions