### PR TITLE
Scan with halt

### DIFF
--- a/docs/stream.md
+++ b/docs/stream.md
@@ -120,11 +120,13 @@ Argument     | Type                 | Required | Description
 
 Creates a new stream with the results of calling the function on every value in the stream with an accumulator and the incoming value.
 
+Note that you can prevent dependent streams from being updated by returning the special value `stream.HALT` inside the accumulator function.
+
 `stream = Stream.scan(fn, accumulator, stream)`
 
 Argument      | Type                             | Required | Description
 ------------- | -------------------------------- | -------- | ---
-`fn`          | `(accumulator, value) -> result` | Yes      | A function that takes an accumulator and value parameter and returns a new accumulator value
+`fn`          | `(accumulator, value) -> result \| HALT` | Yes      | A function that takes an accumulator and value parameter and returns a new accumulator value
 `accumulator` | `any`                            | Yes      | The starting value for the accumulator
 `stream`      | `Stream`                         | Yes      | Stream containing the values
 **returns**   | `Stream`                         |          | Returns a new stream containing the result

--- a/stream/stream.js
+++ b/stream/stream.js
@@ -117,7 +117,9 @@ function merge(streams) {
 
 function scan(reducer, seed, stream) {
 	var newStream = combine(function (s) {
-		return seed = reducer(seed, s._state.value)
+		var next = reducer(seed, s._state.value)
+		if (next !== HALT) return seed = next
+		return HALT
 	}, [stream])
 
 	if (newStream._state.state === 0) newStream(seed)

--- a/stream/tests/test-scan.js
+++ b/stream/tests/test-scan.js
@@ -30,4 +30,36 @@ o.spec("scan", function() {
 		o(result[2]).equals(undefined)
 		o(result[3]).deepEquals({a: 1})
 	})
+
+	o("reducer can return HALT to prevent child updates", function() {
+		var count = 0
+		var action = stream()
+		var store = stream.scan(function (arr, value) {
+			switch (typeof value) {
+				case "number":
+					return arr.concat(value)
+				default:
+					return stream.HALT
+			}
+		}, [], action)
+		var child = store.map(function (p) {
+			count++
+			return p
+		})
+		var result
+
+		action(7)
+		action("11")
+		action(undefined)
+		action({a: 1})
+
+		result = child()
+
+		// check we got the expect result
+		o(result[0]).equals(7)
+
+		// check child received minimum # of updates
+		o(count).equals(2)
+	})
+
 })


### PR DESCRIPTION
Description
------------

If the reducer function doesn't change the value, then don't call the dependant streams.

Motivation and Context
-----------------------

Example use case:

```javascript
var dispatch = Stream()
var store = Stream.scan(update, init(), dispatch)

function update(store, {type, value}) {
	switch (type) {
		case UNDO:
			return undo(store) // if nothing to undo, then return `store` (= HALT).
		case REDO:
			return redo(store)
		case INSERT:
			return insert(store, value)
		case FLUSH:
			return init() // creates an empty undo history
		default:
			return store // shouldn't trigger update
	}
}
```

Equally, if `scan` accepted the `HALT` value, then I could get the desired effect with a higher-order reducer:

```javascript
function wrapReducer(reducer) {
	return function (state, action) {
		var next = reducer(state)
		if (next === state) return Stream.HALT
		return next
	}
}

Stream.scan(wrapReducer(update), {}, dispatch)
```

Types of changes
------------------

- [x] New feature (non-breaking change which adds functionality)

Checklist
----------

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (awaiting feedback)
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated docs/change-log.md (awaiting feedback)

<hr />

Does this seem like reasonable expectation for `scan`? Feedback greatly appreciated.

Test case provided, and style guide followed :)