### PR TITLE
Don't reject m.request Promise if extract callback supplied

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -20,6 +20,7 @@
 - API: `m.redraw()` is always asynchronous ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: `m.mount()` will only render its own root when called, it will not trigger a `redraw()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Assigning to `vnode.state` (as in `vnode.state = ...`) is no longer supported. Instead, an error is thrown if `vnode.state` changes upon the invocation of a lifecycle hook.
+- API: `m.request` will no longer reject the Promise on server errors (eg. status >= 400) if the caller supplies an `extract` callback. This gives applications more control over handling server responses.
 
 #### News
 

--- a/docs/request.md
+++ b/docs/request.md
@@ -54,7 +54,7 @@ Argument                  | Type                              | Required | Descr
 `options.type`            | `any = Function(any)`             | No       | A constructor to be applied to each object in the response. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).
 `options.serialize`       | `string = Function(any)`          | No       | A serialization method to be applied to `data`. Defaults to `JSON.stringify`, or if `options.data` is an instance of [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData), defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function) (i.e. `function(value) {return value}`).
 `options.deserialize`     | `any = Function(string)`          | No       | A deserialization method to be applied to the `xhr.responseText`. Defaults to a small wrapper around `JSON.parse` that returns `null` for empty responses. If `extract` is defined, `deserialize` will be skipped.
-`options.extract`         | `any = Function(xhr, options)`    | No       | A hook to specify how the XMLHttpRequest response should be read. Useful for processing response data, reading headers and cookies. By default this is a function that returns `xhr.responseText`, which is in turn passed to `deserialize`. If a custom `extract` callback is provided, the `xhr` parameter is the XMLHttpRequest instance used for the request, and `options` is the object that was passed to the `m.request` call. Additionally, `deserialize` will be skipped and the value returned from the extract callback will not automatically be parsed as JSON.
+`options.extract`         | `any = Function(xhr, options)`    | No       | A hook to specify how the XMLHttpRequest response should be read. Useful for processing response data, reading headers and cookies. By default this is a function that returns `xhr.responseText`, which is in turn passed to `deserialize`. If a custom `extract` callback is provided, the `xhr` parameter is the XMLHttpRequest instance used for the request, and `options` is the object that was passed to the `m.request` call. Additionally, `deserialize` will be skipped and the value returned from the extract callback will be left as-is when the promise resolves. Furthermore, when an extract callback is provided, exceptions are *not* thrown when the server response status code indicates an error.
 `options.useBody`         | `Boolean`                         | No       | Force the use of the HTTP body section for `data` in `GET` requests when set to `true`, or the use of querystring for other HTTP methods when set to `false`. Defaults to `false` for `GET` requests and `true` for other methods.
 `options.background`      | `Boolean`                         | No       | If `false`, redraws mounted components upon completion of the request. If `true`, it does not. Defaults to `false`.
 **returns**               | `Promise`                         |          | A promise that resolves to the response data, after it has been piped through the `extract`, `deserialize` and `type` methods
@@ -80,6 +80,8 @@ m.request({
 A call to `m.request` returns a [promise](promise.md) and triggers a redraw upon completion of its promise chain.
 
 By default, `m.request` assumes the response is in JSON format and parses it into a Javascript object (or array).
+
+If the HTTP response status code indicates an error, the returned Promise will be rejected. Supplying an extract callback will prevent the promise rejection.
 
 ---
 
@@ -426,7 +428,7 @@ m.request({
 
 ### Retrieving response details
 
-By default Mithril attempts to parse a response as JSON and returns `xhr.responseText`. It may be useful to inspect a server response in more detail, this can be accomplished by passing a custom `options.extract` function:
+By default Mithril attempts to parse `xhr.responseText` as JSON and returns the parsed object. It may be useful to inspect a server response in more detail and process it manually. This can be accomplished by passing a custom `options.extract` function:
 
 ```javascript
 m.request({

--- a/request/request.js
+++ b/request/request.js
@@ -86,20 +86,25 @@ module.exports = function($window, Promise) {
 				if(aborted) return
 
 				if (xhr.readyState === 4) {
-					try {
-						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
-						if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || FILE_PROTOCOL_REGEX.test(args.url)) {
-							resolve(cast(args.type, response))
+					if (args.extract !== extract) {
+						var response = args.extract(xhr, args)
+						resolve(cast(args.type, response))
+					} else {
+						try {
+							var response = args.deserialize(args.extract(xhr, args))
+							if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || FILE_PROTOCOL_REGEX.test(args.url)) {
+								resolve(cast(args.type, response))
+							}
+							else {
+								var error = new Error(xhr.responseText)
+								error.code = xhr.status
+								error.response = response
+								reject(error)
+							}
 						}
-						else {
-							var error = new Error(xhr.responseText)
-							error.code = xhr.status
-							error.response = response
-							reject(error)
+						catch (e) {
+							reject(e)
 						}
-					}
-					catch (e) {
-						reject(e)
 					}
 				}
 			}

--- a/request/request.js
+++ b/request/request.js
@@ -86,25 +86,20 @@ module.exports = function($window, Promise) {
 				if(aborted) return
 
 				if (xhr.readyState === 4) {
-					if (args.extract !== extract) {
-						var response = args.extract(xhr, args)
-						resolve(cast(args.type, response))
-					} else {
-						try {
-							var response = args.deserialize(args.extract(xhr, args))
-							if ((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || FILE_PROTOCOL_REGEX.test(args.url)) {
-								resolve(cast(args.type, response))
-							}
-							else {
-								var error = new Error(xhr.responseText)
-								error.code = xhr.status
-								error.response = response
-								reject(error)
-							}
+					try {
+						var response = (args.extract !== extract) ? args.extract(xhr, args) : args.deserialize(args.extract(xhr, args))
+						if (args.extract !== extract || (xhr.status >= 200 && xhr.status < 300) || xhr.status === 304 || FILE_PROTOCOL_REGEX.test(args.url)) {
+							resolve(cast(args.type, response))
 						}
-						catch (e) {
-							reject(e)
+						else {
+							var error = new Error(xhr.responseText)
+							error.code = xhr.status
+							error.response = response
+							reject(error)
 						}
+					}
+					catch (e) {
+						reject(e)
 					}
 				}
 			}

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -519,5 +519,19 @@ o.spec("xhr", function() {
 				o(e instanceof Error).equals(true)
 			}).then(done)
 		})
+		o("does not reject on error when extract provided", function(done) {
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return {status: 500, responseText: JSON.stringify({message: "error"})}
+				}
+			})
+			xhr({
+				method: "GET", url: "/item",
+				extract: function(xhr) {return JSON.parse(xhr.responseText)}
+			}).then(function(data) {
+				o(data.message).equals("error")
+				done()
+			})
+		})
 	})
 })

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -519,7 +519,7 @@ o.spec("xhr", function() {
 				o(e instanceof Error).equals(true)
 			}).then(done)
 		})
-		o("does not reject on error when extract provided", function(done) {
+		o("does not reject on status error code when extract provided", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function() {
 					return {status: 500, responseText: JSON.stringify({message: "error"})}
@@ -530,6 +530,21 @@ o.spec("xhr", function() {
 				extract: function(xhr) {return JSON.parse(xhr.responseText)}
 			}).then(function(data) {
 				o(data.message).equals("error")
+				done()
+			})
+		})
+		o("rejects on error in extract", function(done) {
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return {status: 500, responseText: JSON.stringify({message: "error"})}
+				}
+			})
+			xhr({
+				method: "GET", url: "/item",
+				extract: function() {throw new Error("error")}
+			}).catch(function(e) {
+				o(e instanceof Error).equals(true)
+			}).then(function() {
 				done()
 			})
 		})

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -536,7 +536,7 @@ o.spec("xhr", function() {
 		o("rejects on error in extract", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function() {
-					return {status: 500, responseText: JSON.stringify({message: "error"})}
+					return {status: 200, responseText: JSON.stringify({a: 1})}
 				}
 			})
 			xhr({
@@ -544,6 +544,7 @@ o.spec("xhr", function() {
 				extract: function() {throw new Error("error")}
 			}).catch(function(e) {
 				o(e instanceof Error).equals(true)
+				o(e.message).equals("error")
 			}).then(function() {
 				done()
 			})


### PR DESCRIPTION
Changes to accommodate #2000.

## Description
`m.request` will no longer reject the Promise if the caller supplies an `extract` callback.

## Motivation and Context
See #2000 

## How Has This Been Tested?
Test added.

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
