### PR TITLE
Remove unnecessary branch filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,6 @@ deploy:
     on:
       tags: true
       repo: MithrilJS/mithril.js
-      branch: master
   
   - provider: npm
     skip_cleanup: true
@@ -94,4 +93,3 @@ deploy:
     on:
       tags: true
       repo: MithrilJS/mithril.js
-      branch: master


### PR DESCRIPTION
According to [the docs](https://docs.travis-ci.com/user/deployment/#Conditional-Releases-with-on%3A) both `tags` and `branch` don't make sense, and we only care about tagged commits.

This is prep work for cutting `0.2.6` (and any other future releases in the `0.2.x` line).