### PR TITLE
[WIP, don't merge] Fix #1804 and tweak #1595

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -40,9 +40,7 @@
 
 - API: `m.route.set()` causes all mount points to be redrawn ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - render/attrs: Using style objects in hyperscript calls will now properly diff style properties from one render to another as opposed to re-writing all element style properties every render.
-- render/attrs: `xlink:href` attributes are now correctly removed
-- render/attrs: fix element value don't change if new value is undefined [#2082](https://github.com/MithrilJS/mithril.js/issues/2082)
-(https://github.com/MithrilJS/mithril.js/pull/2130)
+- render/attrs All vnodes attributes are properly removed when absent or set to `null` or `undefined` [#1804](https://github.com/MithrilJS/mithril.js/issues/1804) [#2082](https://github.com/MithrilJS/mithril.js/issues/2082) ([#1865](https://github.com/MithrilJS/mithril.js/pull/1865), [#2130](https://github.com/MithrilJS/mithril.js/pull/2130))
 - render/core: Render state correctly on select change event [#1916](https://github.com/MithrilJS/mithril.js/issues/1916) ([#1918](https://github.com/MithrilJS/mithril.js/pull/1918) [@robinchew](https://github.com/robinchew), [#2052](https://github.com/MithrilJS/mithril.js/pull/2052))
 - render/core: fix various updateNodes/removeNodes issues when the pool and fragments are involved [#1990](https://github.com/MithrilJS/mithril.js/issues/1990), [#1991](https://github.com/MithrilJS/mithril.js/issues/1991), [#2003](https://github.com/MithrilJS/mithril.js/issues/2003), [#2021](https://github.com/MithrilJS/mithril.js/pull/2021)
 - render/core: fix crashes when the keyed vnodes with the same `key` had different `tag` values [#2128](https://github.com/MithrilJS/mithril.js/issues/2128) [@JacksonJN](https://github.com/JacksonJN) ([#2130](https://github.com/MithrilJS/mithril.js/pull/2130))

--- a/docs/lint.js
+++ b/docs/lint.js
@@ -101,12 +101,14 @@ function ensureLinkIsValid(file, data) {
 }
 
 function initMocks() {
-	global.window = require("../test-utils/browserMock")() // eslint-disable-line global-require
+	/* eslint-disable global-require */
+	global.window = require("../test-utils/browserMock")()
 	global.document = window.document
-	global.m = require("../index") // eslint-disable-line global-require
-	global.o = require("../ospec/ospec") // eslint-disable-line global-require
-	global.stream = require("../stream") // eslint-disable-line global-require
+	global.m = require("../index")
+	global.o = require("../ospec/ospec")
+	global.stream = require("../stream")
 	global.alert = function() {}
+	/* eslint-enable global-require */
 
 	//routes consumed by request.md
 	global.window.$defineRoutes({

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -1,4 +1,3 @@
-/* eslint-disable global-require, no-bitwise, no-process-exit */
 "use strict"
 ;(function(m) {
 if (typeof module !== "undefined") module["exports"] = m()
@@ -92,7 +91,7 @@ else window.o = m()
 				if (typeof reporter === "function") reporter(results)
 				else {
 					var errCount = o.report(results)
-					if (hasProcess && errCount !== 0) process.exit(1)
+					if (hasProcess && errCount !== 0) process.exit(1) // eslint-disable-line no-process-exit
 				}
 			})
 		}, null), 200 /*default timeout delay*/)
@@ -225,7 +224,7 @@ else window.o = m()
 	}
 	function deepEqual(a, b) {
 		if (a === b) return true
-		if (a === null ^ b === null || a === undefined ^ b === undefined) return false
+		if (a === null ^ b === null || a === undefined ^ b === undefined) return false // eslint-disable-line no-bitwise
 		if (typeof a === "object" && typeof b === "object") {
 			var aIsArgs = isArguments(a), bIsArgs = isArguments(b)
 			if (a.constructor === Object && b.constructor === Object && !aIsArgs && !bIsArgs) {
@@ -287,7 +286,7 @@ else window.o = m()
 		results[assertion.i].error = error != null ? error : ensureStackTrace(new Error)
 	}
 	function serialize(value) {
-		if (hasProcess) return require("util").inspect(value)
+		if (hasProcess) return require("util").inspect(value) // eslint-disable-line global-require
 		if (value === null || (typeof value === "object" && !(value instanceof Array)) || typeof value === "number") return String(value)
 		else if (typeof value === "function") return value.name || "<anonymous function>"
 		try {return JSON.stringify(value)} catch (e) {return String(value)}

--- a/performance/test-perf.js
+++ b/performance/test-perf.js
@@ -233,7 +233,7 @@ suite.add({
 		var counter = 0
 		var keyLooper = function (n) { return function (c) { return c % n ? (c + "px") : c } }
 		var get = function (obj, i) { return obj[i%obj.length] }
-		var classes = ["foo", "foo bar", "", "baz-bat", null, "fooga"]
+		var classes = ["foo", "foo bar", "", "baz-bat", null, "fooga", null, null, undefined]
 		var styles = []
 		var multivalue = ["0 1px", "0 0 1px 0", "0", "1px", "20px 10px", "7em 5px", "1px 0 5em 2px"]
 		var stylekeys = [

--- a/render/render.js
+++ b/render/render.js
@@ -685,9 +685,8 @@ module.exports = function($window) {
 		}
 	}
 	function setAttr(vnode, key, old, value, ns) {
-		if (key === "key" || key === "is" || isLifecycleMethod(key)) return
+		if (key === "key" || key === "is" || value == null || isLifecycleMethod(key) || (old === value && !isFormAttribute(vnode, key)) && typeof value !== "object") return
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
-		if ((old === value && !isFormAttribute(vnode, key)) && typeof value !== "object" || value == null) return
 		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
 		else if (key === "style") updateStyle(vnode.dom, old, value)
 		else if (key in vnode.dom && !isAttribute(key) && ns === undefined && !isCustomElement(vnode.tag, vnode.attrs)) {
@@ -751,10 +750,11 @@ module.exports = function($window) {
 				setAttr(vnode, key, old && old[key], attrs[key], ns)
 			}
 		}
+		var val
 		if (old != null) {
 			for (var key in old) {
-				if (attrs == null || attrs[key] == null) {
-					removeAttr(vnode, key, old[key], ns)
+				if (((val = old[key]) != null) && (attrs == null || attrs[key] == null)) {
+					removeAttr(vnode, key, val, ns)
 				}
 			}
 		}

--- a/render/render.js
+++ b/render/render.js
@@ -726,6 +726,9 @@ module.exports = function($window) {
 			else element.setAttribute(key === "className" ? "class" : key, value)
 		}
 	}
+	function removeAttr(vnode, key, old, ns) {
+
+	}
 	function setLateAttrs(vnode) {
 		var attrs = vnode.attrs
 		if (vnode.tag === "select" && attrs != null) {

--- a/render/render.js
+++ b/render/render.js
@@ -556,9 +556,7 @@ module.exports = function($window) {
 			u = 0
 			v = result.length - 1
 			while (u < v) {
-				/*eslint-disable no-bitwise*/
-				var c = ((u + v) / 2) | 0
-				/*eslint-enable no-bitwise*/
+				var c = ((u + v) / 2) | 0 // eslint-disable-line no-bitwise
 				if (a[result[c]] < a[i]) {
 					u = c + 1
 				}
@@ -734,9 +732,7 @@ module.exports = function($window) {
 			if(attrs.value === null) {
 				if (vnode.dom.selectedIndex !== -1) vnode.dom.value = null
 			} else {
-				/*eslint-disable no-implicit-coercion*/
-				var normalized = "" + attrs.value
-				/*eslint-enable no-implicit-coercion*/
+				var normalized = "" + attrs.value // eslint-disable-line no-implicit-coercion
 				if (vnode.dom.value !== normalized || vnode.dom.selectedIndex === -1) {
 					vnode.dom.value = normalized
 				}

--- a/render/render.js
+++ b/render/render.js
@@ -692,10 +692,9 @@ module.exports = function($window) {
 			return
 		}
 		if ((old === value && !isFormAttribute(vnode, key)) && typeof value !== "object" || value === undefined) return
-		var element = vnode.dom
-		if (key.slice(0, 6) === "xlink:") element.setAttributeNS("http://www.w3.org/1999/xlink", key, value)
-		else if (key === "style") updateStyle(element, old, value)
-		else if (key in element && !isAttribute(key) && ns === undefined && !isCustomElement(vnode)) {
+		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key, value)
+		else if (key === "style") updateStyle(vnode.dom, old, value)
+		else if (key in vnode.dom && !isAttribute(key) && ns === undefined && !isCustomElement(vnode)) {
 			if (key === "value") {
 				var normalized = "" + value // eslint-disable-line no-implicit-coercion
 				//setting input[value] to same value by typing on focused element moves cursor to end in Chrome
@@ -713,17 +712,17 @@ module.exports = function($window) {
 			}
 			// If you assign an input type that is not supported by IE 11 with an assignment expression, an error will occur.
 			if (vnode.tag === "input" && key === "type") {
-				element.setAttribute(key, value)
+				vnode.dom.setAttribute(key, value)
 				return
 			}
-			element[key] = value
+			vnode.dom[key] = value
 		}
 		else {
 			if (typeof value === "boolean") {
-				if (value) element.setAttribute(key, "")
-				else element.removeAttribute(key)
+				if (value) vnode.dom.setAttribute(key, "")
+				else vnode.dom.removeAttribute(key)
 			}
-			else element.setAttribute(key === "className" ? "class" : key, value)
+			else vnode.dom.setAttribute(key === "className" ? "class" : key, value)
 		}
 	}
 	function removeAttr(vnode, key, old, ns) {

--- a/render/render.js
+++ b/render/render.js
@@ -688,7 +688,7 @@ module.exports = function($window) {
 		if (key === "key" || key === "is" || isLifecycleMethod(key)) return
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if ((old === value && !isFormAttribute(vnode, key)) && typeof value !== "object" || value == null) return
-		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key, value)
+		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
 		else if (key === "style") updateStyle(vnode.dom, old, value)
 		else if (key in vnode.dom && !isAttribute(key) && ns === undefined && !isCustomElement(vnode.tag, vnode.attrs)) {
 			if (key === "value") {
@@ -713,11 +713,7 @@ module.exports = function($window) {
 	}
 	function removeAttr(vnode, key, old, ns) {
 		if (key === "key" || key === "is" || old == null || isLifecycleMethod(key)) return
-		var nsLastIndex = key.indexOf(":")
-		if (nsLastIndex > -1 && key.substr(0, nsLastIndex) === "xlink") {
-			vnode.dom.removeAttributeNS("http://www.w3.org/1999/xlink", key.slice(nsLastIndex + 1))
-		}
-		else if (key[0] === "o" && key[1] === "n" && !isLifecycleMethod(key)) updateEvent(vnode, key, undefined)
+		if (key[0] === "o" && key[1] === "n" && !isLifecycleMethod(key)) updateEvent(vnode, key, undefined)
 		else if (key === "style") updateStyle(vnode.dom, old, null)
 		else if (
 			key in vnode.dom && !isAttribute(key)
@@ -729,6 +725,8 @@ module.exports = function($window) {
 		) {
 			vnode.dom[key] = null
 		} else {
+			var nsLastIndex = key.indexOf(":")
+			if (nsLastIndex !== -1) key = key.slice(nsLastIndex + 1)
 			if (old !== false) vnode.dom.removeAttribute(key === "className" ? "class" : key)
 		}
 	}

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -357,24 +357,27 @@ o.spec("attributes", function() {
 
 			o(a.dom.attributes["class"].value).equals("test")
 		})
-		o("removes xlink:href", function() {
+		/* eslint-disable no-script-url */
+		o("handles xlink:href", function() {
 			var vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
 				{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {"xlink:href": "javascript:;"}}
 			]}
 			render(root, [vnode])
-	
+
 			o(vnode.dom.nodeName).equals("svg")
-			o(vnode.dom.firstChild.attributes["xlink:href"].value).equals("javascript:;")
-			o(vnode.dom.firstChild.attributes["xlink:href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
-	
+			o(vnode.dom.firstChild.attributes["href"].value).equals("javascript:;")
+			o(vnode.dom.firstChild.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+
 			vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
 				{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {}}
 			]}
 			render(root, [vnode])
-	
+
 			o(vnode.dom.nodeName).equals("svg")
-			o(vnode.dom.firstChild.attributes["xlink:href"]).equals(undefined)
+			o("href" in vnode.dom.firstChild.attributes).equals(false)
 		})
+		/* eslint-enable no-script-url */
+
 	})
 
 	o.spec("option.value", function() {

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -349,7 +349,7 @@ o.spec("attributes", function() {
 			o(canvas.dom.width).equals(100)
 		})
 	})
-	o.spec("svg class", function() {
+	o.spec("svg", function() {
 		o("when className is specified then it should be added as a class", function() {
 			var a = {tag: "svg", attrs: {className: "test"}}
 
@@ -357,7 +357,26 @@ o.spec("attributes", function() {
 
 			o(a.dom.attributes["class"].value).equals("test")
 		})
+		o("removes xlink:href", function() {
+			var vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
+				{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {"xlink:href": "javascript:;"}}
+			]}
+			render(root, [vnode])
+	
+			o(vnode.dom.nodeName).equals("svg")
+			o(vnode.dom.firstChild.attributes["xlink:href"].value).equals("javascript:;")
+			o(vnode.dom.firstChild.attributes["xlink:href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+	
+			vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
+				{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {}}
+			]}
+			render(root, [vnode])
+	
+			o(vnode.dom.nodeName).equals("svg")
+			o(vnode.dom.firstChild.attributes["xlink:href"]).equals(undefined)
+		})
 	})
+
 	o.spec("option.value", function() {
 		o("can be set as text", function() {
 			var a = {tag: "option", attrs: {value: "test"}}

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -377,9 +377,7 @@ o.spec("attributes", function() {
 			o("href" in vnode.dom.firstChild.attributes).equals(false)
 		})
 		/* eslint-enable no-script-url */
-
 	})
-
 	o.spec("option.value", function() {
 		o("can be set as text", function() {
 			var a = {tag: "option", attrs: {value: "test"}}

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -44,11 +44,10 @@ o.spec("attributes", function() {
 			o(b.dom.hasAttribute("id")).equals(true)
 			o(b.dom.getAttribute("id")).equals("test")
 
+			// #1804
 			render(root, [c]);
 
-			// #1804
-			// TODO: uncomment
-			// o(c.dom.hasAttribute("id")).equals(false)
+			o(c.dom.hasAttribute("id")).equals(false)
 		})
 	})
 	o.spec("customElements", function(){
@@ -147,7 +146,7 @@ o.spec("attributes", function() {
 		o("a lack of attribute removes `value`", function() {
 			var a = {tag: "input", attrs: {}}
 			var b = {tag: "input", attrs: {value: "test"}}
-			// var c = {tag: "input", attrs: {}}
+			var c = {tag: "input", attrs: {}}
 
 			render(root, [a])
 
@@ -158,10 +157,9 @@ o.spec("attributes", function() {
 			o(a.dom.value).equals("test")
 
 			// https://github.com/MithrilJS/mithril.js/issues/1804#issuecomment-304521235
-			// TODO: Uncomment
-			// render(root, [c])
+			render(root, [c])
 
-			// o(a.dom.value).equals("")
+			o(a.dom.value).equals("")
 		})
 		o("can be set as number", function() {
 			var a = {tag: "input", attrs: {value: 1}}
@@ -276,17 +274,16 @@ o.spec("attributes", function() {
 	o.spec("textarea.value", function() {
 		o("can be removed by not passing a value", function() {
 			var a = {tag: "textarea", attrs: {value:"x"}}
-			// var b = {tag: "textarea", attrs: {}}
+			var b = {tag: "textarea", attrs: {}}
 
 			render(root, [a])
 
 			o(a.dom.value).equals("x")
 
 			// https://github.com/MithrilJS/mithril.js/issues/1804#issuecomment-304521235
-			// TODO: Uncomment
-			// render(root, [b])
+			render(root, [b])
 
-			// o(b.dom.value).equals("")
+			o(b.dom.value).equals("")
 		})
 		o("isn't set when equivalent to the previous value and focused", function() {
 			var $window = domMock({spy: o.spy})

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -373,15 +373,15 @@ o.spec("attributes", function() {
 
 			o(a.dom.value).equals("1")
 		})
-		o("null becomes 'null'", function() {
+		o("null removes the attribute", function() {
 			var a = {tag: "option", attrs: {value: null}}
 			var b = {tag: "option", attrs: {value: "test"}}
 			var c = {tag: "option", attrs: {value: null}}
 
 			render(root, [a]);
 
-			o(a.dom.value).equals("null")
-			o(a.dom.getAttribute("value")).equals("null")
+			o(a.dom.value).equals("")
+			o(a.dom.hasAttribute("value")).equals(false)
 
 			render(root, [b]);
 
@@ -390,8 +390,8 @@ o.spec("attributes", function() {
 
 			render(root, [c]);
 
-			o(c.dom.value).equals("null")
-			o(c.dom.getAttribute("value")).equals("null")
+			o(c.dom.value).equals("")
+			o(c.dom.hasAttribute("value")).equals(false)
 		})
 		o("'' and 0 are different values", function() {
 			var a = {tag: "option", attrs: {value: 0}, children:[{tag:"#", children:""}]}

--- a/render/tests/test-createElement.js
+++ b/render/tests/test-createElement.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-script-url */
 "use strict"
 
 var o = require("../../ospec/ospec")
@@ -54,6 +53,7 @@ o.spec("createElement", function() {
 		o(vnode.dom.childNodes[0].nodeName).equals("A")
 		o(vnode.dom.childNodes[1].nodeName).equals("B")
 	})
+	/* eslint-disable no-script-url */
 	o("creates svg", function() {
 		var vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
 			{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {"xlink:href": "javascript:;"}},
@@ -65,35 +65,18 @@ o.spec("createElement", function() {
 		o(vnode.dom.namespaceURI).equals("http://www.w3.org/2000/svg")
 		o(vnode.dom.firstChild.nodeName).equals("a")
 		o(vnode.dom.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
-		o(vnode.dom.firstChild.attributes["xlink:href"].value).equals("javascript:;")
-		o(vnode.dom.firstChild.attributes["xlink:href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+		o(vnode.dom.firstChild.attributes["href"].value).equals("javascript:;")
+		o(vnode.dom.firstChild.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
 		o(vnode.dom.childNodes[1].nodeName).equals("foreignObject")
 		o(vnode.dom.childNodes[1].firstChild.nodeName).equals("body")
 		o(vnode.dom.childNodes[1].firstChild.namespaceURI).equals("http://www.w3.org/1999/xhtml")
 	})
+	/* eslint-enable no-script-url */
 	o("sets attributes correctly for svg", function() {
 		var vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", attrs: {viewBox: "0 0 100 100"}}
 		render(root, [vnode])
 
 		o(vnode.dom.attributes["viewBox"].value).equals("0 0 100 100")
-	})
-	o("removes xlink:href", function() {
-		var vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
-			{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {"xlink:href": "javascript:;"}}
-		]}
-		render(root, [vnode])
-
-		o(vnode.dom.nodeName).equals("svg")
-		o(vnode.dom.firstChild.attributes["xlink:href"].value).equals("javascript:;")
-		o(vnode.dom.firstChild.attributes["xlink:href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
-
-		vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
-			{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {}}
-		]}
-		render(root, [vnode])
-
-		o(vnode.dom.nodeName).equals("svg")
-		o(vnode.dom.firstChild.attributes["xlink:href"]).equals(undefined)
 	})
 	o("creates mathml", function() {
 		var vnode = {tag: "math", ns: "http://www.w3.org/1998/Math/MathML", children: [{tag: "mrow", ns: "http://www.w3.org/1998/Math/MathML"}]}

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -205,6 +205,72 @@ o.spec("updateElement", function() {
 
 		o(updated.dom.style.color).equals("red")
 	})
+	o("setting style to `null` removes all styles", function() {
+		var vnode = {"tag": "p", attrs: {style: "background-color: red"}}
+		var updated = {"tag": "p", attrs: {style: null}}
+
+		render(root, [vnode])
+
+		o("style" in vnode.dom.attributes).equals(true)
+		o(vnode.dom.attributes.style.value).equals("background-color: red;")
+
+		render(root, [updated])
+
+		//browsers disagree here
+		try {
+
+			o(updated.dom.attributes.style.value).equals("")
+
+		} catch (e) {
+
+			o("style" in updated.dom.attributes).equals(false)
+
+		}
+	})
+	o("setting style to `undefined` removes all styles", function() {
+		var vnode = {"tag": "p", attrs: {style: "background-color: red"}}
+		var updated = {"tag": "p", attrs: {style: undefined}}
+
+		render(root, [vnode])
+
+		o("style" in vnode.dom.attributes).equals(true)
+		o(vnode.dom.attributes.style.value).equals("background-color: red;")
+
+		render(root, [updated])
+
+		//browsers disagree here
+		try {
+
+			o(updated.dom.attributes.style.value).equals("")
+
+		} catch (e) {
+
+			o("style" in updated.dom.attributes).equals(false)
+
+		}
+	})
+	o("not setting style removes all styles", function() {
+		var vnode = {"tag": "p", attrs: {style: "background-color: red"}}
+		var updated = {"tag": "p", attrs: {}}
+
+		render(root, [vnode])
+
+		o("style" in vnode.dom.attributes).equals(true)
+		o(vnode.dom.attributes.style.value).equals("background-color: red;")
+
+		render(root, [updated])
+
+		//browsers disagree here
+		try {
+
+			o(updated.dom.attributes.style.value).equals("")
+
+		} catch (e) {
+
+			o("style" in updated.dom.attributes).equals(false)
+
+		}
+	})
 	o("replaces el", function() {
 		var vnode = {tag: "a"}
 		var updated = {tag: "b"}

--- a/render/tests/test-updateNodesFuzzer.js
+++ b/render/tests/test-updateNodesFuzzer.js
@@ -61,9 +61,7 @@ function longestIncreasingSubsequence(a) {
 		v = result.length - 1
 
 		while (u < v) {
-			/*eslint-disable no-bitwise*/
-			var c = ((u + v) / 2) | 0
-			/*eslint-enable no-bitwise*/
+			var c = ((u + v) / 2) | 0 // eslint-disable-line no-bitwise
 			if (a[result[c]] < a[i]) {
 				u = c + 1
 			} else {

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -247,7 +247,7 @@ module.exports = function(options) {
 									}
 								}
 							}
-							cssText = buf.join(" ")
+							element.setAttribute("style", cssText = buf.join(" "))
 						}
 					}
 				})

--- a/test-utils/tests/test-domMock.js
+++ b/test-utils/tests/test-domMock.js
@@ -618,6 +618,7 @@ o.spec("domMock", function() {
 
 			o(div.style.backgroundColor).equals("red")
 			o(div.style.borderBottom).equals("1px solid red")
+			o(div.attributes.style.value).equals("background-color: red; border-bottom: 1px solid red;")
 		})
 		o("removing via setting style.cssText string works", function() {
 			var div = $document.createElement("div")
@@ -625,6 +626,7 @@ o.spec("domMock", function() {
 			div.style.cssText = ""
 
 			o(div.style.background).equals("")
+			o(div.attributes.style.value).equals("")
 		})
 		o("the final semicolon is optional when setting style.cssText", function() {
 			var div = $document.createElement("div")
@@ -632,6 +634,7 @@ o.spec("domMock", function() {
 
 			o(div.style.background).equals("red")
 			o(div.style.cssText).equals("background: red;")
+			o(div.attributes.style.value).equals("background: red;")
 		})
 		o("'cssText' as a property name is ignored when setting style.cssText", function(){
 			var div = $document.createElement("div")

--- a/test-utils/tests/test-domMock.js
+++ b/test-utils/tests/test-domMock.js
@@ -364,6 +364,12 @@ o.spec("domMock", function() {
 
 			o(div.getAttribute("id")).equals("aaa")
 		})
+		o("works for attributes with a namespace", function() {
+			var div = $document.createElement("div")
+			div.setAttributeNS("http://www.w3.org/1999/xlink", "href", "aaa")
+
+			o(div.getAttribute("href")).equals("aaa")
+		})
 	})
 
 	o.spec("setAttribute", function() {
@@ -429,18 +435,40 @@ o.spec("domMock", function() {
 
 	o.spec("setAttributeNS", function() {
 		o("works", function() {
-			var div = $document.createElement("div")
-			div.setAttributeNS("http://www.w3.org/1999/xlink", "href", "aaa")
+			var a = $document.createElementNS("http://www.w3.org/2000/svg", "a")
+			a.setAttributeNS("http://www.w3.org/1999/xlink", "href", "/aaa")
 
-			o(div.attributes["href"].value).equals("aaa")
-			o(div.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+			o(a.href).deepEquals({baseVal: "/aaa", animVal: "/aaa"})
+			o(a.attributes["href"].value).equals("/aaa")
+			o(a.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
 		})
 		o("works w/ number", function() {
-			var div = $document.createElement("div")
-			div.setAttributeNS("http://www.w3.org/1999/xlink", "href", 123)
+			var a = $document.createElementNS("http://www.w3.org/2000/svg", "a")
+			a.setAttributeNS("http://www.w3.org/1999/xlink", "href", 123)
 
-			o(div.attributes["href"].value).equals("123")
-			o(div.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+			o(a.href).deepEquals({baseVal: "123", animVal: "123"})
+			o(a.attributes["href"].value).equals("123")
+			o(a.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+		})
+		o("attributes with a namespace can be querried, updated and removed with non-NS functions", function() {
+			var a = $document.createElementNS("http://www.w3.org/2000/svg", "a")
+			a.setAttributeNS("http://www.w3.org/1999/xlink", "href", "/aaa")
+
+			o(a.hasAttribute("href")).equals(true)
+			o(a.getAttribute("href")).equals("/aaa")
+
+			a.setAttribute("href", "/bbb")
+
+			o(a.href).deepEquals({baseVal: "/bbb", animVal: "/bbb"})
+			o(a.getAttribute("href")).equals("/bbb")
+			o(a.attributes["href"].value).equals("/bbb")
+			o(a.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+
+			a.removeAttribute("href")
+
+			o(a.hasAttribute("href")).equals(false)
+			o(a.getAttribute("href")).equals(null)
+			o("href" in a.attributes).equals(false)
 		})
 	})
 
@@ -1265,6 +1293,13 @@ o.spec("domMock", function() {
 
 				o(a.href).notEquals("")
 				o(a.attributes["href"].value).equals("")
+			})
+			o("property is read-only for SVG elements", function() {
+				var a = $document.createElementNS("http://www.w3.org/2000/svg", "a")
+				a.href = "/foo"
+
+				o(a.href).deepEquals({baseVal: "", animVal: ""})
+				o("href" in a.attributes).equals(false)
 			})
 		})
 		o.spec("input[checked]", function() {


### PR DESCRIPTION
This fixes #1804 and tweaks #1595.

`removeAttr()` now mirrors `setAttr()`. values set to `undefined` or `null` are equivalent to a lack of value, except for `select`, where `null` 

There are still possibly problematic corner cases with `select.value`, please don't merge this yet.

#1862 can be merged as is in the mean time if you want. I'll rebase this.