### PR TITLE
Don't overwrite the options object when redirecting from onmatch with m.route.set

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -39,7 +39,10 @@ module.exports = function($window, redrawService) {
 		redrawService.subscribe(root, run)
 	}
 	route.set = function(path, data, options) {
-		if (lastUpdate != null) options = {replace: true}
+		if (lastUpdate != null) {
+			options = options || {}
+			options.replace = true
+		}
 		lastUpdate = null
 		routeService.setPath(path, data, options)
 	}

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -665,7 +665,7 @@ o.spec("route", function() {
 					route(root, "/a", {
 						"/a" : {
 							onmatch: function() {
-								route.set("/b")
+								route.set("/b", {}, {state: {a: 5}})
 							},
 							render: render
 						},
@@ -684,6 +684,7 @@ o.spec("route", function() {
 							o(view.callCount).equals(1)
 							o(root.childNodes.length).equals(1)
 							o(root.firstChild.nodeName).equals("DIV")
+							o($window.history.state).deepEquals({a: 5})
 
 							done()
 						})


### PR DESCRIPTION
fix #1857