### PR TITLE
Fix #1921

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -24,6 +24,7 @@
 #### Bug fixes
 
 - API: `m.route.set()` causes all mount points to be redrawn ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
+- core: don't call `onremove` on the children of components that return null from the view [#1921](https://github.com/MithrilJS/mithril.js/issues/1921) [octavore](https://github.com/octavore) ([#1922](https://github.com/MithrilJS/mithril.js/pull/1922))
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -451,9 +451,10 @@ module.exports = function($window) {
 	}
 	function onremove(vnode) {
 		if (vnode.attrs && typeof vnode.attrs.onremove === "function") vnode.attrs.onremove.call(vnode.state, vnode)
-		if (typeof vnode.tag !== "string" && typeof vnode._state.onremove === "function") vnode._state.onremove.call(vnode.state, vnode)
-		if (vnode.instance != null) onremove(vnode.instance)
-		else {
+		if (typeof vnode.tag !== "string") {
+			if (typeof vnode._state.onremove === "function") vnode._state.onremove.call(vnode.state, vnode)
+			if (vnode.instance != null) onremove(vnode.instance)
+		} else {
 			var children = vnode.children
 			if (Array.isArray(children)) {
 				for (var i = 0; i < children.length; i++) {

--- a/render/tests/test-onremove.js
+++ b/render/tests/test-onremove.js
@@ -89,6 +89,7 @@ o.spec("onremove", function() {
 
 		o(vnode.dom.onremove).equals(undefined)
 		o(vnode.dom.attributes["onremove"]).equals(undefined)
+		o(vnode.events).equals(undefined)
 	})
 	o("calls onremove on recycle", function() {
 		var remove = o.spy()
@@ -149,6 +150,46 @@ o.spec("onremove", function() {
 				render(root, null)
 				
 				o(spy.callCount).equals(1)
+			})
+			o("doesn't call onremove on children when the corresponding view returns null (after removing the parent)", function() {
+				var threw = false
+				var spy = o.spy()
+				var parent = createComponent({
+					view: function() {}
+				})
+				var child = createComponent({
+					view: function() {},
+					onremove: spy
+				})
+				render(root, {tag: parent, children: [child]})
+				try {
+					render(root, null)
+				} catch (e) {
+					threw = e
+				}
+
+				o(spy.callCount).equals(0)
+				o(threw).equals(false)
+			})
+			o("doesn't call onremove on children when the corresponding view returns null (after removing the children)", function() {
+				var threw = false
+				var spy = o.spy()
+				var parent = createComponent({
+					view: function() {}
+				})
+				var child = createComponent({
+					view: function() {},
+					onremove: spy
+				})
+				render(root, {tag: parent, children: [child]})
+				try {
+					render(root, {tag: parent})
+				} catch (e) {
+					threw = true
+				}
+
+				o(spy.callCount).equals(0)
+				o(threw).equals(false)
 			})
 		})
 	})


### PR DESCRIPTION
## Description

fix for #1921: Don't visit the `children` array of components, even when the `instance` is null.

## How Has This Been Tested?

`npm run test` before and after the fix. Fails before (exception thrown because the `_state` is `null`), succeeds after.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
