### PR TITLE
Fix small typo in render.html

### DIFF
--- a/render.html
+++ b/render.html
@@ -116,7 +116,7 @@
 <h3 id="standalone-usage"><a href="#standalone-usage">Standalone usage</a></h3>
 <p><code>var render = require(&quot;mithril/render&quot;)</code></p>
 <p>The <code>m.render</code> module is similar in scope to view libraries like Knockout, React and Vue. It is approximately 500 lines of code (3kb min+gzip) and implements a virtual DOM diffing engine with a modern search space reduction algorithm and DOM recycling, which translate to top-of-class performance, both in terms of initial page load and re-rendering. It has no dependencies on other parts of Mithril and can be used as a standalone library.</p>
-<p>Despite being incredibly small, the render module is fully functional and self-suficient. It supports everything you might expect: SVG, custom elements, and all valid attributes and events - without any weird case-sensitive edge cases or exceptions. Of course, it also fully supports <a href="components.html">components</a> and <a href="lifecycle-methods.html">lifecycle methods</a>.</p>
+<p>Despite being incredibly small, the render module is fully functional and self-sufficient. It supports everything you might expect: SVG, custom elements, and all valid attributes and events - without any weird case-sensitive edge cases or exceptions. Of course, it also fully supports <a href="components.html">components</a> and <a href="lifecycle-methods.html">lifecycle methods</a>.</p>
 
 				<hr />
 				<small>License: MIT. &copy; Leo Horie.</small>


### PR DESCRIPTION
Found a small typo in the documentation, hopefully this is the right way to edit it. Thanks for the awesome library!