### PR TITLE
Handle newlines in error messages, fixes #1495

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -29,6 +29,7 @@
 
 - Added support for async functions and promises in tests - ([#1928](https://github.com/MithrilJS/mithril.js/pull/1928))
 - Error handling for async tests with `done` callbacks supports error as first argument
+- Error messages which include newline characters do not swallow the stack trace ([#1495](https://github.com/MithrilJS/mithril.js/issues/1495))
 
 #### Bug fixes
 

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -49,6 +49,9 @@ module.exports = new function init(name) {
 		spy.callCount = 0
 		return spy
 	}
+	o.cleanStackTrace = function(stack) {
+		return stack.match(/^(?:(?!Error|[\/\\]ospec[\/\\]ospec\.js).)*$/gm).pop()
+	}
 	o.run = function() {
 		results = []
 		start = new Date
@@ -235,7 +238,7 @@ module.exports = new function init(name) {
 		var status = 0
 		for (var i = 0, r; r = results[i]; i++) {
 			if (!r.pass) {
-				var stackTrace = r.error.match(/^(?:(?!Error|[\/\\]ospec[\/\\]ospec\.js).)*$/m)
+				var stackTrace = o.cleanStackTrace(r.error)
 				console.error(r.context + ":\n" + highlight(r.message) + (stackTrace ? "\n\n" + stackTrace + "\n\n" : ""), hasProcess ? "" : "color:red", hasProcess ? "" : "color:black")
 				status = 1
 			}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -149,6 +149,18 @@ o.spec("ospec", function() {
 		})
 	})
 
+	o.spec('stack trace cleaner', function() {
+		o('handles line breaks', function() {
+			try {
+				throw new Error('line\nbreak')
+			} catch(error) {
+				var trace = o.cleanStackTrace(error.stack)
+				o(trace).notEquals('break')
+				o(trace.includes("test-ospec.js")).equals(true)
+			}
+		})
+	})
+
 	o.spec("async promise", function() {
 		var a = 0, b = 0
 


### PR DESCRIPTION
## Description
Moves an inline `match` call into its own function (`o.fn` level), adds a failing test to that function, then fixes its behavior.

## Motivation and Context
Fixes #1495 

## How Has This Been Tested?
Created a new function, ran `node ospec/bin/ospec` on it

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [~] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
