### PR TITLE
Use manual path resolution in webpack.config.js

### DIFF
--- a/docs/es6.md
+++ b/docs/es6.md
@@ -70,10 +70,12 @@ Create a `.babelrc` file:
 Next, create a file called `webpack.config.js`
 
 ```javascript
+const path = require('path')
+
 module.exports = {
 	entry: './src/index.js',
 	output: {
-		path: './bin',
+		path: path.resolve(__dirname, './bin'),
 		filename: 'app.js',
 	},
 	module: {

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -112,10 +112,12 @@ Create a `.babelrc` file:
 Next, create a file called `webpack.config.js`
 
 ```javascript
+const path = require('path')
+
 module.exports = {
 	entry: './src/index.js',
 	output: {
-		path: './bin',
+		path: path.resolve(__dirname, './bin'),
 		filename: 'app.js',
 	},
 	module: {


### PR DESCRIPTION
Webpack doesn't support relative paths in the output.path config parameter, so this updated code uses the 'path' module to resolve the relative path.