### PR TITLE
Update eslint rules for ospec

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,9 +5,6 @@ module.exports = {
         "es6": true,
         "node": true
 	},
-	"parserOptions": {
-		"ecmaVersion": 2017,
-	},
     "extends": "eslint:recommended",
     "rules": {
         "accessor-pairs": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,10 @@ module.exports = {
         "commonjs": true,
         "es6": true,
         "node": true
-    },
+	},
+	"parserOptions": {
+		"ecmaVersion": 2017,
+	},
     "extends": "eslint:recommended",
     "rules": {
         "accessor-pairs": "error",

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-bitwise, no-process-exit */
+/* eslint-disable global-require, no-bitwise, no-process-exit */
 "use strict"
 
 module.exports = new function init(name) {

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -188,8 +188,8 @@ o.spec("ospec", function() {
 			})
 		})
 
-		o("promise functions", async function() {
-			await wrapPromise(function() {
+		o("promise functions", function() {
+			return wrapPromise(function() {
 				o(a).equals(b)
 				o(a).equals(1)("a and b should be initialized")
 			})


### PR DESCRIPTION
ospec needs global-require suppressed so it can use `require('util')`.

~~test-ospec needs `ecmaVersion: 2017` so it can use `async`/`await`.~~

Removed async/await from test-ospec; just return Promise instead.

## Description
Modified `ospec.js`, `test-ospec.js`

## Motivation and Context
Mithril's test script linting was failing.

## How Has This Been Tested?
`npm test` now succeeds without errors.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
