### PR TITLE
Enable setting navigation options with m.route.link API

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -52,7 +52,7 @@ module.exports = function($window, redrawService) {
 	}
 	route.get = function() {return currentPath}
 	route.prefix = function(prefix) {routeService.prefix = prefix}
-	route.link = function(vnode) {
+	var link = function(options, vnode) {
 		vnode.dom.setAttribute("href", routeService.prefix + vnode.attrs.href)
 		vnode.dom.onclick = function(e) {
 			if (e.ctrlKey || e.metaKey || e.shiftKey || e.which === 2) return
@@ -60,8 +60,12 @@ module.exports = function($window, redrawService) {
 			e.redraw = false
 			var href = this.getAttribute("href")
 			if (href.indexOf(routeService.prefix) === 0) href = href.slice(routeService.prefix.length)
-			route.set(href, undefined, undefined)
+			route.set(href, undefined, options)
 		}
+	}
+	route.link = function(args) {
+		if (args.tag == null) return link.bind(link, args)
+		return link({}, args)
 	}
 	route.param = function(key) {
 		if(typeof attrs !== "undefined" && typeof key !== "undefined") return attrs[key]

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -281,6 +281,36 @@ o.spec("route", function() {
 					o($window.location.href).equals(env.protocol + "//" + (env.hostname === "/" ? "" : env.hostname) + slash + (prefix ? prefix + "/" : "") + "test")
 				})
 
+				o("passes options on route.link", function() {
+					var opts = {}
+					var e = $window.document.createEvent("MouseEvents")
+
+					e.initEvent("click", true, true)
+					$window.location.href = prefix + "/"
+
+					route(root, "/", {
+						"/" : {
+							view: function() {
+								return m("a", {
+									href: "/test",
+									oncreate: route.link(opts)
+								})
+							}
+						},
+						"/test" : {
+							view : function() {
+								return m("div")
+							}
+						}
+					})
+					route.set = o.spy(route.set)
+
+					root.firstChild.dispatchEvent(e)
+
+					o(route.set.callCount).equals(1)
+					o(route.set.args[2]).equals(opts)
+				})
+
 				o("accepts RouteResolver with onmatch that returns Component", function(done) {
 					var matchCount = 0
 					var renderCount = 0

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -25,6 +25,7 @@
 
 - API: Introduction of `m.redraw.sync()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Event handlers may also be objects with `handleEvent` methods ([#1939](https://github.com/MithrilJS/mithril.js/issues/1939)).
+- API: `m.route.link` accepts an optional `options` object ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
 
 #### Ospec improvements:
 

--- a/docs/route.md
+++ b/docs/route.md
@@ -104,7 +104,7 @@ Argument          | Type      | Required | Description
 This function can be used as the `oncreate` (and `onupdate`) hook in a `m("a")` vnode:
 
 ```JS
-m("a[href=/]", {oncreate: m.route.link})`.
+m("a[href=/]", {oncreate: m.route.link})
 ```
 
 Using `m.route.link` as a `oncreate` hook causes the link to behave as a router link (i.e. it navigates to the route specified in `href`, instead of navigating away from the current page to the URL specified in `href`.
@@ -112,15 +112,21 @@ Using `m.route.link` as a `oncreate` hook causes the link to behave as a router 
 If the `href` attribute is not static, the `onupdate` hook must also be set:
 
 ```JS
-m("a", {href: someVariable, oncreate: m.route.link, onupdate: m.route.link})`
+m("a", {href: someVariable, oncreate: m.route.link, onupdate: m.route.link})
 ```
 
-`m.route.link(vnode)`
+`m.route.link` can also set the `options` passed to `m.route.set` when the link is clicked by calling the function in the lifecycle methods:
 
-Argument          | Type        | Required | Description
------------------ | ----------- | -------- | ---
-`vnode`           | `Vnode`     | Yes      | This method is meant to be used as or in conjunction with an `<a>` [vnode](vnodes.md)'s [`oncreate` and `onupdate` hooks](lifecycle-methods.md)
-**returns**       |             |          | Returns `undefined`
+```JS
+m("a[href=/]", {oncreate: m.route.link({replace: true})})
+```
+
+`m.route.link(args)`
+
+Argument          | Type           | Required | Description
+----------------- | ---------------| -------- | ---
+`args`            | `Vnode|Object` | Yes      | This method is meant to be used as or in conjunction with an `<a>` [vnode](vnodes.md)'s [`oncreate` and `onupdate` hooks](lifecycle-methods.md)
+**returns**       | `function`     |          | Returns the onclick handler function for the component
 
 ##### m.route.param
 


### PR DESCRIPTION
## Description

Some refactoring to enable passing the `options` object to `m.route.set` using the `m.route.link` API in lifecycle methods.

## Motivation and Context

With current functionality, there is no way to overwrite browser history entries and pass specific parameters to the history API with `m.route.link`, this always requires a custom method to be written.

Related issues #1807 #1810 

## How Has This Been Tested?

`npm t` with new test case.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
