### PR TITLE
XHR errors have response/code fields

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -93,7 +93,8 @@ module.exports = function($window, Promise) {
 						}
 						else {
 							var error = new Error(xhr.responseText)
-							for (var key in response) error[key] = response[key]
+							error.code = xhr.status
+							error.response = response
 							reject(error)
 						}
 					}

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -458,9 +458,10 @@ o.spec("xhr", function() {
 			xhr({method: "GET", url: "/item"}).catch(function(e) {
 				o(e instanceof Error).equals(true)
 				o(e.message).equals(JSON.stringify({error: "error"}))
+				o(e.code).equals(500)
 			}).then(done)
 		})
-		o("extends Error with JSON response", function(done) {
+		o("adds response to Error", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function() {
 					return {status: 500, responseText: JSON.stringify({message: "error", stack: "error on line 1"})}
@@ -468,8 +469,8 @@ o.spec("xhr", function() {
 			})
 			xhr({method: "GET", url: "/item"}).catch(function(e) {
 				o(e instanceof Error).equals(true)
-				o(e.message).equals("error")
-				o(e.stack).equals("error on line 1")
+				o(e.response.message).equals("error")
+				o(e.response.stack).equals("error on line 1")
 			}).then(done)
 		})
 		o("rejects on non-JSON server error", function(done) {


### PR DESCRIPTION
So that there's no chance of data loss and it's trivial to get the response code (because it's hella useful!)

Fixes #1866
Fixes #1876