### PR TITLE
Remove m.request URL interpolation

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -51,7 +51,6 @@ module.exports = function($window, Promise) {
 			if (typeof args.deserialize !== "function") args.deserialize = deserialize
 			if (typeof args.extract !== "function") args.extract = extract
 
-			args.url = interpolate(args.url, args.data)
 			if (useBody) args.data = args.serialize(args.data)
 			else args.url = assemble(args.url, args.data)
 
@@ -127,25 +126,11 @@ module.exports = function($window, Promise) {
 				delete $window[callbackName]
 			}
 			if (args.data == null) args.data = {}
-			args.url = interpolate(args.url, args.data)
 			args.data[args.callbackKey || "callback"] = callbackName
 			script.src = assemble(args.url, args.data)
 			$window.document.documentElement.appendChild(script)
 		})
 		return args.background === true? promise : finalize(promise)
-	}
-
-	function interpolate(url, data) {
-		if (data == null) return url
-
-		var tokens = url.match(/:[^\/]+/gi) || []
-		for (var i = 0; i < tokens.length; i++) {
-			var key = tokens[i].slice(1)
-			if (data[key] != null) {
-				url = url.replace(tokens[i], data[key])
-			}
-		}
-		return url
 	}
 
 	function assemble(url, data) {

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -113,26 +113,6 @@ o.spec("xhr", function() {
 				o(data).deepEquals({a: {x: ":y"}})
 			}).then(done)
 		})
-		o("works w/ parameterized url via GET", function(done) {
-			mock.$defineRoutes({
-				"GET /item/y": function(request) {
-					return {status: 200, responseText: JSON.stringify({a: request.url, b: request.query})}
-				}
-			})
-			xhr({method: "GET", url: "/item/:x", data: {x: "y"}}).then(function(data) {
-				o(data).deepEquals({a: "/item/y", b: "?x=y"})
-			}).then(done)
-		})
-		o("works w/ parameterized url via POST", function(done) {
-			mock.$defineRoutes({
-				"POST /item/y": function(request) {
-					return {status: 200, responseText: JSON.stringify({a: request.url, b: JSON.parse(request.body)})}
-				}
-			})
-			xhr({method: "POST", url: "/item/:x", data: {x: "y"}}).then(function(data) {
-				o(data).deepEquals({a: "/item/y", b: {x: "y"}})
-			}).then(done)
-		})
 		o("works w/ array", function(done) {
 			mock.$defineRoutes({
 				"POST /items": function(request) {
@@ -141,26 +121,6 @@ o.spec("xhr", function() {
 			})
 			xhr({method: "POST", url: "/items", data: [{x: "y"}]}).then(function(data) {
 				o(data).deepEquals({a: "/items", b: [{x: "y"}]})
-			}).then(done)
-		})
-		o("ignores unresolved parameter via GET", function(done) {
-			mock.$defineRoutes({
-				"GET /item/:x": function(request) {
-					return {status: 200, responseText: JSON.stringify({a: request.url})}
-				}
-			})
-			xhr({method: "GET", url: "/item/:x"}).then(function(data) {
-				o(data).deepEquals({a: "/item/:x"})
-			}).then(done)
-		})
-		o("ignores unresolved parameter via POST", function(done) {
-			mock.$defineRoutes({
-				"GET /item/:x": function(request) {
-					return {status: 200, responseText: JSON.stringify({a: request.url})}
-				}
-			})
-			xhr({method: "GET", url: "/item/:x"}).then(function(data) {
-				o(data).deepEquals({a: "/item/:x"})
 			}).then(done)
 		})
 		o("type parameter works for Array responses", function(done) {
@@ -435,18 +395,6 @@ o.spec("xhr", function() {
 				done()
 			})
 		})
-		/*o("data maintains after interpolate", function() {
-			mock.$defineRoutes({
-				"PUT /items/:x": function() {
-					return {status: 200, responseText: ""}
-				}
-			})
-			var data = {x: 1, y: 2}
-			var dataCopy = Object.assign({}, data);
-			xhr({method: "PUT", url: "/items/:x", data})
-
-			o(data).deepEquals(dataCopy)
-		})*/
 	})
 	o.spec("failure", function() {
 		o("rejects on server error", function(done) {


### PR DESCRIPTION
The [URL interpolation](https://mithril.js.org/request.html#dynamic-urls) support has caused multiple issues and PRs since 1.0 shipped.

#1702 | #1654 | #1699

As @isiahmeadows pointed out in https://github.com/MithrilJS/mithril.js/issues/1699#issuecomment-285830871 you can handle this trivially now with template literals. So here's a PR to drop support for it. Also shaves ~70 bytes off the gzipped bundle size.

Does anyone feel strongly about retaining this feature?