### PR TITLE
Use util.inspect to log in node - fixes #1661

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -44,6 +44,9 @@
 - hypertext: correct handling of shared attributes object passed to `m()`. Will copy attributes when it's necessary [#1941](https://github.com/MithrilJS/mithril.js/issues/1941) [s-ilya](https://github.com/s-ilya) ([#1942](https://github.com/MithrilJS/mithril.js/pull/1942))
 - Fix IE bug where active element is null causing render function to throw error. ([1943](https://github.com/MithrilJS/mithril.js/pull/1943))
 
+#### Ospec improvements:
+
+- Log using util.inspect to show object content instead of "[object Object]" ([#1661](https://github.com/MithrilJS/mithril.js/issues/1661), [@porsager](https://github.com/porsager))
 ---
 
 ### v1.1.3

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -222,6 +222,7 @@ module.exports = new function init(name) {
 		results.push(result)
 	}
 	function serialize(value) {
+		if (hasProcess) return require("util").inspect(value)
 		if (value === null || (typeof value === "object" && !(value instanceof Array)) || typeof value === "number") return String(value)
 		else if (typeof value === "function") return value.name || "<anonymous function>"
 		try {return JSON.stringify(value)} catch (e) {return String(value)}


### PR DESCRIPTION
## Description
Use util.inspect if available to do better logging of objects

## Motivation and Context
Mainly deepEquals on objects just prints [object Object] instead of the contents, making it hard to see the possible error.

## How Has This Been Tested?
Tested by visually inspecting the output which looked correct.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
