### PR TITLE
[docs] Fix headings displaying over menu on mobile

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -57,7 +57,7 @@ h1 + ul strong + ul {border-left:3px solid #1e5799;}
 	.hamburger:hover {text-decoration:none;}
 	main section {margin:0;}
 	header section {margin:0 0 20px;position:static;width:auto;}
-	h1 + ul {background:#eee;border:1px solid #ccc;box-sizing:border-box;display:none;height:100%;margin:0;overflow:auto;padding:20px;position:fixed;right:0;top:0;width:100%;}
+	h1 + ul {background:#eee;border:1px solid #ccc;box-sizing:border-box;display:none;height:100%;margin:0;overflow:auto;padding:20px;position:fixed;right:0;top:0;width:100%;z-index:1}
 	h1 + ul + hr {display:block;}
 	.navigating h1 + ul {display:block;}
 	.navigating {overflow:hidden;}


### PR DESCRIPTION
Fix headings displaying over menu on mobile, applying a z-index:1 on the CSS rule of the menu element.

![immagine](https://user-images.githubusercontent.com/3874459/33212440-6f92f8d6-d123-11e7-8f0e-3c9f2d75f730.png)