### PR TITLE
Add support for `timeout` to `m.request`

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -27,6 +27,7 @@
 - API: Introduction of `m.redraw.sync()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Event handlers may also be objects with `handleEvent` methods ([#1939](https://github.com/MithrilJS/mithril.js/issues/1939)).
 - API: `m.route.link` accepts an optional `options` object ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
+- API: `m.request` supports `timeout` as attr - ([#1966](https://github.com/MithrilJS/mithril.js/pull/1966))
 
 #### Ospec improvements:
 

--- a/docs/request.md
+++ b/docs/request.md
@@ -49,6 +49,7 @@ Argument                  | Type                              | Required | Descr
 `options.user`            | `String`                          | No       | A username for HTTP authorization. Defaults to `undefined`.
 `options.password`        | `String`                          | No       | A password for HTTP authorization. Defaults to `undefined`. This option is provided for `XMLHttpRequest` compatibility, but you should avoid using it because it sends the password in plain text over the network.
 `options.withCredentials` | `Boolean`                         | No       | Whether to send cookies to 3rd party domains. Defaults to `false`
+`options.timeout`         | `Number`                          | No       | The amount of milliseconds a request can take before automatically being [terminated](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout).  Defaults to `undefined`.
 `options.config`          | `xhr = Function(xhr)`             | No       | Exposes the underlying XMLHttpRequest object for low-level configuration. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).
 `options.headers`         | `Object`                          | No       | Headers to append to the request before sending it (applied right before `options.config`).
 `options.type`            | `any = Function(any)`             | No       | A constructor to be applied to each object in the response. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).

--- a/request/request.js
+++ b/request/request.js
@@ -75,6 +75,8 @@ module.exports = function($window, Promise) {
 			}
 			if (args.withCredentials) xhr.withCredentials = args.withCredentials
 
+			if (args.timeout) xhr.timeout = args.timeout
+
 			for (var key in args.headers) if ({}.hasOwnProperty.call(args.headers, key)) {
 				xhr.setRequestHeader(key, args.headers[key])
 			}

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -435,6 +435,20 @@ o.spec("xhr", function() {
 				done()
 			})
 		})
+		o("set timeout to xhr instance", function() {
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return {status: 200, responseText: ''}
+				}
+			})
+			return xhr({
+				method: "GET", url: "/item",
+				timeout: 42,
+				config: function(xhr) {
+					o(xhr.timeout).equals(42)
+				}
+			})
+		})
 		/*o("data maintains after interpolate", function() {
 			mock.$defineRoutes({
 				"PUT /items/:x": function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for `timeout` to `m.request`.

## Motivation and Context

I think it's obvious that `timeout` is a thing you want to set to an xhr.

## How Has This Been Tested?

Added a test that verifies xhr setting

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
