### PR TITLE
Redraw callback & immediate invoke from lifecycle methods

### DIFF
--- a/api/redraw.js
+++ b/api/redraw.js
@@ -39,21 +39,21 @@ module.exports = function($window, throttleMock) {
 		var index = callbacks.indexOf(key)
 		if (index > -1) callbacks.splice(index, 2)
 	}
-	function sync() {
+	function processCallbacks() {
 		// [0] Required by: test-redraw > the callback passed to redraw() is called when all roots have been redrawn
 		rendering++ // [0]
 		for (var i = 1; i < callbacks.length; i+=2) try {callbacks[i]()} catch (e) {/*noop*/}
 		processAfterRenderCallbacks() // [0]
 		rendering-- // [0]
 	}
-	var throttledSync = (throttleMock || throttle)(sync)
+	var throttledProcessCallbacks = (throttleMock || throttle)(processCallbacks)
 	function redraw(afterRenderCallback, log) {
 		if (rendering) {
-			afterRenderCallbacks.push(sync)
+			afterRenderCallbacks.push(processCallbacks)
 			if (afterRenderCallback) afterRenderCallbacks.push(afterRenderCallback)
 		} else {
 			if (afterRenderCallback) afterRenderCallbacks.push(afterRenderCallback)
-			throttledSync(log)
+			throttledProcessCallbacks(log)
 		}
 	}
 	function render() {
@@ -68,6 +68,5 @@ module.exports = function($window, throttleMock) {
 		}
 	}
 
-	redraw.sync = sync
 	return {subscribe: subscribe, unsubscribe: unsubscribe, redraw: redraw, render: render}
 }

--- a/api/redraw.js
+++ b/api/redraw.js
@@ -39,21 +39,21 @@ module.exports = function($window, throttleMock) {
 		var index = callbacks.indexOf(key)
 		if (index > -1) callbacks.splice(index, 2)
 	}
-	function processCallbacks() {
+	function sync() {
 		// [0] Required by: test-redraw > the callback passed to redraw() is called when all roots have been redrawn
 		rendering++ // [0]
 		for (var i = 1; i < callbacks.length; i+=2) try {callbacks[i]()} catch (e) {/*noop*/}
 		processAfterRenderCallbacks() // [0]
 		rendering-- // [0]
 	}
-	var throttledProcessCallbacks = (throttleMock || throttle)(processCallbacks)
-	function redraw(afterRenderCallback, log) {
+	var throttledSync = (throttleMock || throttle)(sync)
+	var redraw = function(afterRenderCallback) {
 		if (rendering) {
-			afterRenderCallbacks.push(processCallbacks)
+			afterRenderCallbacks.push(sync)
 			if (afterRenderCallback) afterRenderCallbacks.push(afterRenderCallback)
 		} else {
 			if (afterRenderCallback) afterRenderCallbacks.push(afterRenderCallback)
-			throttledProcessCallbacks(log)
+			throttledSync()
 		}
 	}
 	function render() {
@@ -68,5 +68,6 @@ module.exports = function($window, throttleMock) {
 		}
 	}
 
+	redraw.sync = sync
 	return {subscribe: subscribe, unsubscribe: unsubscribe, redraw: redraw, render: render}
 }

--- a/api/tests/test-redraw.js
+++ b/api/tests/test-redraw.js
@@ -139,35 +139,6 @@ o.spec("redrawService", function() {
 			done()
 		}, 20)
 	})
-
-	o("redraw.sync() redraws all roots synchronously", function() {
-		var el1 = $document.createElement("div")
-		var el2 = $document.createElement("div")
-		var el3 = $document.createElement("div")
-		var spy1 = o.spy()
-		var spy2 = o.spy()
-		var spy3 = o.spy()
-
-		redrawService.subscribe(el1, spy1)
-		redrawService.subscribe(el2, spy2)
-		redrawService.subscribe(el3, spy3)
-
-		o(spy1.callCount).equals(0)
-		o(spy2.callCount).equals(0)
-		o(spy3.callCount).equals(0)
-
-		redrawService.redraw.sync()
-
-		o(spy1.callCount).equals(1)
-		o(spy2.callCount).equals(1)
-		o(spy3.callCount).equals(1)
-
-		redrawService.redraw.sync()
-
-		o(spy1.callCount).equals(2)
-		o(spy2.callCount).equals(2)
-		o(spy3.callCount).equals(2)
-	})
 	
 	o("the callback passed to redraw() is called when all roots have been redrawn", function(done) {
 		var el1 = $document.createElement("div")

--- a/api/tests/test-redraw.js
+++ b/api/tests/test-redraw.js
@@ -139,6 +139,35 @@ o.spec("redrawService", function() {
 			done()
 		}, 20)
 	})
+
+	o("redraw.sync() redraws all roots synchronously", function() {
+		var el1 = $document.createElement("div")
+		var el2 = $document.createElement("div")
+		var el3 = $document.createElement("div")
+		var spy1 = o.spy()
+		var spy2 = o.spy()
+		var spy3 = o.spy()
+
+		redrawService.subscribe(el1, spy1)
+		redrawService.subscribe(el2, spy2)
+		redrawService.subscribe(el3, spy3)
+
+		o(spy1.callCount).equals(0)
+		o(spy2.callCount).equals(0)
+		o(spy3.callCount).equals(0)
+
+		redrawService.redraw.sync()
+
+		o(spy1.callCount).equals(1)
+		o(spy2.callCount).equals(1)
+		o(spy3.callCount).equals(1)
+
+		redrawService.redraw.sync()
+
+		o(spy1.callCount).equals(2)
+		o(spy2.callCount).equals(2)
+		o(spy3.callCount).equals(2)
+	})
 	
 	o("the callback passed to redraw() is called when all roots have been redrawn", function(done) {
 		var el1 = $document.createElement("div")

--- a/api/tests/test-redraw.js
+++ b/api/tests/test-redraw.js
@@ -168,4 +168,35 @@ o.spec("redrawService", function() {
 		o(spy2.callCount).equals(2)
 		o(spy3.callCount).equals(2)
 	})
+	
+	o("the callback passed to redraw() is called when all roots have been redrawn", function(done) {
+		var el1 = $document.createElement("div")
+		var el2 = $document.createElement("div")
+		var el3 = $document.createElement("div")
+		var spy1 = o.spy()
+		var spy2 = o.spy()
+		var spy3 = o.spy()
+	
+		redrawService.subscribe(el1, spy1)
+		redrawService.subscribe(el2, spy2)
+		redrawService.subscribe(el3, spy3)
+	
+		o(spy1.callCount).equals(0)
+		o(spy2.callCount).equals(0)
+		o(spy3.callCount).equals(0)
+	
+		redrawService.redraw(function() {
+			o(spy1.callCount).equals(1)
+			o(spy2.callCount).equals(1)
+			o(spy3.callCount).equals(1)
+			
+			redrawService.redraw(function() {
+				o(spy1.callCount).equals(2)
+				o(spy2.callCount).equals(2)
+				o(spy3.callCount).equals(2)
+				
+				done()
+			})
+		})
+	})
 })

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -16,6 +16,7 @@
 
 #### Breaking changes
 
+- API: `m.redraw()` callback & immediate invoke from lifecycle methods ([#1946](https://github.com/MithrilJS/mithril.js/pull/1946))
 - API: `m.redraw()` is always asynchronous ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: `m.mount()` will only render its own root when called, it will not trigger a `redraw()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 

--- a/docs/redraw.md
+++ b/docs/redraw.md
@@ -22,9 +22,10 @@ You DO need to call it in `setTimeout`/`setInterval`/`requestAnimationFrame` cal
 
 `m.redraw()`
 
-Argument    | Type                 | Required | Description
------------ | -------------------- | -------- | ---
-**returns** |                      |          | Returns nothing
+Argument              | Type                 | Required | Description
+--------------------- | -------------------- | -------- | ---
+`afterRenderCallback` | `Function`           | No       | A function to be called after redraw finishes
+**returns**           |                      |          | Returns nothing
 
 #### Static members
 
@@ -44,7 +45,7 @@ When callbacks outside of Mithril run, you need to notify Mithril's rendering en
 
 To trigger a redraw, call `m.redraw()`. Note that `m.redraw` only works if you used `m.mount` or `m.route`. If you rendered via `m.render`, you should use `m.render` to redraw.
 
-`m.redraw()` always triggers an asynchronous redraws, whereas `m.redraw.sync()` triggers a synchronous one. `m.redraw()` is tied to `window.requestAnimationFrame()` (we provide a fallback for IE9). It will thus typically fire at most 60 times per second. It may fire faster if your monitor has a higher refresh rate.
+`m.redraw()` always triggers an asynchronous redraw, whereas `m.redraw.sync()` triggers a synchronous one. If you need to complete some action right after the redraw, you can pass a callback function to `m.redraw()`. `m.redraw()` is tied to `window.requestAnimationFrame()` (we provide a fallback for IE9). It will thus typically fire at most 60 times per second. It may fire faster if your monitor has a higher refresh rate. It will also fire immediately after the previous redraw when called from inside a lifecycle method.
 
 `m.redraw.sync()` is mostly intended to make videos play work in iOS. That only works in response to user-triggered events. It comes with several caveat:
 


### PR DESCRIPTION
## Description
I propose reworking `redraw` so that a call to it from a lifecycle method will result in an immediate redraw after the current redraw cycle finishes (no nesting). I also propose adding an optional callback to `redraw` that is called after the next redraw cycle is complete.

## Motivation and Context
Routing, measuring sizes and some other operations require a `redraw` call from lifecycle events. `redraw.sync` is not callable from lifecycle events. This change allows redraw cycles to happen immediately after each other, so flash of intermediate state can be avoided.

## How Has This Been Tested?

Added unit tests.
Tested in a 20000 LOC internal project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
