### PR TITLE
Allow for changing focus in lifecycle hooks

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -40,6 +40,7 @@
 - core: `Object.prototype` properties can no longer interfere with event listener calls.
 - API: Event handlers, when set to literally `undefined` (or any non-function), are now correctly removed.
 - core: `xlink:href` attributes are now correctly removed
+- core: render() function can no longer prevent from changing `document.activeElement` in lifecycle hooks
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -664,9 +664,9 @@ module.exports = function($window) {
 		if (!Array.isArray(vnodes)) vnodes = [vnodes]
 		updateNodes(dom, dom.vnodes, Vnode.normalizeChildren(vnodes), false, hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
 		dom.vnodes = vnodes
-		for (var i = 0; i < hooks.length; i++) hooks[i]()
 		// document.activeElement can return null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
 		if (active != null && $doc.activeElement !== active) active.focus()
+		for (var i = 0; i < hooks.length; i++) hooks[i]()
 	}
 
 	return {render: render, setEventCallback: setEventCallback}

--- a/render/tests/test-input.js
+++ b/render/tests/test-input.js
@@ -30,6 +30,16 @@ o.spec("form inputs", function() {
 			o($window.document.activeElement).equals(input.dom)
 		})
 
+		o("maintains focus when changed manually in hook", function() {
+			var input = {tag: "input", attrs: {oncreate: function() {
+				input.dom.focus();
+			}}};
+
+			render(root, [input])
+
+			o($window.document.activeElement).equals(input.dom)
+		})
+
 		o("syncs input value if DOM value differs from vdom value", function() {
 			var input = {tag: "input", attrs: {value: "aaa", oninput: function() {}}}
 			var updated = {tag: "input", attrs: {value: "aaa", oninput: function() {}}}


### PR DESCRIPTION
Changing focus on element creation and update is currently no possible even if intended. The original activeElement is restored after rendering, because of some issues with rendering in IE according to the comments: https://github.com/MithrilJS/mithril.js/blob/next/render/render.js#L668-L669

## Motivation and Context
There is a valid use case for changing the behavior. Let's assume we have a modal (might come from 3rd party library) that sets the focus to inner input when shown. When closed it resets the focus to original active element.

```js
function openModal(node) {
     renderModal(node);
     previousActiveElement = document.activeElement;
     input.focus();
}

function closeModal() {
     previousActiveElement.focus();
}

const modal = () => 
 <Modal oncreate={({dom}) => openModal(dom)}>
   <Input id="input"/>
 </Modal>

render(root, modal()); // focus should be set to input inside modal
```
My change is not including `remove` callbacks. Focus can be set only in `init`, `create` and `update` hooks.  Fixing it would require much deeper changes. If you agree with the approach I could follow up on it and made another PR. If not, it would make sense at least to include a warning in documentation.

## How Has This Been Tested?
Unit test + application code.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
