### PR TITLE
Don't add travis-only deps to package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 # Custom install step so the travis-only stuff doesn't need to be in package.json
 install:
 - npm install
-- npm install @alrra/travis-scripts@^3.0.1 gh-pages@^0.12.0
+- npm install --no-save @alrra/travis-scripts@^3.0.1 gh-pages@^0.12.0
 
 # Bundle before running tests so the bundle is always up-to-date
 before_script: npm run build --silent

--- a/package.json
+++ b/package.json
@@ -25,10 +25,8 @@
     "postversion": "git push --follow-tags"
   },
   "devDependencies": {
-    "@alrra/travis-scripts": "^3.0.1",
     "benchmark": "^2.1.4",
     "eslint": "^3.19.0",
-    "gh-pages": "^0.12.0",
     "istanbul": "^0.4.5",
     "marked": "^0.3.6"
   },


### PR DESCRIPTION
`npm@5` changed to save-by-default, which screwed up the plan of keeping travis-only deps out of `package.json`. Remove them entirely from `devDependencies` and ensure that Travis won't accidentally re-add them.

Fixes #1894