### PR TITLE
Remove bundle bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,5 @@
   },
   "bin": {
     "ospec": "./ospec/bin/ospec"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "marked": "^0.3.6"
   },
   "bin": {
-    "ospec": "./ospec/bin/ospec",
-    "bundle": "./bundler/bin/bundle"
+    "ospec": "./ospec/bin/ospec"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
No end-user needs it, it's solely for mithril development. Also causes problems for some folks.

Fixes #1668