### PR TITLE
More accurate style object diffs

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -27,6 +27,7 @@
 
 - API: `m.route.set()` causes all mount points to be redrawn ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: If a user sets the Content-Type header within a request's options, that value will be the entire header value rather than being appended to the default value ([#1924](https://github.com/MithrilJS/mithril.js/pull/1924))
+- API: Using style objects in hyperscript calls will now properly diff style properties from one render to another as opposed to re-writing all element style properties every render.
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -572,11 +572,6 @@ module.exports = function($window) {
 			for (var key in style) {
 				element.style[key] = style[key]
 			}
-			if (old != null && typeof old !== "string") {
-				for (var key in old) {
-					if (!(key in style)) element.style[key] = ""
-				}
-			}
 		}
 	}
 

--- a/render/render.js
+++ b/render/render.js
@@ -552,6 +552,18 @@ module.exports = function($window) {
 
 	//style
 	function updateStyle(element, old, style) {
+		if (old != null && style != null && typeof old === "object" && typeof style === "object" && style !== old) {
+			// Both old & new are (different) objects.
+			// Update style properties that have changed
+			for (var key in style) {
+				if (style[key] !== old[key]) element.style[key] = style[key]
+			}
+			// Remove style properties that no longer exist
+			for (var key in old) {
+				if (!(key in style)) element.style[key] = ""
+			}
+			return
+		}
 		if (old === style) element.style.cssText = "", old = null
 		if (style == null) element.style.cssText = ""
 		else if (typeof style === "string") element.style.cssText = style

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -192,6 +192,19 @@ o.spec("updateElement", function() {
 		o(updated.dom.style.backgroundColor).equals("")
 		o(updated.dom.style.color).equals("gold")
 	})
+	o("does not re-render element styles for equivalent style objects", function() {
+		var style = {color: "gold"}
+		var vnode = {tag: "a", attrs: {style: style}}
+
+		render(root, [vnode])
+
+		root.firstChild.style.color = "red"
+		style = {color: "gold"}
+		var updated = {tag: "a", attrs: {style: style}}
+		render(root, [updated])
+
+		o(updated.dom.style.color).equals("red")
+	})
 	o("replaces el", function() {
 		var vnode = {tag: "a"}
 		var updated = {tag: "b"}


### PR DESCRIPTION
## Description

This change attempts to partially improve on style object diffs (See: https://github.com/MithrilJS/mithril.js/issues/1932)

This change only takes effect when a fresh style object is provided each render. If a cached style object is used, then the behaviour remains unchanged (all element style properties will be wiped and re-rendered.)

Since `attrs` objects are not cloned, it's not easy to keep a copy of the style object used for the previous render. Furthermore, since [undesirable behaviour](https://flems.io/#0=N4IgzgpgNhDGAuEAmIBcIB0ArMIA0IAZgJYy6oDaoAdgIYC2EamAFvPVPiLAPbWL9mIAL54aDJumy4CvfhEHo5YeAAIATjx5qAvKqQ9YAV0b8MAIx5IAngB1q9mGtrx46sKr3AV1mKlUA5LxQPOr+AMQAYgAM0QHC9vb0GOoKSBDqABSa2nj2qqr0mQEBeKoubmBltiAASsg1AJT2zQ50ru4YPjCegcGhEdExAfYA9KMV7r3e8L4Q-kE8IWGq4UNxCW3jqgDKLDxGUEiq5hCqAOapCmXqxOdsAPxJKWkZ2VrwedQFRSVlk1VVDUAOJXBwgVqtERiEB0RjMDCwMAybh8ATwITCAC6BCgxGoAGtyFQQEZ1Jx0Gx4AAHMCocZGajUgnnRE8eijejEeAsW6cAizamSEA4ERY4RAA) can already result from re-using attrs objects, re-using style objects should similarly be discouraged.

And since using fresh attrs and style objects every render would seem to be the more common use-case, I think this is a useful improvement.

## Motivation and Context
When a `attrs.style` object is used in a hyperscript call, all an element's style properties are re-written regardless of differences (or lack thereof) from the previous render.

If the dom is manipulated directly by the app, the app should expect mithril only to change elements where the vdom differs between renders. (Eg. animation use-cases.)

## How Has This Been Tested?
See test added to `render/tests/test-updateElement.js`

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This may affect apps that relied (intentionally or otherwise) on the old behaviour.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
