### PR TITLE
Allow `xlink:href` to get removed, fix `option.value` in mock

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -38,6 +38,7 @@
 - core: Event listeners allocate less memory, swap at low cost, and are properly diffed now when rendered via `m.mount()`/`m.redraw()`.
 - core: `Object.prototype` properties can no longer interfere with event listener calls.
 - API: Event handlers, when set to literally `undefined` (or any non-function), are now correctly removed.
+- core: `xlink:href` attributes are now correctly removed
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -476,7 +476,7 @@ module.exports = function($window) {
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if ((old === value && !isFormAttribute(vnode, key)) && typeof value !== "object" || value === undefined) return
 		var element = vnode.dom
-		if (key.slice(0, 6) === "xlink:") element.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
+		if (key.slice(0, 6) === "xlink:") element.setAttributeNS("http://www.w3.org/1999/xlink", key, value)
 		else if (key === "style") updateStyle(element, old, value)
 		else if (key in element && !isAttribute(key) && ns === undefined && !isCustomElement(vnode)) {
 			if (key === "value") {

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -376,15 +376,15 @@ o.spec("attributes", function() {
 
 			o(a.dom.value).equals("1")
 		})
-		o("null becomes the empty string", function() {
+		o("null becomes 'null'", function() {
 			var a = {tag: "option", attrs: {value: null}}
 			var b = {tag: "option", attrs: {value: "test"}}
 			var c = {tag: "option", attrs: {value: null}}
 
 			render(root, [a]);
 
-			o(a.dom.value).equals("")
-			o(a.dom.getAttribute("value")).equals("")
+			o(a.dom.value).equals("null")
+			o(a.dom.getAttribute("value")).equals("null")
 
 			render(root, [b]);
 
@@ -393,8 +393,8 @@ o.spec("attributes", function() {
 
 			render(root, [c]);
 
-			o(c.dom.value).equals("")
-			o(c.dom.getAttribute("value")).equals("")
+			o(c.dom.value).equals("null")
+			o(c.dom.getAttribute("value")).equals("null")
 		})
 		o("'' and 0 are different values", function() {
 			var a = {tag: "option", attrs: {value: 0}, children:[{tag:"#", children:""}]}

--- a/render/tests/test-createElement.js
+++ b/render/tests/test-createElement.js
@@ -65,8 +65,8 @@ o.spec("createElement", function() {
 		o(vnode.dom.namespaceURI).equals("http://www.w3.org/2000/svg")
 		o(vnode.dom.firstChild.nodeName).equals("a")
 		o(vnode.dom.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
-		o(vnode.dom.firstChild.attributes["href"].value).equals("javascript:;")
-		o(vnode.dom.firstChild.attributes["href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+		o(vnode.dom.firstChild.attributes["xlink:href"].value).equals("javascript:;")
+		o(vnode.dom.firstChild.attributes["xlink:href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
 		o(vnode.dom.childNodes[1].nodeName).equals("foreignObject")
 		o(vnode.dom.childNodes[1].firstChild.nodeName).equals("body")
 		o(vnode.dom.childNodes[1].firstChild.namespaceURI).equals("http://www.w3.org/1999/xhtml")
@@ -76,6 +76,24 @@ o.spec("createElement", function() {
 		render(root, [vnode])
 
 		o(vnode.dom.attributes["viewBox"].value).equals("0 0 100 100")
+	})
+	o("removes xlink:href", function() {
+		var vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
+			{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {"xlink:href": "javascript:;"}}
+		]}
+		render(root, [vnode])
+
+		o(vnode.dom.nodeName).equals("svg")
+		o(vnode.dom.firstChild.attributes["xlink:href"].value).equals("javascript:;")
+		o(vnode.dom.firstChild.attributes["xlink:href"].namespaceURI).equals("http://www.w3.org/1999/xlink")
+
+		vnode = {tag: "svg", ns: "http://www.w3.org/2000/svg", children: [
+			{tag: "a", ns: "http://www.w3.org/2000/svg", attrs: {}}
+		]}
+		render(root, [vnode])
+
+		o(vnode.dom.nodeName).equals("svg")
+		o(vnode.dom.firstChild.attributes["xlink:href"]).equals(undefined)
 	})
 	o("creates mathml", function() {
 		var vnode = {tag: "math", ns: "http://www.w3.org/1998/Math/MathML", children: [{tag: "mrow", ns: "http://www.w3.org/1998/Math/MathML"}]}

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -445,7 +445,7 @@ module.exports = function(options) {
 				if (element.nodeName === "OPTION") {
 					var valueSetter = spy(function(value) {
 						/*eslint-disable no-implicit-coercion*/
-						this.setAttribute("value", value === null ? "" : "" + value)
+						this.setAttribute("value", "" + value)
 						/*eslint-enable no-implicit-coercion*/
 					})
 					Object.defineProperty(element, "value", {

--- a/test-utils/tests/test-domMock.js
+++ b/test-utils/tests/test-domMock.js
@@ -954,11 +954,11 @@ o.spec("domMock", function() {
 					o(select.selectedIndex).equals(1)
 				}
 			})
-			o("option.value = null is converted to the empty string", function() {
+			o("option.value = null is converted to 'null'", function() {
 				var option = $document.createElement("option")
 				option.value = null
 
-				o(option.value).equals("")
+				o(option.value).equals("null")
 			})
 			o("setting valid value works with optgroup", function() {
 				var select = $document.createElement("select")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just noticed while playing around with some optimization that `xlink:*` attributes were being mishandled, but I also noticed that `option.value` was incorrect in the mock, so I fixed it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added some new tests and ran them all as usual.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
