### PR TITLE
Clarify source of 2nd render pass re: preloading data

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -588,7 +588,7 @@ m.route(document.body, "/secret", {
 
 #### Preloading data
 
-Typically, a component can load data upon initialization. Loading data this way renders the component twice (once upon routing, and once after the request completes).
+Typically, a component can load data upon initialization. Loading data this way renders the component twice. The first render pass occurs upon routing, and the second fires after the request completes. Take care to note that `loadUsers()` returns a Promise, but any Promise returned by `oninit` is currently ignored. The second render pass comes from the [`background` option for `m.request`](request.md).
 
 ```javascript
 var state = {


### PR DESCRIPTION
## Description, Motivation and Context
#2002 

While the docs do say that a second render pass for preloaded data comes
from request completion, the example code for preloading data suggests that
a promise chain returned from `oninit` has a role to play in controlling the
second render pass.

The docs should make explicit where the redraw is initiated so the reader
does not mistakingly believe that `oninit()` retuning a promise changes
anything.


## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
