### PR TITLE
Don't show diffs for package lock files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 /mithril.js binary
 /mithril.min.js binary
 /package-lock.json binary
-/yarn.lock
+/yarn.lock binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 * text=auto
 /mithril.js binary
 /mithril.min.js binary
+/package-lock.json binary
+/yarn.lock


### PR DESCRIPTION
Modified the .gitattributes so that lock files don't show often noisy, useless diffs every time they're updated. It's pretty self-explanatory.

I included Yarn's `yarn.lock` as well, in case that file ever finds its way into our repo (likely by my own unconscious doing).