### PR TITLE
Set event.redraw to true before passing it to event handlers, fixes #1850

### DIFF
--- a/api/redraw.js
+++ b/api/redraw.js
@@ -26,7 +26,8 @@ function throttle(callback) {
 module.exports = function($window) {
 	var renderService = coreRenderer($window)
 	renderService.setEventCallback(function(e) {
-		if (e.redraw !== false) redraw()
+		if (e.redraw === false) e.redraw = undefined
+		else redraw()
 	})
 
 	var callbacks = []

--- a/api/tests/test-mount.js
+++ b/api/tests/test-mount.js
@@ -5,7 +5,6 @@ var components = require("../../test-utils/components")
 var domMock = require("../../test-utils/domMock")
 
 var m = require("../../render/hyperscript")
-var coreRenderer = require("../../render/render")
 var apiRedraw = require("../../api/redraw")
 var apiMounter = require("../../api/mount")
 
@@ -20,7 +19,7 @@ o.spec("mount", function() {
 
 		redrawService = apiRedraw($window)
 		mount = apiMounter(redrawService)
-		render = coreRenderer($window).render
+		render = redrawService.render
 	})
 
 	o("throws on invalid component", function() {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -224,9 +224,11 @@ o.spec("route", function() {
 						}
 					})
 
+					o(oninit.callCount).equals(1)
+
 					root.firstChild.dispatchEvent(e)
 
-					o(oninit.callCount).equals(1)
+					o(e.redraw).notEquals(false)
 
 					// Wrapped to ensure no redraw fired
 					callAsync(function() {


### PR DESCRIPTION
No tests for this since the mocks don't implement event bubbling right now.

I suggest we merge this and leave #1850 open with the "needs test case" label only...