### PR TITLE
Handle shared attributes object in hyperscript

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -36,6 +36,7 @@
 #### Bug fixes:
 
 - core: don't call `onremove` on the children of components that return null from the view [#1921](https://github.com/MithrilJS/mithril.js/issues/1921) [octavore](https://github.com/octavore) ([#1922](https://github.com/MithrilJS/mithril.js/pull/1922))
+- hypertext: correct handling of shared attributes object passed to `m()`. Will copy attributes when it's necessary [#1941](https://github.com/MithrilJS/mithril.js/issues/1941) [s-ilya](https://github.com/s-ilya) ([#1942](https://github.com/MithrilJS/mithril.js/pull/1942))
 
 ---
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -28,6 +28,18 @@ function execSelector(state, attrs, children) {
 	var hasAttrs = false, childList, text
 	var className = attrs.className || attrs.class
 
+	if (Object.keys(state.attrs).length && Object.keys(attrs).length) {
+		var newAttrs = {}
+
+		for(var key in attrs) {
+			if (hasOwn.call(attrs, key)) {
+				newAttrs[key] = attrs[key]
+			}
+		}
+
+		attrs = newAttrs
+	}
+
 	for (var key in state.attrs) {
 		if (hasOwn.call(state.attrs, key)) {
 			attrs[key] = state.attrs[key]

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -6,6 +6,11 @@ var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["
 var selectorCache = {}
 var hasOwn = {}.hasOwnProperty
 
+function isEmpty(object) {
+	for (var key in object) if (hasOwn.call(object, key)) return false
+	return true
+}
+
 function compileSelector(selector) {
 	var match, tag = "div", classes = [], attrs = {}
 	while (match = selectorParser.exec(selector)) {
@@ -28,7 +33,7 @@ function execSelector(state, attrs, children) {
 	var hasAttrs = false, childList, text
 	var className = attrs.className || attrs.class
 
-	if (Object.keys(state.attrs).length && Object.keys(attrs).length) {
+	if (!isEmpty(state.attrs) && !isEmpty(attrs)) {
 		var newAttrs = {}
 
 		for(var key in attrs) {

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -507,6 +507,23 @@ o.spec("hyperscript", function() {
 			o(vnode.children[0].tag).equals("i")
 			o(vnode.children[1].tag).equals("s")
 		})
+		o("handles shared attrs", function() {
+			var attrs = {a: "b"}
+
+			var nodeA = m(".a", attrs)
+			var nodeB = m(".b", attrs)
+
+			o(nodeA.attrs.className).equals("a")
+			o(nodeA.attrs.a).equals("b")
+
+			o(nodeB.attrs.className).equals("b")
+			o(nodeB.attrs.a).equals("b")
+		})
+		o("doesnt modify passed attributes object", function() {
+			var attrs = {a: "b"}
+			m(".a", attrs)
+			o(attrs).deepEquals({a: "b"})
+		})
 		o("handles fragment children without attr unwrapped", function() {
 			var vnode = m("div", [m("i")], [m("s")])
 


### PR DESCRIPTION
Possible fix for **Shared attributes for different component results in concatenated class names** #1941 

Mithril modifies passed attributes object to store classname derived from selector. I suggest we make a copy so there will no unexpected side-effects. 

btw, I'm using custom shallow copy instead of `Object.assign` because mithril seems to support IE9 and 10. Is it still the case?