### PR TITLE
suport promise return in ospec

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -84,23 +84,34 @@ module.exports = new function init(name) {
 				if (cursor === fns.length) return
 
 				var fn = fns[cursor++]
+				var timeout = 0, delay = 200, s = new Date
+				var isDone = false
+
+				function done() {
+					if (timeout !== undefined) {
+						timeout = clearTimeout(timeout)
+						if (delay !== Infinity) record(null)
+						if (!isDone) next()
+						else throw new Error("`" + arg + "()` should only be called once")
+						isDone = true
+					}
+					else console.log("# elapsed: " + Math.round(new Date - s) + "ms, expected under " + delay + "ms")
+				}
+
+				function startTimer() {
+					timeout = setTimeout(function() {
+						timeout = undefined
+						record("async test timed out")
+						next()
+					}, Math.min(delay, 2147483647))
+				}
+
 				if (fn.length > 0) {
-					var timeout = 0, delay = 200, s = new Date
-					var isDone = false
 					var body = fn.toString()
 					var arg = (body.match(/\(([\w$]+)/) || body.match(/([\w$]+)\s*=>/) || []).pop()
 					if (body.indexOf(arg) === body.lastIndexOf(arg)) throw new Error("`" + arg + "()` should be called at least once")
 					try {
-						fn(function done() {
-							if (timeout !== undefined) {
-								timeout = clearTimeout(timeout)
-								if (delay !== Infinity) record(null)
-								if (!isDone) next()
-								else throw new Error("`" + arg + "()` should only be called once")
-								isDone = true
-							}
-							else console.log("# elapsed: " + Math.round(new Date - s) + "ms, expected under " + delay + "ms")
-						}, function(t) {delay = t})
+						fn(done, function(t) {delay = t})
 					}
 					catch (e) {
 						record(e.message, e)
@@ -108,16 +119,17 @@ module.exports = new function init(name) {
 						next()
 					}
 					if (timeout === 0) {
-						timeout = setTimeout(function() {
-							timeout = undefined
-							record("async test timed out")
-							next()
-						}, Math.min(delay, 2147483647))
+						startTimer()
 					}
 				}
 				else {
-					fn()
-					nextTickish(next)
+					var p = fn()
+					if (p && p.then) {
+						startTimer()
+						p.then(done)
+					} else {
+						next()
+					}
 				}
 			}
 		}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -107,7 +107,7 @@ o.spec("ospec", function() {
 			o(output).deepEquals({tag: "div", children: children})
 		})
 	})
-	o.spec("async", function() {
+	o.spec("async callback", function() {
 		var a = 0, b = 0
 
 		o.before(function(done) {
@@ -145,6 +145,49 @@ o.spec("ospec", function() {
 				o(a).equals(1)("a and b should be initialized")
 
 				done()
+			})
+		})
+	})
+
+	o.spec("async promise", function() {
+		var a = 0, b = 0
+
+		function wrapPromise(fn) {
+			return new Promise(resolve => {
+				callAsync(() => {
+					fn()
+					resolve()
+				})
+			})
+		}
+
+		o.before(function() {
+			return wrapPromise(() => {
+				a = 1
+			})
+		})
+
+		o.after(function() {
+			return wrapPromise(function() {
+				a = 0
+			})
+		})
+
+		o.beforeEach(function() {
+			return wrapPromise(function() {
+				b = 1
+			})
+		})
+		o.afterEach(function() {
+			return wrapPromise(function() {
+				b = 0
+			})
+		})
+
+		o("promise functions", async function() {
+			await wrapPromise(function() {
+				o(a).equals(b)
+				o(a).equals(1)("a and b should be initialized")
 			})
 		})
 	})


### PR DESCRIPTION
Support promise returns in ospec as alternative to `done` callback. Also supports `async/await` automatically

## Description
Currently ospec does not support returning promises or using `async/await` without wrapper. This PR tries to add support for that.

## Motivation and Context
async/await is the future for async stuff. We should support this.

## How Has This Been Tested?
* Wrote a test that verifies basic usage
* checkt if timeouts work

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
