### PR TITLE
fix: closure compiler requires HTTPS now

### DIFF
--- a/bundler/minify.js
+++ b/bundler/minify.js
@@ -1,6 +1,6 @@
 "use strict"
 
-var http = require("http")
+var http = require("https")
 var querystring = require("querystring")
 var fs = require("fs")
 
@@ -22,7 +22,6 @@ module.exports = function(input, output, options, done) {
 		var response = ""
 		var req = http.request({
 			method: "POST",
-			protocol: "http:",
 			hostname: "closure-compiler.appspot.com",
 			path: "/compile",
 			headers: {
@@ -33,8 +32,16 @@ module.exports = function(input, output, options, done) {
 			res.on("data", function(chunk) {
 				response += chunk.toString()
 			})
+
 			res.on("end", function() {
-				var results = JSON.parse(response)
+				try {
+					var results = JSON.parse(response)
+				} catch(e) {
+					console.error(response);
+
+					throw e;
+				}
+
 				if (results.errors) {
 					for (var i = 0; i < results.errors.length; i++) console.log(results.errors[i])
 				}


### PR DESCRIPTION
## Description
Closure compiler endpoint was returning a `302` since we were using HTTP and it now requires HTTPS. So now using the `https` module instead of the `http` module for communication.

## Motivation and Context
Fixes #2005 

## How Has This Been Tested?

`npm run minify`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
