### PR TITLE
Update ospec to ignore hidden directories and files

### DIFF
--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -17,6 +17,7 @@ function traverseDirectory(pathname, callback) {
 					var promises = []
 					for (var i = 0; i < pathnames.length; i++) {
 						if (pathnames[i] === "node_modules") continue
+						if (pathnames[i][0] === ".") continue
 						pathnames[i] = path.join(pathname, pathnames[i])
 						promises.push(traverseDirectory(pathnames[i], callback))
 					}


### PR DESCRIPTION
Motivation: When using ospec on Cloud9, a difficult-to-diagnose error shows up with `SyntaxError: Unexpected token :` because ospec is trying to parse metadata about the tests files (like undo information for working on `tests/hello.js`) that is stored under `.c9/metadata` with the exact same file path and names as the edited files have (e.g. `.c9/metadata/workspace/tests/hello.js`).