### PR TITLE
feat(ospec): Allow custom reporters for CI reasons (#2019)

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -32,6 +32,7 @@
 #### Ospec improvements:
 
 - Added support for async functions and promises in tests - ([#1928](https://github.com/MithrilJS/mithril.js/pull/1928))
+- Added support for custom reporters ([#2009](https://github.com/MithrilJS/mithril.js/pull/2020))
 - Error handling for async tests with `done` callbacks supports error as first argument
 - Error messages which include newline characters do not swallow the stack trace ([#1495](https://github.com/MithrilJS/mithril.js/issues/1495))
 

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -2,7 +2,7 @@
 "use strict"
 
 module.exports = new function init(name) {
-	var spec = {}, subjects = [], results, only = null, ctx = spec, start, stack = 0, nextTickish, hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
+	var spec = {}, subjects = [], results, only = null, ctx = spec, start, stack = 0, nextTickish, hasProcess = typeof process === "object", reporter, hasOwn = ({}).hasOwnProperty
 
 	if (name != null) spec[name] = ctx = {}
 
@@ -52,9 +52,10 @@ module.exports = new function init(name) {
 	o.cleanStackTrace = function(stack) {
 		return stack.match(/^(?:(?!Error|[\/\\]ospec[\/\\]ospec\.js).)*$/gm).pop()
 	}
-	o.run = function() {
+	o.run = function(_reporter) {
 		results = []
 		start = new Date
+		reporter = _reporter
 		test(spec, [], [], report)
 
 		function test(spec, pre, post, finalize) {
@@ -236,6 +237,9 @@ module.exports = new function init(name) {
 
 	function report() {
 		var status = 0
+
+		if (typeof reporter === "function") return reporter(results)
+
 		for (var i = 0, r; r = results[i]; i++) {
 			if (!r.pass) {
 				var stackTrace = o.cleanStackTrace(r.error)

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -18,6 +18,40 @@ new function(o) {
 	o.run()
 }(o)
 
+new function(o) {
+	var clone = o.new()
+
+	clone.spec("clone", function() {
+		clone("fail", function() {
+			clone(true).equals(false)
+		})
+
+		clone("pass", function() {
+			clone(true).equals(true)
+		})
+	})
+
+	// Predicate test passing on clone results
+	o.spec("reporting", function() {
+		o("reports per instance", function(done, timeout) {
+			timeout(100) // Waiting on clone
+
+			clone.run(function(results) {
+				o(typeof results).equals("object")
+				o("length" in results).equals(true)
+				o(results.length).equals(2)("Two results")
+
+				o("error" in results[0] && "pass" in results[0]).equals(true)("error and pass keys present in failing result")
+				o(!("error" in results[1]) && "pass" in results[1]).equals(true)("only pass key present in passing result")
+				o(results[0].pass).equals(false)("Test meant to fail has failed")
+				o(results[1].pass).equals(true)("Test meant to pass has passed")
+
+				done()
+			})
+		})
+	})
+}(o)
+
 o.spec("ospec", function() {
 	o.spec("sync", function() {
 		var a = 0, b = 0, illegalAssertionThrows = false


### PR DESCRIPTION
Valiantly defy one bullet in the ospec goal of blocking test configuration by adding custom reporter support. :crown:

## Motivation and Context
See #2019

## Description
I added a `reporter` param to `o.run()` to allow custom processing of results, falling back to current behavior if one is not specified.

ospec absolutely should limit test space config, but not having this feature has severely limited my ability to pass results along to a CI system when running ospec in a browser or Node.js. This change in made with the intent to leverage the entire Mithril toolset for real-world systems.

## How Has This Been Tested?
I used `o.new()` to make a new `ospec` runner, and then used the clone's custom reporter to run assertions against the original `ospec` instance. So if the reporting did not work, `test-ospec.js` would fail.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
