### PR TITLE
Add support for EventListener objects

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -583,7 +583,7 @@ module.exports = function($window) {
 	function updateEvent(vnode, key, value) {
 		var element = vnode.dom
 		var listener = typeof onevent !== "function" ? value : function(e) {
-			var result = typeof value === "function" ? value.call(element, e) : value.handleEvent(value, e)
+			var result = typeof value === "function" ? value.call(element, e) : value.handleEvent(e)
 			onevent.call(element, e)
 			return result
 		}

--- a/render/render.js
+++ b/render/render.js
@@ -478,7 +478,7 @@ module.exports = function($window) {
 		if (nsLastIndex > -1 && key.substr(0, nsLastIndex) === "xlink") {
 			element.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(nsLastIndex + 1), value)
 		}
-		else if (key[0] === "o" && key[1] === "n" && typeof value === "function") updateEvent(vnode, key, value)
+		else if (key[0] === "o" && key[1] === "n" && isEventListener(value)) updateEvent(vnode, key, value)
 		else if (key === "style") updateStyle(element, old, value)
 		else if (key in element && !isAttribute(key) && ns === undefined && !isCustomElement(vnode)) {
 			if (key === "value") {
@@ -549,6 +549,10 @@ module.exports = function($window) {
 	function hasIntegrationMethods(source) {
 		return source != null && (source.oncreate || source.onupdate || source.onbeforeremove || source.onremove)
 	}
+	/** Test if value can be used as an event listener */
+	function isEventListener(value) {
+		return typeof value === "function" || (value != null && typeof value === "object" && typeof value.handleEvent === "function")
+	}
 
 	//style
 	function updateStyle(element, old, style) {
@@ -578,19 +582,19 @@ module.exports = function($window) {
 	//event
 	function updateEvent(vnode, key, value) {
 		var element = vnode.dom
-		var callback = typeof onevent !== "function" ? value : function(e) {
-			var result = value.call(element, e)
+		var listener = typeof onevent !== "function" ? value : function(e) {
+			var result = typeof value === "function" ? value.call(element, e) : value.handleEvent(value, e)
 			onevent.call(element, e)
 			return result
 		}
-		if (key in element) element[key] = typeof value === "function" ? callback : null
+		if (key in element) element[key] = typeof value === "function" ? listener : null
 		else {
 			var eventName = key.slice(2)
 			if (vnode.events === undefined) vnode.events = {}
-			if (vnode.events[key] === callback) return
+			if (vnode.events[key] === listener) return
 			if (vnode.events[key] != null) element.removeEventListener(eventName, vnode.events[key], false)
-			if (typeof value === "function") {
-				vnode.events[key] = callback
+			if (value != null) {
+				vnode.events[key] = listener
 				element.addEventListener(eventName, vnode.events[key], false)
 			}
 		}

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -33,7 +33,27 @@ o.spec("event", function() {
 		o(onevent.args[0].type).equals("click")
 		o(onevent.args[0].target).equals(div.dom)
 	})
-	
+
+	o("handleEvent click", function() {
+		var spy = o.spy()
+		var listener = {handleEvent: function(e) {spy(e)}}
+		var div = {tag: "div", attrs: {onclick: listener}}
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+
+		render(root, [div])
+		div.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(1)
+		o(spy.this).equals(listener)
+		o(spy.args[0].type).equals("click")
+		o(spy.args[0].target).equals(div.dom)
+		o(onevent.callCount).equals(1)
+		o(onevent.this).equals(div.dom)
+		o(onevent.args[0].type).equals("click")
+		o(onevent.args[0].target).equals(div.dom)
+	})
+
 	o("removes event", function() {
 		var spy = o.spy()
 		var vnode = {tag: "a", attrs: {onclick: spy}}
@@ -45,7 +65,7 @@ o.spec("event", function() {
 		var e = $window.document.createEvent("MouseEvents")
 		e.initEvent("click", true, true)
 		vnode.dom.dispatchEvent(e)
-		
+
 		o(spy.callCount).equals(0)
 	})
 

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -69,11 +69,118 @@ o.spec("event", function() {
 		o(spy.callCount).equals(0)
 	})
 
+	o("removes event when null", function() {
+		var spy = o.spy()
+		var vnode = {tag: "a", attrs: {onclick: spy}}
+		var updated = {tag: "a", attrs: {onclick: null}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes event when undefined", function() {
+		var spy = o.spy()
+		var vnode = {tag: "a", attrs: {onclick: spy}}
+		var updated = {tag: "a", attrs: {onclick: undefined}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes event added via addEventListener when null", function() {
+		var spy = o.spy()
+		var vnode = {tag: "a", attrs: {ontouchstart: spy}}
+		var updated = {tag: "a", attrs: {ontouchstart: null}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("TouchEvents")
+		e.initEvent("touchstart", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes event added via addEventListener", function() {
+		var spy = o.spy()
+		var vnode = {tag: "a", attrs: {ontouchstart: spy}}
+		var updated = {tag: "a", attrs: {}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("TouchEvents")
+		e.initEvent("touchstart", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes event added via addEventListener when undefined", function() {
+		var spy = o.spy()
+		var vnode = {tag: "a", attrs: {ontouchstart: spy}}
+		var updated = {tag: "a", attrs: {ontouchstart: undefined}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("TouchEvents")
+		e.initEvent("touchstart", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
 	o("removes EventListener object", function() {
 		var spy = o.spy()
 		var listener = {handleEvent: spy}
 		var vnode = {tag: "a", attrs: {onclick: listener}}
 		var updated = {tag: "a", attrs: {}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes EventListener object when null", function() {
+		var spy = o.spy()
+		var listener = {handleEvent: spy}
+		var vnode = {tag: "a", attrs: {onclick: listener}}
+		var updated = {tag: "a", attrs: {onclick: null}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes EventListener object when undefined", function() {
+		var spy = o.spy()
+		var listener = {handleEvent: spy}
+		var vnode = {tag: "a", attrs: {onclick: listener}}
+		var updated = {tag: "a", attrs: {onclick: undefined}}
 
 		render(root, [vnode])
 		render(root, [updated])

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -34,9 +34,9 @@ o.spec("event", function() {
 		o(onevent.args[0].target).equals(div.dom)
 	})
 
-	o("handleEvent click", function() {
+	o("handles click EventListener object", function() {
 		var spy = o.spy()
-		var listener = {handleEvent: function(e) {spy(e)}}
+		var listener = {handleEvent: spy}
 		var div = {tag: "div", attrs: {onclick: listener}}
 		var e = $window.document.createEvent("MouseEvents")
 		e.initEvent("click", true, true)
@@ -57,6 +57,22 @@ o.spec("event", function() {
 	o("removes event", function() {
 		var spy = o.spy()
 		var vnode = {tag: "a", attrs: {onclick: spy}}
+		var updated = {tag: "a", attrs: {}}
+
+		render(root, [vnode])
+		render(root, [updated])
+
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+		vnode.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(0)
+	})
+
+	o("removes EventListener object", function() {
+		var spy = o.spy()
+		var listener = {handleEvent: spy}
+		var vnode = {tag: "a", attrs: {onclick: listener}}
 		var updated = {tag: "a", attrs: {}}
 
 		render(root, [vnode])
@@ -92,6 +108,30 @@ o.spec("event", function() {
 		o(div.dom.attributes["id"].value).equals("b")
 	})
 
+	o("fires click EventListener object only once after redraw", function() {
+		var spy = o.spy()
+		var listener = {handleEvent: spy}
+		var div = {tag: "div", attrs: {id: "a", onclick: listener}}
+		var updated = {tag: "div", attrs: {id: "b", onclick: listener}}
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+
+		render(root, [div])
+		render(root, [updated])
+		div.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(1)
+		o(spy.this).equals(listener)
+		o(spy.args[0].type).equals("click")
+		o(spy.args[0].target).equals(div.dom)
+		o(onevent.callCount).equals(1)
+		o(onevent.this).equals(div.dom)
+		o(onevent.args[0].type).equals("click")
+		o(onevent.args[0].target).equals(div.dom)
+		o(div.dom).equals(updated.dom)
+		o(div.dom.attributes["id"].value).equals("b")
+	})
+
 	o("handles ontransitionend", function() {
 		var spy = o.spy()
 		var div = {tag: "div", attrs: {ontransitionend: spy}}
@@ -103,6 +143,26 @@ o.spec("event", function() {
 
 		o(spy.callCount).equals(1)
 		o(spy.this).equals(div.dom)
+		o(spy.args[0].type).equals("transitionend")
+		o(spy.args[0].target).equals(div.dom)
+		o(onevent.callCount).equals(1)
+		o(onevent.this).equals(div.dom)
+		o(onevent.args[0].type).equals("transitionend")
+		o(onevent.args[0].target).equals(div.dom)
+	})
+
+	o("handles transitionend EventListener object", function() {
+		var spy = o.spy()
+		var listener = {handleEvent: spy}
+		var div = {tag: "div", attrs: {ontransitionend: listener}}
+		var e = $window.document.createEvent("HTMLEvents")
+		e.initEvent("transitionend", true, true)
+
+		render(root, [div])
+		div.dom.dispatchEvent(e)
+
+		o(spy.callCount).equals(1)
+		o(spy.this).equals(listener)
 		o(spy.args[0].type).equals("transitionend")
 		o(spy.args[0].target).equals(div.dom)
 		o(onevent.callCount).equals(1)

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -278,7 +278,11 @@ module.exports = function(options) {
 						e.target = this
 						if (events[e.type] != null) {
 							for (var i = 0; i < events[e.type].length; i++) {
-								events[e.type][i].call(this, e)
+								if (typeof events[e.type][i] === "function") {
+									events[e.type][i].call(this, e)
+								} else {
+									events[e.type][i].handleEvent(e)
+								}
 							}
 						}
 						e.preventDefault = function() {


### PR DESCRIPTION
Add support for event listener objects (objects that have a handleEvent function property.)

NOTE that this is a WIP, which probably shouldn't be merged until https://github.com/MithrilJS/mithril.js/pull/1865 is completed.

## Description
The render module will now check for objects in addition to functions to use for element event callbacks.

## Motivation and Context
See: https://github.com/MithrilJS/mithril.js/issues/1939

## How Has This Been Tested?
Tests included.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
