### PR TITLE
Added 'shouldRedraw' option to withAttr

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -34,6 +34,10 @@
 - API: If a user sets the Content-Type header within a request's options, that value will be the entire header value rather than being appended to the default value ([#1924](https://github.com/MithrilJS/mithril.js/pull/1924))
 - API: Using style objects in hyperscript calls will now properly diff style properties from one render to another as opposed to re-writing all element style properties every render.
 
+#### Other
+
+- API: `m.withAttr` now has a 4th parameter that suppresses autoredraw when the callback is fired.
+
 ---
 
 ### v1.1.4

--- a/docs/withAttr.md
+++ b/docs/withAttr.md
@@ -36,12 +36,13 @@ m.mount(document.body, Component)
 
 `m.withAttr(attrName, callback, thisArg?)`
 
-Argument    | Type                 | Required | Description
------------ | -------------------- | -------- | ---
-`attrName`  | `String`             | Yes      | The name of the attribute or property whose value will be used
-`callback`  | `any -> undefined`   | Yes      | The callback
-`thisArg`   | `any`                | No       | An object to bind to the `this` keyword in the callback function
-**returns** | `Event -> undefined` |          | An event handler function
+Argument      | Type                 | Required | Description
+------------- | -------------------- | -------- | ---
+`attrName`    | `String`             | Yes      | The name of the attribute or property whose value will be used
+`callback`    | `any -> undefined`   | Yes      | The callback
+`thisArg`     | `any`                | No       | An object to bind to the `this` keyword in the callback function
+`shouldRedraw`| `Boolean`            | No       | Whether an autoredraw should be triggered by the callback function. Defaults to `true`
+**returns**   | `Event -> undefined` |          | An event handler function
 
 [How to read signatures](signatures.md)
 

--- a/util/withAttr.js
+++ b/util/withAttr.js
@@ -1,7 +1,9 @@
 "use strict"
 
-module.exports = function(attrName, callback, context) {
+module.exports = function(attrName, callback, context, shouldRedraw) {
+	if(shouldRedraw === undefined) shouldRedraw = true;
 	return function(e) {
+		e.redraw = shouldRedraw;
 		callback.call(context || this, attrName in e.currentTarget ? e.currentTarget[attrName] : e.currentTarget.getAttribute(attrName))
 	}
 }


### PR DESCRIPTION
## Description
Adds a fourth parameter `shouldRedraw` to `m.withAttr`. It defaults to `true`. When `false`, the callback fired by `m.withAttr` will not cause an autoredraw.

## Motivation and Context
There are many situations in which an event should not trigger a redraw. For instance, consider a situation in which I have a table of records and a "Filter by..." `<input>`. With the current implementation of `m.withAttr`, when a user types anything into the `input` field the filtering mechanism will be triggered instantly. If there are many records on the page, this may degrade performance. It would be more desirous for the user to type their filter into the `input` field and then click a "Submit" button to trigger the redraw.

## How Has This Been Tested?
This is a non-breaking change. I tested it in the context of[ a data fetching/displaying/filtering/sorting applet](https://github.com/RobertAKARobin/hubspot_revenue_too) I am creating.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. // Except for the tests that already fail in the `next` branch
- [x] I have updated `docs/change-log.md`
