### PR TITLE
support promise return in ospec

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -23,6 +23,11 @@
 
 - API: Introduction of `m.redraw.sync()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 
+#### Ospec improvements:
+
+- Added support for async functions and promises in tests - ([#1928](https://github.com/MithrilJS/mithril.js/pull/1928))
+- Error handling for async tests with `done` callbacks supports error as first argument
+
 #### Bug fixes
 
 - API: `m.route.set()` causes all mount points to be redrawn ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -148,6 +148,22 @@ o("setTimeout calls callback", function(done) {
 })
 ```
 
+Alternativly you can return a promise or even use an async function in tests:
+
+```javascript
+o("promise test", function() {
+	return new Promise(function(resolve) {
+		setTimeout(resolve, 10)
+	})
+})
+```
+
+```javascript
+o("promise test", async function() {
+	await someOtherAsyncFunction()
+})
+```
+
 By default, asynchronous tests time out after 20ms. This can be changed on a per-test basis using the `timeout` argument:
 
 ```javascript
@@ -158,7 +174,22 @@ o("setTimeout calls callback", function(done, timeout) {
 })
 ```
 
-Note that the `timeout` function call must be the first statement in its test.
+Note that the `timeout` function call must be the first statement in its test.	This currently does not work for promise tests. You can combine both methods to do this:
+
+```javascript
+o("promise test", function(done, timeout) {
+	timeout(1000)
+	someOtherAsyncFunctionThatTakes900ms().then(done)
+})
+```
+
+```javascript
+o("promise test", async function(done, timeout) {
+	timeout(1000)
+	await someOtherAsyncFunctionThatTakes900ms()
+	done()
+})
+```
 
 Asynchronous tests generate an assertion that succeeds upon calling `done` or fails on timeout with the error message `async test timed out`.
 

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -87,7 +87,13 @@ module.exports = new function init(name) {
 				var timeout = 0, delay = 200, s = new Date
 				var isDone = false
 
-				function done() {
+				function done(err) {
+					if (err) {
+						if (err.message) record(err.message, err)
+						else record(err)
+						subjects.pop()
+						next()
+					}
 					if (timeout !== undefined) {
 						timeout = clearTimeout(timeout)
 						if (delay !== Infinity) record(null)
@@ -114,9 +120,7 @@ module.exports = new function init(name) {
 						fn(done, function(t) {delay = t})
 					}
 					catch (e) {
-						record(e.message, e)
-						subjects.pop()
-						next()
+						done(e)
 					}
 					if (timeout === 0) {
 						startTimer()
@@ -126,11 +130,7 @@ module.exports = new function init(name) {
 					var p = fn()
 					if (p && p.then) {
 						startTimer()
-						p.then(done, e => {
-							record(e.message, e)
-							subjects.pop()
-							next()
-						})
+						p.then(function() { done() }, done)
 					} else {
 						nextTickish(next)
 					}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -107,7 +107,7 @@ o.spec("ospec", function() {
 			o(output).deepEquals({tag: "div", children: children})
 		})
 	})
-	o.spec("async", function() {
+	o.spec("async callback", function() {
 		var a = 0, b = 0
 
 		o.before(function(done) {
@@ -145,6 +145,49 @@ o.spec("ospec", function() {
 				o(a).equals(1)("a and b should be initialized")
 
 				done()
+			})
+		})
+	})
+
+	o.spec("async promise", function() {
+		var a = 0, b = 0
+
+		function wrapPromise(fn) {
+			return new Promise(resolve => {
+				callAsync(() => {
+					fn()
+					resolve()
+				})
+			})
+		}
+
+		o.before(function() {
+			return wrapPromise(() => {
+				a = 1
+			})
+		})
+
+		o.after(function() {
+			return wrapPromise(function() {
+				a = 0
+			})
+		})
+
+		o.beforeEach(function() {
+			return wrapPromise(function() {
+				b = 1
+			})
+		})
+		o.afterEach(function() {
+			return wrapPromise(function() {
+				b = 0
+			})
+		})
+
+		o("promise functions", async function() {
+			await wrapPromise(function() {
+				o(a).equals(b)
+				o(a).equals(1)("a and b should be initialized")
 			})
 		})
 	})

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -153,10 +153,14 @@ o.spec("ospec", function() {
 		var a = 0, b = 0
 
 		function wrapPromise(fn) {
-			return new Promise(resolve => {
+			return new Promise((resolve, reject) => {
 				callAsync(() => {
-					fn()
-					resolve()
+					try {
+						fn()
+						resolve()
+					} catch(e) {
+						reject(e)
+					}
 				})
 			})
 		}

--- a/promise/tests/test-promise.js
+++ b/promise/tests/test-promise.js
@@ -131,7 +131,7 @@ o.spec("promise", function() {
 				callAsync(function() {resolve(promise)})
 			})
 
-			promise.then(null, done)
+			promise.then(null, () => done())
 		})
 		o("non-function onFulfilled is ignored", function(done) {
 			var promise = Promise.resolve(1)


### PR DESCRIPTION
Support promise returns in ospec as alternative to `done` callback. Also supports `async/await` automatically

## Description
Currently ospec does not support returning promises or using `async/await` without wrapper. This PR tries to add support for that.

## Motivation and Context
async/await is the future for async stuff. We should support this.

## How Has This Been Tested?
* Wrote a test that verifies basic usage
* checkt if timeouts work

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
