### PR TITLE
Fixing IE bug causing active element to be null causing render function to error

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -28,7 +28,6 @@
 - API: `m.route.set()` causes all mount points to be redrawn ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: If a user sets the Content-Type header within a request's options, that value will be the entire header value rather than being appended to the default value ([#1924](https://github.com/MithrilJS/mithril.js/pull/1924))
 - API: Using style objects in hyperscript calls will now properly diff style properties from one render to another as opposed to re-writing all element style properties every render.
-- Fix IE11 active element is null causing render function to throw error.
 
 ---
 
@@ -38,6 +37,7 @@
 
 - core: don't call `onremove` on the children of components that return null from the view [#1921](https://github.com/MithrilJS/mithril.js/issues/1921) [octavore](https://github.com/octavore) ([#1922](https://github.com/MithrilJS/mithril.js/pull/1922))
 - hypertext: correct handling of shared attributes object passed to `m()`. Will copy attributes when it's necessary [#1941](https://github.com/MithrilJS/mithril.js/issues/1941) [s-ilya](https://github.com/s-ilya) ([#1942](https://github.com/MithrilJS/mithril.js/pull/1942))
+- Fix IE bug where active element is null causing render function to throw error. ([1943](https://github.com/MithrilJS/mithril.js/pull/1943))
 
 ---
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -28,6 +28,7 @@
 - API: `m.route.set()` causes all mount points to be redrawn ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: If a user sets the Content-Type header within a request's options, that value will be the entire header value rather than being appended to the default value ([#1924](https://github.com/MithrilJS/mithril.js/pull/1924))
 - API: Using style objects in hyperscript calls will now properly diff style properties from one render to another as opposed to re-writing all element style properties every render.
+- Fix IE11 active element is null causing render function to throw error.
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -630,6 +630,7 @@ module.exports = function($window) {
 		updateNodes(dom, dom.vnodes, Vnode.normalizeChildren(vnodes), false, hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
 		dom.vnodes = vnodes
 		for (var i = 0; i < hooks.length; i++) hooks[i]()
+		// document.activeElement can return null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
 		if (active !== null && $doc.activeElement !== active) active.focus()
 	}
 

--- a/render/render.js
+++ b/render/render.js
@@ -630,7 +630,7 @@ module.exports = function($window) {
 		updateNodes(dom, dom.vnodes, Vnode.normalizeChildren(vnodes), false, hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
 		dom.vnodes = vnodes
 		for (var i = 0; i < hooks.length; i++) hooks[i]()
-		if ($doc.activeElement !== active) active.focus()
+		if (active !== null && $doc.activeElement !== active) active.focus()
 	}
 
 	return {render: render, setEventCallback: setEventCallback}

--- a/render/render.js
+++ b/render/render.js
@@ -631,7 +631,7 @@ module.exports = function($window) {
 		dom.vnodes = vnodes
 		for (var i = 0; i < hooks.length; i++) hooks[i]()
 		// document.activeElement can return null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
-		if (active !== null && $doc.activeElement !== active) active.focus()
+		if (active != null && $doc.activeElement !== active) active.focus()
 	}
 
 	return {render: render, setEventCallback: setEventCallback}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is an issue in IE where `document.activeElement` becomes null sometimes. For example when you [use `removeChild` to remove an element, the active element isn't reset](https://stackoverflow.com/questions/36008978/document-activeelement-is-null-in-internet-explorer). And sometimes in [iframes](https://www.tjvantoll.com/2013/08/30/bugs-with-document-activeelement-in-internet-explorer/).

When this happens using mithril, the render function throws an error on [line 633](https://github.com/MithrilJS/mithril.js/blob/next/render/render.js#L633).

This is an issue that has come up in other frameworks, [for example in Angular](https://github.com/angular/material2/issues/2760).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In my case, I have a click event that removes an element that has an `onremove` function. That `onremove` function uses `removeChild` to remove the dom element. The same click event creates an element that runs `.focus()` inside a `oncreate` function. This causes the if statement on line 633 to pass and `active.focus()` to run, during which an error is caused by `active` being null. 

## How Has This Been Tested?
Confirmed this does not break any tests and does not cause any lint errors. I'm not sure what a new test would look like since `activeElement` can't be set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
