### PR TITLE
Make the benchmark a little more precise

### DIFF
--- a/performance/test-perf.js
+++ b/performance/test-perf.js
@@ -70,7 +70,7 @@ suite.on("complete", function() {
 suite.on("error", console.error.bind(console))
 
 suite.add({
-	name : "rerender without changes",
+	name : "rerender identical vnode",
 	onStart : function() {
 		this.vdom = m("div", {class: "foo bar", "data-foo": "bar", p: 2},
 			m("header",
@@ -116,6 +116,53 @@ suite.add({
 	},
 	fn : function() {
 		m.render(scratch, this.vdom)
+	}
+})
+
+suite.add({
+	name : "rerender same tree",
+	fn : function() {
+		m.render(scratch, m("div", {class: "foo bar", "data-foo": "bar", p: 2},
+			m("header",
+				m("h1", {class: "asdf"}, "a ", "b", " c ", 0, " d"),
+				m("nav",
+					m("a", {href: "/foo"}, "Foo"),
+					m("a", {href: "/bar"}, "Bar")
+				)
+			),
+			m("main",
+				m("form", {onSubmit: function onSubmit() {}},
+					m("input", {type: "checkbox", checked: true}),
+					m("input", {type: "checkbox", checked: false}),
+					m("fieldset",
+						m("label",
+							m("input", {type: "radio", checked: true})
+						),
+						m("label",
+							m("input", {type: "radio"})
+						)
+					),
+					m("button-bar",
+						m("button",
+							{style: "width:10px; height:10px; border:1px solid #FFF;"},
+							"Normal CSS"
+						),
+						m("button",
+							{style: "top:0 ; right: 20"},
+							"Poor CSS"
+						),
+						m("button",
+							{style: "invalid-prop:1;padding:1px;font:12px/1.1 arial,sans-serif;", icon: true},
+							"Poorer CSS"
+						),
+						m("button",
+							{style: {margin: 0, padding: "10px", overflow: "visible"}},
+							"Object CSS"
+						)
+					)
+				)
+			)
+		))
 	}
 })
 


### PR DESCRIPTION
We special-case identical vnode trees, so it's better that we test both
identical and rebuilt trees when benchmarking rendering.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internally, we skip rendering when we re-render identical vnode trees, and we also recommend that people *not* cache vnode trees for obvious reasons.

For similar reasons, I added a new benchmark to test the (exceedingly common) case of completely static, newly rebuilt trees. The copied test features a single event handler, attributes, and some `style` modifications, so it also lends itself well to benchmarking other aspects of the diffing algorithm.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-ran the benchmarks right after the change, as you might expect.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
