### PR TITLE
Fix mismatched brace in Authentication example

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -568,7 +568,7 @@ var Login = {
 		return m("form", [
 			m("input[type=text]", {oninput: m.withAttr("value", Auth.setUsername), value: Auth.username}),
 			m("input[type=password]", {oninput: m.withAttr("value", Auth.setPassword), value: Auth.password}),
-			m("button[type=button]", {onclick: Auth.login, "Login")
+			m("button[type=button]", {onclick: Auth.login}, "Login")
 		])
 	}
 }


### PR DESCRIPTION
## Description

This is just a simple documentation fix for those who copy/paste examples to test basic functionality.  There was a missing `}` that caused a syntax error.
