### PR TITLE
docs: add warning message to pre-v1 pages

### DIFF
--- a/archive/v0.1.1/auto-redrawing.html
+++ b/archive/v0.1.1/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -130,7 +133,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/change-log.html
+++ b/archive/v0.1.1/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/comparison.html
+++ b/archive/v0.1.1/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/comparisons/angular.rendering.html
+++ b/archive/v0.1.1/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.1/comparisons/angular.safety.html
+++ b/archive/v0.1.1/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.1/compiling-templates.html
+++ b/archive/v0.1.1/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -102,7 +105,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/components.html
+++ b/archive/v0.1.1/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/getting-started.html
+++ b/archive/v0.1.1/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -438,7 +441,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/how-to-read-signatures.html
+++ b/archive/v0.1.1/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -145,7 +148,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/index.html
+++ b/archive/v0.1.1/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -91,8 +94,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -120,7 +123,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -160,10 +163,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -187,7 +190,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.1/installation.html
+++ b/archive/v0.1.1/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -77,7 +80,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/integration.html
+++ b/archive/v0.1.1/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.computation.html
+++ b/archive/v0.1.1/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.deferred.html
+++ b/archive/v0.1.1/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -128,7 +131,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.html
+++ b/archive/v0.1.1/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.module.html
+++ b/archive/v0.1.1/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.prop.html
+++ b/archive/v0.1.1/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.redraw.html
+++ b/archive/v0.1.1/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.render.html
+++ b/archive/v0.1.1/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.request.html
+++ b/archive/v0.1.1/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -253,7 +256,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -261,10 +264,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -273,10 +276,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -303,7 +306,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -338,7 +341,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.route.html
+++ b/archive/v0.1.1/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -213,7 +216,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.sync.html
+++ b/archive/v0.1.1/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -103,7 +106,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.trust.html
+++ b/archive/v0.1.1/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.withAttr.html
+++ b/archive/v0.1.1/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/mithril.xhr.html
+++ b/archive/v0.1.1/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -68,7 +71,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/practices.html
+++ b/archive/v0.1.1/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/refactoring.html
+++ b/archive/v0.1.1/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/roadmap.html
+++ b/archive/v0.1.1/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/routing.html
+++ b/archive/v0.1.1/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/style.css
+++ b/archive/v0.1.1/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.1/style.css
+++ b/archive/v0.1.1/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.1/tools.html
+++ b/archive/v0.1.1/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.1/web-services.html
+++ b/archive/v0.1.1/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -204,7 +207,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/auto-redrawing.html
+++ b/archive/v0.1.10/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/change-log.html
+++ b/archive/v0.1.10/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -199,7 +202,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/community.html
+++ b/archive/v0.1.10/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/comparison.html
+++ b/archive/v0.1.10/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/comparisons/angular.rendering.html
+++ b/archive/v0.1.10/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.10/comparisons/angular.safety.html
+++ b/archive/v0.1.10/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.10/compiling-templates.html
+++ b/archive/v0.1.10/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/components.html
+++ b/archive/v0.1.10/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/getting-started.html
+++ b/archive/v0.1.10/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/how-to-read-signatures.html
+++ b/archive/v0.1.10/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/index.html
+++ b/archive/v0.1.10/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -101,8 +104,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -130,7 +133,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -172,11 +175,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -200,7 +203,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.10/installation.html
+++ b/archive/v0.1.10/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/integration.html
+++ b/archive/v0.1.10/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.computation.html
+++ b/archive/v0.1.10/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -163,7 +166,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.deferred.html
+++ b/archive/v0.1.10/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.html
+++ b/archive/v0.1.10/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.module.html
+++ b/archive/v0.1.10/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.prop.html
+++ b/archive/v0.1.10/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.redraw.html
+++ b/archive/v0.1.10/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.render.html
+++ b/archive/v0.1.10/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.request.html
+++ b/archive/v0.1.10/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>any unwrapSuccess(any data)</strong> (optional)</p>
@@ -280,10 +283,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -292,10 +295,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -326,7 +329,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is <code>function(xhr, options) {return xhr.responseText}</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -361,7 +364,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.route.html
+++ b/archive/v0.1.10/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.sync.html
+++ b/archive/v0.1.10/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.trust.html
+++ b/archive/v0.1.10/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.withAttr.html
+++ b/archive/v0.1.10/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/mithril.xhr.html
+++ b/archive/v0.1.10/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/practices.html
+++ b/archive/v0.1.10/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/refactoring.html
+++ b/archive/v0.1.10/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/roadmap.html
+++ b/archive/v0.1.10/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/routing.html
+++ b/archive/v0.1.10/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/style.css
+++ b/archive/v0.1.10/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.10/style.css
+++ b/archive/v0.1.10/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.10/tools.html
+++ b/archive/v0.1.10/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.10/web-services.html
+++ b/archive/v0.1.10/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/auto-redrawing.html
+++ b/archive/v0.1.11/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/change-log.html
+++ b/archive/v0.1.11/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -212,7 +215,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/community.html
+++ b/archive/v0.1.11/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/comparison.html
+++ b/archive/v0.1.11/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/comparisons/angular.rendering.html
+++ b/archive/v0.1.11/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.11/comparisons/angular.safety.html
+++ b/archive/v0.1.11/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.11/compiling-templates.html
+++ b/archive/v0.1.11/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/components.html
+++ b/archive/v0.1.11/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/getting-started.html
+++ b/archive/v0.1.11/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/how-to-read-signatures.html
+++ b/archive/v0.1.11/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -147,7 +150,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/index.html
+++ b/archive/v0.1.11/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -101,8 +104,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -130,7 +133,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -172,11 +175,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -200,7 +203,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.11/installation.html
+++ b/archive/v0.1.11/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/integration.html
+++ b/archive/v0.1.11/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.computation.html
+++ b/archive/v0.1.11/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -164,7 +167,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.deferred.html
+++ b/archive/v0.1.11/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -156,7 +159,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.html
+++ b/archive/v0.1.11/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.module.html
+++ b/archive/v0.1.11/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -169,7 +172,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.prop.html
+++ b/archive/v0.1.11/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.redraw.html
+++ b/archive/v0.1.11/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -83,7 +86,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.render.html
+++ b/archive/v0.1.11/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.request.html
+++ b/archive/v0.1.11/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -283,7 +286,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -298,10 +301,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -310,10 +313,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -344,7 +347,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -379,7 +382,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.route.html
+++ b/archive/v0.1.11/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -236,7 +239,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.sync.html
+++ b/archive/v0.1.11/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -105,7 +108,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.trust.html
+++ b/archive/v0.1.11/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.withAttr.html
+++ b/archive/v0.1.11/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/mithril.xhr.html
+++ b/archive/v0.1.11/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -70,7 +73,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/practices.html
+++ b/archive/v0.1.11/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/refactoring.html
+++ b/archive/v0.1.11/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/roadmap.html
+++ b/archive/v0.1.11/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -97,7 +100,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/routing.html
+++ b/archive/v0.1.11/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/style.css
+++ b/archive/v0.1.11/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.11/style.css
+++ b/archive/v0.1.11/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.11/tools.html
+++ b/archive/v0.1.11/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.11/web-services.html
+++ b/archive/v0.1.11/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/auto-redrawing.html
+++ b/archive/v0.1.12/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/change-log.html
+++ b/archive/v0.1.12/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -224,7 +227,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/community.html
+++ b/archive/v0.1.12/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/comparison.html
+++ b/archive/v0.1.12/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/comparisons/angular.rendering.html
+++ b/archive/v0.1.12/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.12/comparisons/angular.safety.html
+++ b/archive/v0.1.12/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.12/compiling-templates.html
+++ b/archive/v0.1.12/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/components.html
+++ b/archive/v0.1.12/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/getting-started.html
+++ b/archive/v0.1.12/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/how-to-read-signatures.html
+++ b/archive/v0.1.12/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -147,7 +150,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/index.html
+++ b/archive/v0.1.12/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -101,8 +104,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -130,7 +133,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -172,11 +175,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -200,7 +203,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.12/installation.html
+++ b/archive/v0.1.12/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/integration.html
+++ b/archive/v0.1.12/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.computation.html
+++ b/archive/v0.1.12/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -175,7 +178,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.deferred.html
+++ b/archive/v0.1.12/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -193,7 +196,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.html
+++ b/archive/v0.1.12/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.module.html
+++ b/archive/v0.1.12/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -169,7 +172,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.prop.html
+++ b/archive/v0.1.12/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.redraw.html
+++ b/archive/v0.1.12/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -83,7 +86,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.render.html
+++ b/archive/v0.1.12/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.request.html
+++ b/archive/v0.1.12/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -283,7 +286,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -298,10 +301,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -310,10 +313,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -344,7 +347,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -379,7 +382,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.route.html
+++ b/archive/v0.1.12/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -147,7 +150,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -257,7 +260,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.sync.html
+++ b/archive/v0.1.12/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -105,7 +108,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.trust.html
+++ b/archive/v0.1.12/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.withAttr.html
+++ b/archive/v0.1.12/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/mithril.xhr.html
+++ b/archive/v0.1.12/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -70,7 +73,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/practices.html
+++ b/archive/v0.1.12/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/refactoring.html
+++ b/archive/v0.1.12/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/roadmap.html
+++ b/archive/v0.1.12/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -97,7 +100,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/routing.html
+++ b/archive/v0.1.12/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/style.css
+++ b/archive/v0.1.12/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.12/style.css
+++ b/archive/v0.1.12/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.12/tools.html
+++ b/archive/v0.1.12/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.12/web-services.html
+++ b/archive/v0.1.12/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/auto-redrawing.html
+++ b/archive/v0.1.13/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/benchmarks.html
+++ b/archive/v0.1.13/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/change-log.html
+++ b/archive/v0.1.13/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -233,7 +236,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/community.html
+++ b/archive/v0.1.13/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -68,7 +71,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/comparison.html
+++ b/archive/v0.1.13/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/comparisons/angular.rendering.html
+++ b/archive/v0.1.13/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.13/comparisons/angular.safety.html
+++ b/archive/v0.1.13/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.13/compiling-templates.html
+++ b/archive/v0.1.13/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/components.html
+++ b/archive/v0.1.13/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/getting-started.html
+++ b/archive/v0.1.13/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -450,7 +453,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/how-to-read-signatures.html
+++ b/archive/v0.1.13/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/index.html
+++ b/archive/v0.1.13/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -34,7 +37,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -185,11 +188,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -222,7 +225,7 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: Another MVC JS Framework &lt;&lt; there&#39;s always room for one more, especially when they&#39;re this small... <a href="http://t.co/gDp3kyUkxL">http://t.co/gDp3kyUkxL</a></p>&mdash; Graham Ashton (@grahamashton) <a href="https://twitter.com/grahamashton/statuses/446353031677100033">March 19, 2014</a></blockquote>
 						 
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 					<div class="col(4,12,12)">
 						<div class="callout">
@@ -236,7 +239,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.13/installation.html
+++ b/archive/v0.1.13/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/integration.html
+++ b/archive/v0.1.13/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.computation.html
+++ b/archive/v0.1.13/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -174,7 +177,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.deferred.html
+++ b/archive/v0.1.13/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -192,7 +195,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.html
+++ b/archive/v0.1.13/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -290,7 +293,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.module.html
+++ b/archive/v0.1.13/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -189,7 +192,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.prop.html
+++ b/archive/v0.1.13/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.redraw.html
+++ b/archive/v0.1.13/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.render.html
+++ b/archive/v0.1.13/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.request.html
+++ b/archive/v0.1.13/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -297,10 +300,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -309,10 +312,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -343,7 +346,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -378,7 +381,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.route.html
+++ b/archive/v0.1.13/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -278,7 +281,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.sync.html
+++ b/archive/v0.1.13/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.trust.html
+++ b/archive/v0.1.13/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.withAttr.html
+++ b/archive/v0.1.13/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/mithril.xhr.html
+++ b/archive/v0.1.13/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/practices.html
+++ b/archive/v0.1.13/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/refactoring.html
+++ b/archive/v0.1.13/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/roadmap.html
+++ b/archive/v0.1.13/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/routing.html
+++ b/archive/v0.1.13/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/style.css
+++ b/archive/v0.1.13/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.13/style.css
+++ b/archive/v0.1.13/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.13/tools.html
+++ b/archive/v0.1.13/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -94,7 +97,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.13/web-services.html
+++ b/archive/v0.1.13/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/auto-redrawing.html
+++ b/archive/v0.1.14/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/benchmarks.html
+++ b/archive/v0.1.14/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/change-log.html
+++ b/archive/v0.1.14/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -249,7 +252,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/community.html
+++ b/archive/v0.1.14/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -68,7 +71,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/comparison.html
+++ b/archive/v0.1.14/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/comparisons/angular.rendering.html
+++ b/archive/v0.1.14/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.14/comparisons/angular.safety.html
+++ b/archive/v0.1.14/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.14/compiling-templates.html
+++ b/archive/v0.1.14/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/components.html
+++ b/archive/v0.1.14/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/getting-started.html
+++ b/archive/v0.1.14/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -452,7 +455,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/how-to-read-signatures.html
+++ b/archive/v0.1.14/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/index.html
+++ b/archive/v0.1.14/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -34,7 +37,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -185,11 +188,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -246,14 +249,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.14/installation.html
+++ b/archive/v0.1.14/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/integration.html
+++ b/archive/v0.1.14/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.computation.html
+++ b/archive/v0.1.14/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -175,7 +178,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.deferred.html
+++ b/archive/v0.1.14/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -231,7 +234,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.html
+++ b/archive/v0.1.14/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -290,7 +293,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.module.html
+++ b/archive/v0.1.14/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -189,7 +192,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.prop.html
+++ b/archive/v0.1.14/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.redraw.html
+++ b/archive/v0.1.14/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.render.html
+++ b/archive/v0.1.14/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.request.html
+++ b/archive/v0.1.14/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -297,10 +300,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -309,10 +312,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -343,7 +346,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -378,7 +381,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.route.html
+++ b/archive/v0.1.14/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -177,7 +180,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -292,7 +295,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.sync.html
+++ b/archive/v0.1.14/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.trust.html
+++ b/archive/v0.1.14/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.withAttr.html
+++ b/archive/v0.1.14/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/mithril.xhr.html
+++ b/archive/v0.1.14/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/practices.html
+++ b/archive/v0.1.14/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/refactoring.html
+++ b/archive/v0.1.14/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/roadmap.html
+++ b/archive/v0.1.14/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/routing.html
+++ b/archive/v0.1.14/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/style.css
+++ b/archive/v0.1.14/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.14/style.css
+++ b/archive/v0.1.14/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.14/tools.html
+++ b/archive/v0.1.14/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -94,7 +97,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.14/web-services.html
+++ b/archive/v0.1.14/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/auto-redrawing.html
+++ b/archive/v0.1.15/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/benchmarks.html
+++ b/archive/v0.1.15/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/change-log.html
+++ b/archive/v0.1.15/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -257,7 +260,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/community.html
+++ b/archive/v0.1.15/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -68,7 +71,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/comparison.html
+++ b/archive/v0.1.15/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/comparisons/angular.rendering.html
+++ b/archive/v0.1.15/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.15/comparisons/angular.safety.html
+++ b/archive/v0.1.15/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.15/compiling-templates.html
+++ b/archive/v0.1.15/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/components.html
+++ b/archive/v0.1.15/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/getting-started.html
+++ b/archive/v0.1.15/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -451,7 +454,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/how-to-read-signatures.html
+++ b/archive/v0.1.15/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/index.html
+++ b/archive/v0.1.15/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -34,7 +37,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -185,11 +188,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -246,14 +249,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.15/installation.html
+++ b/archive/v0.1.15/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/integration.html
+++ b/archive/v0.1.15/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.computation.html
+++ b/archive/v0.1.15/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -175,7 +178,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.deferred.html
+++ b/archive/v0.1.15/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -231,7 +234,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.html
+++ b/archive/v0.1.15/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -290,7 +293,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.module.html
+++ b/archive/v0.1.15/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -189,7 +192,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.prop.html
+++ b/archive/v0.1.15/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.redraw.html
+++ b/archive/v0.1.15/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.render.html
+++ b/archive/v0.1.15/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.request.html
+++ b/archive/v0.1.15/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -297,10 +300,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -309,10 +312,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -343,7 +346,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -378,7 +381,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.route.html
+++ b/archive/v0.1.15/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -177,7 +180,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -292,7 +295,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.sync.html
+++ b/archive/v0.1.15/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.trust.html
+++ b/archive/v0.1.15/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.withAttr.html
+++ b/archive/v0.1.15/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/mithril.xhr.html
+++ b/archive/v0.1.15/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/practices.html
+++ b/archive/v0.1.15/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/refactoring.html
+++ b/archive/v0.1.15/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/roadmap.html
+++ b/archive/v0.1.15/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/routing.html
+++ b/archive/v0.1.15/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/style.css
+++ b/archive/v0.1.15/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.15/style.css
+++ b/archive/v0.1.15/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.15/tools.html
+++ b/archive/v0.1.15/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -94,7 +97,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.15/web-services.html
+++ b/archive/v0.1.15/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/auto-redrawing.html
+++ b/archive/v0.1.16/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/benchmarks.html
+++ b/archive/v0.1.16/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/change-log.html
+++ b/archive/v0.1.16/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -279,7 +282,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/community.html
+++ b/archive/v0.1.16/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -68,7 +71,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/comparison.html
+++ b/archive/v0.1.16/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/comparisons/angular.rendering.html
+++ b/archive/v0.1.16/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.16/comparisons/angular.safety.html
+++ b/archive/v0.1.16/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.16/compiling-templates.html
+++ b/archive/v0.1.16/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/components.html
+++ b/archive/v0.1.16/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -183,7 +186,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/getting-started.html
+++ b/archive/v0.1.16/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -451,7 +454,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/how-to-read-signatures.html
+++ b/archive/v0.1.16/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/index.html
+++ b/archive/v0.1.16/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -34,7 +37,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -185,11 +188,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -246,14 +249,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.16/installation.html
+++ b/archive/v0.1.16/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/integration.html
+++ b/archive/v0.1.16/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.computation.html
+++ b/archive/v0.1.16/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -175,7 +178,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.deferred.html
+++ b/archive/v0.1.16/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -231,7 +234,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.html
+++ b/archive/v0.1.16/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -310,7 +313,7 @@ m(&quot;div&quot;, {config: alertsRedrawCount})</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.module.html
+++ b/archive/v0.1.16/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -197,7 +200,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.prop.html
+++ b/archive/v0.1.16/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.redraw.html
+++ b/archive/v0.1.16/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.render.html
+++ b/archive/v0.1.16/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.request.html
+++ b/archive/v0.1.16/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -292,7 +295,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -307,10 +310,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -319,10 +322,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -353,7 +356,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -391,7 +394,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.route.html
+++ b/archive/v0.1.16/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -177,7 +180,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -292,7 +295,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.sync.html
+++ b/archive/v0.1.16/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.trust.html
+++ b/archive/v0.1.16/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.withAttr.html
+++ b/archive/v0.1.16/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/mithril.xhr.html
+++ b/archive/v0.1.16/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/practices.html
+++ b/archive/v0.1.16/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/refactoring.html
+++ b/archive/v0.1.16/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/roadmap.html
+++ b/archive/v0.1.16/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/routing.html
+++ b/archive/v0.1.16/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/style.css
+++ b/archive/v0.1.16/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.16/style.css
+++ b/archive/v0.1.16/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.16/tools.html
+++ b/archive/v0.1.16/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -94,7 +97,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.16/web-services.html
+++ b/archive/v0.1.16/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/auto-redrawing.html
+++ b/archive/v0.1.17/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/benchmarks.html
+++ b/archive/v0.1.17/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/change-log.html
+++ b/archive/v0.1.17/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -296,7 +299,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/community.html
+++ b/archive/v0.1.17/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/comparison.html
+++ b/archive/v0.1.17/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/comparisons/angular.rendering.html
+++ b/archive/v0.1.17/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.17/comparisons/angular.safety.html
+++ b/archive/v0.1.17/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.17/compiling-templates.html
+++ b/archive/v0.1.17/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -105,7 +108,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/components.html
+++ b/archive/v0.1.17/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/getting-started.html
+++ b/archive/v0.1.17/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -452,7 +455,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/how-to-read-signatures.html
+++ b/archive/v0.1.17/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -147,7 +150,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/index.html
+++ b/archive/v0.1.17/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -186,11 +189,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -247,14 +250,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.17/installation.html
+++ b/archive/v0.1.17/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -107,7 +110,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/integration.html
+++ b/archive/v0.1.17/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.computation.html
+++ b/archive/v0.1.17/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -176,7 +179,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.deferred.html
+++ b/archive/v0.1.17/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -232,7 +235,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.html
+++ b/archive/v0.1.17/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -367,7 +370,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.module.html
+++ b/archive/v0.1.17/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.prop.html
+++ b/archive/v0.1.17/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.redraw.html
+++ b/archive/v0.1.17/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -83,7 +86,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.render.html
+++ b/archive/v0.1.17/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.request.html
+++ b/archive/v0.1.17/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -293,7 +296,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -308,10 +311,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -320,10 +323,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -354,7 +357,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -392,7 +395,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.route.html
+++ b/archive/v0.1.17/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -178,7 +181,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -293,7 +296,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.sync.html
+++ b/archive/v0.1.17/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -105,7 +108,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.trust.html
+++ b/archive/v0.1.17/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.withAttr.html
+++ b/archive/v0.1.17/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/mithril.xhr.html
+++ b/archive/v0.1.17/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -70,7 +73,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/practices.html
+++ b/archive/v0.1.17/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/refactoring.html
+++ b/archive/v0.1.17/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -57,7 +60,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/roadmap.html
+++ b/archive/v0.1.17/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -97,7 +100,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/routing.html
+++ b/archive/v0.1.17/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/style.css
+++ b/archive/v0.1.17/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.17/style.css
+++ b/archive/v0.1.17/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.17/tools.html
+++ b/archive/v0.1.17/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.17/web-services.html
+++ b/archive/v0.1.17/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -211,7 +214,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/auto-redrawing.html
+++ b/archive/v0.1.18/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/benchmarks.html
+++ b/archive/v0.1.18/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/change-log.html
+++ b/archive/v0.1.18/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -303,7 +306,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/community.html
+++ b/archive/v0.1.18/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/comparison.html
+++ b/archive/v0.1.18/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/comparisons/angular.rendering.html
+++ b/archive/v0.1.18/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.18/comparisons/angular.safety.html
+++ b/archive/v0.1.18/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.18/compiling-templates.html
+++ b/archive/v0.1.18/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -105,7 +108,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/components.html
+++ b/archive/v0.1.18/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/getting-started.html
+++ b/archive/v0.1.18/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -452,7 +455,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/how-to-read-signatures.html
+++ b/archive/v0.1.18/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -147,7 +150,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/index.html
+++ b/archive/v0.1.18/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -186,11 +189,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -247,14 +250,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.18/installation.html
+++ b/archive/v0.1.18/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -107,7 +110,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/integration.html
+++ b/archive/v0.1.18/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.computation.html
+++ b/archive/v0.1.18/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -176,7 +179,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.deferred.html
+++ b/archive/v0.1.18/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -232,7 +235,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.html
+++ b/archive/v0.1.18/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -367,7 +370,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.module.html
+++ b/archive/v0.1.18/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.prop.html
+++ b/archive/v0.1.18/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.redraw.html
+++ b/archive/v0.1.18/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -83,7 +86,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.render.html
+++ b/archive/v0.1.18/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.request.html
+++ b/archive/v0.1.18/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -293,7 +296,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -308,10 +311,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -320,10 +323,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -354,7 +357,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -392,7 +395,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.route.html
+++ b/archive/v0.1.18/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -178,7 +181,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -293,7 +296,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.sync.html
+++ b/archive/v0.1.18/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -105,7 +108,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.trust.html
+++ b/archive/v0.1.18/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.withAttr.html
+++ b/archive/v0.1.18/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/mithril.xhr.html
+++ b/archive/v0.1.18/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -70,7 +73,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/practices.html
+++ b/archive/v0.1.18/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/refactoring.html
+++ b/archive/v0.1.18/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -57,7 +60,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/roadmap.html
+++ b/archive/v0.1.18/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -97,7 +100,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/routing.html
+++ b/archive/v0.1.18/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/style.css
+++ b/archive/v0.1.18/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.18/style.css
+++ b/archive/v0.1.18/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.18/tools.html
+++ b/archive/v0.1.18/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.18/web-services.html
+++ b/archive/v0.1.18/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -211,7 +214,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/auto-redrawing.html
+++ b/archive/v0.1.19/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/benchmarks.html
+++ b/archive/v0.1.19/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/change-log.html
+++ b/archive/v0.1.19/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -313,7 +316,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/community.html
+++ b/archive/v0.1.19/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/comparison.html
+++ b/archive/v0.1.19/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/comparisons/angular.rendering.html
+++ b/archive/v0.1.19/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.19/comparisons/angular.safety.html
+++ b/archive/v0.1.19/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.19/compiling-templates.html
+++ b/archive/v0.1.19/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -105,7 +108,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/components.html
+++ b/archive/v0.1.19/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/getting-started.html
+++ b/archive/v0.1.19/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -452,7 +455,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/how-to-read-signatures.html
+++ b/archive/v0.1.19/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -147,7 +150,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/index.html
+++ b/archive/v0.1.19/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -186,11 +189,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -247,14 +250,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.19/installation.html
+++ b/archive/v0.1.19/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -107,7 +110,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/integration.html
+++ b/archive/v0.1.19/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.computation.html
+++ b/archive/v0.1.19/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -176,7 +179,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.deferred.html
+++ b/archive/v0.1.19/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -232,7 +235,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.html
+++ b/archive/v0.1.19/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -367,7 +370,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.module.html
+++ b/archive/v0.1.19/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.prop.html
+++ b/archive/v0.1.19/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.redraw.html
+++ b/archive/v0.1.19/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -83,7 +86,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.render.html
+++ b/archive/v0.1.19/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.request.html
+++ b/archive/v0.1.19/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -293,7 +296,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -308,10 +311,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -320,10 +323,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -354,7 +357,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -392,7 +395,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.route.html
+++ b/archive/v0.1.19/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -178,7 +181,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -293,7 +296,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.sync.html
+++ b/archive/v0.1.19/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -105,7 +108,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.trust.html
+++ b/archive/v0.1.19/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.withAttr.html
+++ b/archive/v0.1.19/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/mithril.xhr.html
+++ b/archive/v0.1.19/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -70,7 +73,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/practices.html
+++ b/archive/v0.1.19/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/refactoring.html
+++ b/archive/v0.1.19/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -57,7 +60,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/roadmap.html
+++ b/archive/v0.1.19/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -97,7 +100,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/routing.html
+++ b/archive/v0.1.19/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/style.css
+++ b/archive/v0.1.19/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.19/style.css
+++ b/archive/v0.1.19/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.19/tools.html
+++ b/archive/v0.1.19/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.19/web-services.html
+++ b/archive/v0.1.19/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -211,7 +214,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/auto-redrawing.html
+++ b/archive/v0.1.2/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/change-log.html
+++ b/archive/v0.1.2/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/community.html
+++ b/archive/v0.1.2/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -60,7 +63,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/comparison.html
+++ b/archive/v0.1.2/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/comparisons/angular.rendering.html
+++ b/archive/v0.1.2/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.2/comparisons/angular.safety.html
+++ b/archive/v0.1.2/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.2/compiling-templates.html
+++ b/archive/v0.1.2/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/components.html
+++ b/archive/v0.1.2/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/getting-started.html
+++ b/archive/v0.1.2/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/how-to-read-signatures.html
+++ b/archive/v0.1.2/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/index.html
+++ b/archive/v0.1.2/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.2/installation.html
+++ b/archive/v0.1.2/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/integration.html
+++ b/archive/v0.1.2/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.computation.html
+++ b/archive/v0.1.2/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.deferred.html
+++ b/archive/v0.1.2/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.html
+++ b/archive/v0.1.2/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -274,7 +277,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.module.html
+++ b/archive/v0.1.2/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.prop.html
+++ b/archive/v0.1.2/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.redraw.html
+++ b/archive/v0.1.2/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.render.html
+++ b/archive/v0.1.2/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.request.html
+++ b/archive/v0.1.2/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -254,7 +257,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -262,10 +265,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -274,10 +277,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -304,7 +307,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -339,7 +342,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.route.html
+++ b/archive/v0.1.2/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.sync.html
+++ b/archive/v0.1.2/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.trust.html
+++ b/archive/v0.1.2/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.withAttr.html
+++ b/archive/v0.1.2/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/mithril.xhr.html
+++ b/archive/v0.1.2/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/practices.html
+++ b/archive/v0.1.2/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/refactoring.html
+++ b/archive/v0.1.2/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/roadmap.html
+++ b/archive/v0.1.2/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/routing.html
+++ b/archive/v0.1.2/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/style.css
+++ b/archive/v0.1.2/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.2/style.css
+++ b/archive/v0.1.2/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.2/tools.html
+++ b/archive/v0.1.2/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.2/web-services.html
+++ b/archive/v0.1.2/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/auto-redrawing.html
+++ b/archive/v0.1.20/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/benchmarks.html
+++ b/archive/v0.1.20/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/change-log.html
+++ b/archive/v0.1.20/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -330,7 +333,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/community.html
+++ b/archive/v0.1.20/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/comparison.html
+++ b/archive/v0.1.20/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/comparisons/angular.rendering.html
+++ b/archive/v0.1.20/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.20/comparisons/angular.safety.html
+++ b/archive/v0.1.20/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.20/compiling-templates.html
+++ b/archive/v0.1.20/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -105,7 +108,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/components.html
+++ b/archive/v0.1.20/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -186,7 +189,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/getting-started.html
+++ b/archive/v0.1.20/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -452,7 +455,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/how-to-read-signatures.html
+++ b/archive/v0.1.20/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/index.html
+++ b/archive/v0.1.20/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -186,11 +189,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -247,14 +250,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.20/installation.html
+++ b/archive/v0.1.20/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -107,7 +110,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/integration.html
+++ b/archive/v0.1.20/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.computation.html
+++ b/archive/v0.1.20/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -180,7 +183,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.deferred.html
+++ b/archive/v0.1.20/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -241,7 +244,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.html
+++ b/archive/v0.1.20/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -371,7 +374,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.module.html
+++ b/archive/v0.1.20/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.prop.html
+++ b/archive/v0.1.20/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.redraw.html
+++ b/archive/v0.1.20/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.render.html
+++ b/archive/v0.1.20/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -158,7 +161,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.request.html
+++ b/archive/v0.1.20/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -302,7 +305,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -317,10 +320,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -329,10 +332,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -363,7 +366,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -401,7 +404,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.route.html
+++ b/archive/v0.1.20/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -182,7 +185,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -297,7 +300,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.sync.html
+++ b/archive/v0.1.20/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -92,7 +95,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -109,7 +112,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.trust.html
+++ b/archive/v0.1.20/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.withAttr.html
+++ b/archive/v0.1.20/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/mithril.xhr.html
+++ b/archive/v0.1.20/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -74,7 +77,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/practices.html
+++ b/archive/v0.1.20/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/refactoring.html
+++ b/archive/v0.1.20/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -57,7 +60,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/roadmap.html
+++ b/archive/v0.1.20/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/routing.html
+++ b/archive/v0.1.20/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/style.css
+++ b/archive/v0.1.20/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.20/style.css
+++ b/archive/v0.1.20/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.20/tools.html
+++ b/archive/v0.1.20/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.20/web-services.html
+++ b/archive/v0.1.20/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -211,7 +214,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/auto-redrawing.html
+++ b/archive/v0.1.21/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/benchmarks.html
+++ b/archive/v0.1.21/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/change-log.html
+++ b/archive/v0.1.21/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -344,7 +347,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/community.html
+++ b/archive/v0.1.21/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -73,7 +76,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/comparison.html
+++ b/archive/v0.1.21/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/comparisons/angular.rendering.html
+++ b/archive/v0.1.21/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.21/comparisons/angular.safety.html
+++ b/archive/v0.1.21/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.21/compiling-templates.html
+++ b/archive/v0.1.21/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -105,7 +108,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/components.html
+++ b/archive/v0.1.21/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -186,7 +189,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/getting-started.html
+++ b/archive/v0.1.21/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -458,7 +461,7 @@ this.description(data.description)</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/how-to-read-signatures.html
+++ b/archive/v0.1.21/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/index.html
+++ b/archive/v0.1.21/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -186,11 +189,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -247,14 +250,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.21/installation.html
+++ b/archive/v0.1.21/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -107,7 +110,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/integration.html
+++ b/archive/v0.1.21/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.computation.html
+++ b/archive/v0.1.21/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -180,7 +183,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.deferred.html
+++ b/archive/v0.1.21/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -187,7 +190,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.html
+++ b/archive/v0.1.21/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -371,7 +374,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.module.html
+++ b/archive/v0.1.21/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.prop.html
+++ b/archive/v0.1.21/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.redraw.html
+++ b/archive/v0.1.21/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.render.html
+++ b/archive/v0.1.21/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -158,7 +161,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.request.html
+++ b/archive/v0.1.21/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -302,7 +305,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -317,10 +320,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -329,10 +332,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -363,7 +366,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -401,7 +404,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.route.html
+++ b/archive/v0.1.21/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -182,7 +185,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -297,7 +300,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.sync.html
+++ b/archive/v0.1.21/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -92,7 +95,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -109,7 +112,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.trust.html
+++ b/archive/v0.1.21/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.withAttr.html
+++ b/archive/v0.1.21/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/mithril.xhr.html
+++ b/archive/v0.1.21/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -74,7 +77,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/practices.html
+++ b/archive/v0.1.21/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/refactoring.html
+++ b/archive/v0.1.21/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -57,7 +60,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/roadmap.html
+++ b/archive/v0.1.21/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/routing.html
+++ b/archive/v0.1.21/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/style.css
+++ b/archive/v0.1.21/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.21/style.css
+++ b/archive/v0.1.21/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.21/tools.html
+++ b/archive/v0.1.21/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.21/web-services.html
+++ b/archive/v0.1.21/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -211,7 +214,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/auto-redrawing.html
+++ b/archive/v0.1.22/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/benchmarks.html
+++ b/archive/v0.1.22/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/change-log.html
+++ b/archive/v0.1.22/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -376,7 +379,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/community.html
+++ b/archive/v0.1.22/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -73,7 +76,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/comparison.html
+++ b/archive/v0.1.22/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/comparisons/angular.rendering.html
+++ b/archive/v0.1.22/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.22/comparisons/angular.safety.html
+++ b/archive/v0.1.22/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.22/compiling-templates.html
+++ b/archive/v0.1.22/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -105,7 +108,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/components.html
+++ b/archive/v0.1.22/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -234,7 +237,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/getting-started.html
+++ b/archive/v0.1.22/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -453,7 +456,7 @@ this.description(data.description)</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/how-to-read-signatures.html
+++ b/archive/v0.1.22/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -172,7 +175,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/index.html
+++ b/archive/v0.1.22/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -186,11 +189,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -247,14 +250,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.22/installation.html
+++ b/archive/v0.1.22/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/integration.html
+++ b/archive/v0.1.22/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.computation.html
+++ b/archive/v0.1.22/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -260,7 +263,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.deferred.html
+++ b/archive/v0.1.22/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -260,7 +263,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.deps.html
+++ b/archive/v0.1.22/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -127,7 +130,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.html
+++ b/archive/v0.1.22/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -448,7 +451,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.module.html
+++ b/archive/v0.1.22/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -193,7 +196,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.prop.html
+++ b/archive/v0.1.22/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -178,7 +181,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.redraw.html
+++ b/archive/v0.1.22/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -214,7 +217,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.render.html
+++ b/archive/v0.1.22/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -175,7 +178,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.request.html
+++ b/archive/v0.1.22/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -355,7 +358,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -370,10 +373,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -382,10 +385,10 @@ where:
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -416,7 +419,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -460,7 +463,7 @@ where:
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -475,7 +478,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.route.html
+++ b/archive/v0.1.22/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -317,7 +320,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.sync.html
+++ b/archive/v0.1.22/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -102,7 +105,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -119,7 +122,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.trust.html
+++ b/archive/v0.1.22/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -128,7 +131,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.withAttr.html
+++ b/archive/v0.1.22/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/mithril.xhr.html
+++ b/archive/v0.1.22/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/practices.html
+++ b/archive/v0.1.22/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/refactoring.html
+++ b/archive/v0.1.22/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -57,7 +60,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/roadmap.html
+++ b/archive/v0.1.22/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/routing.html
+++ b/archive/v0.1.22/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/style.css
+++ b/archive/v0.1.22/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.22/style.css
+++ b/archive/v0.1.22/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.22/tools.html
+++ b/archive/v0.1.22/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -97,7 +100,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.22/web-services.html
+++ b/archive/v0.1.22/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -211,7 +214,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/auto-redrawing.html
+++ b/archive/v0.1.23/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/benchmarks.html
+++ b/archive/v0.1.23/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/change-log.html
+++ b/archive/v0.1.23/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -396,7 +399,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/community.html
+++ b/archive/v0.1.23/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/comparison.html
+++ b/archive/v0.1.23/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/comparisons/angular.rendering.html
+++ b/archive/v0.1.23/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.23/comparisons/angular.safety.html
+++ b/archive/v0.1.23/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.23/compiling-templates.html
+++ b/archive/v0.1.23/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/components.html
+++ b/archive/v0.1.23/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/getting-started.html
+++ b/archive/v0.1.23/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/how-to-read-signatures.html
+++ b/archive/v0.1.23/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/index.html
+++ b/archive/v0.1.23/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.23/installation.html
+++ b/archive/v0.1.23/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/integration.html
+++ b/archive/v0.1.23/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.computation.html
+++ b/archive/v0.1.23/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.deferred.html
+++ b/archive/v0.1.23/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.deps.html
+++ b/archive/v0.1.23/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.html
+++ b/archive/v0.1.23/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.module.html
+++ b/archive/v0.1.23/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -201,7 +204,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.prop.html
+++ b/archive/v0.1.23/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.redraw.html
+++ b/archive/v0.1.23/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -220,7 +223,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.render.html
+++ b/archive/v0.1.23/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.request.html
+++ b/archive/v0.1.23/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.route.html
+++ b/archive/v0.1.23/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.sync.html
+++ b/archive/v0.1.23/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.trust.html
+++ b/archive/v0.1.23/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.withAttr.html
+++ b/archive/v0.1.23/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/mithril.xhr.html
+++ b/archive/v0.1.23/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/practices.html
+++ b/archive/v0.1.23/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/refactoring.html
+++ b/archive/v0.1.23/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/roadmap.html
+++ b/archive/v0.1.23/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/routing.html
+++ b/archive/v0.1.23/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/style.css
+++ b/archive/v0.1.23/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.23/style.css
+++ b/archive/v0.1.23/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.23/tools.html
+++ b/archive/v0.1.23/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.23/web-services.html
+++ b/archive/v0.1.23/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/auto-redrawing.html
+++ b/archive/v0.1.24/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/benchmarks.html
+++ b/archive/v0.1.24/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/change-log.html
+++ b/archive/v0.1.24/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -403,7 +406,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/community.html
+++ b/archive/v0.1.24/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/comparison.html
+++ b/archive/v0.1.24/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/comparisons/angular.rendering.html
+++ b/archive/v0.1.24/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.24/comparisons/angular.safety.html
+++ b/archive/v0.1.24/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.24/compiling-templates.html
+++ b/archive/v0.1.24/compiling-templates.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/components.html
+++ b/archive/v0.1.24/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/getting-started.html
+++ b/archive/v0.1.24/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/how-to-read-signatures.html
+++ b/archive/v0.1.24/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/index.html
+++ b/archive/v0.1.24/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="http://platform.twitter.com/widgets.js"></script>
+						<script async="" src="http://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.24/installation.html
+++ b/archive/v0.1.24/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/integration.html
+++ b/archive/v0.1.24/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.computation.html
+++ b/archive/v0.1.24/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.deferred.html
+++ b/archive/v0.1.24/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.deps.html
+++ b/archive/v0.1.24/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.html
+++ b/archive/v0.1.24/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.module.html
+++ b/archive/v0.1.24/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -201,7 +204,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.prop.html
+++ b/archive/v0.1.24/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.redraw.html
+++ b/archive/v0.1.24/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -220,7 +223,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.render.html
+++ b/archive/v0.1.24/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.request.html
+++ b/archive/v0.1.24/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.route.html
+++ b/archive/v0.1.24/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.sync.html
+++ b/archive/v0.1.24/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.trust.html
+++ b/archive/v0.1.24/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.withAttr.html
+++ b/archive/v0.1.24/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/mithril.xhr.html
+++ b/archive/v0.1.24/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/optimizing-performance.html
+++ b/archive/v0.1.24/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/practices.html
+++ b/archive/v0.1.24/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/refactoring.html
+++ b/archive/v0.1.24/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/roadmap.html
+++ b/archive/v0.1.24/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/routing.html
+++ b/archive/v0.1.24/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/style.css
+++ b/archive/v0.1.24/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.24/style.css
+++ b/archive/v0.1.24/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.24/tools.html
+++ b/archive/v0.1.24/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.24/web-services.html
+++ b/archive/v0.1.24/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/auto-redrawing.html
+++ b/archive/v0.1.25/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/benchmarks.html
+++ b/archive/v0.1.25/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/change-log.html
+++ b/archive/v0.1.25/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -412,7 +415,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/community.html
+++ b/archive/v0.1.25/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/comparison.html
+++ b/archive/v0.1.25/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/comparisons/angular.rendering.html
+++ b/archive/v0.1.25/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.25/comparisons/angular.safety.html
+++ b/archive/v0.1.25/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.25/components.html
+++ b/archive/v0.1.25/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/getting-started.html
+++ b/archive/v0.1.25/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/how-to-read-signatures.html
+++ b/archive/v0.1.25/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/index.html
+++ b/archive/v0.1.25/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.25/installation.html
+++ b/archive/v0.1.25/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/integration.html
+++ b/archive/v0.1.25/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.computation.html
+++ b/archive/v0.1.25/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.deferred.html
+++ b/archive/v0.1.25/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.deps.html
+++ b/archive/v0.1.25/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.html
+++ b/archive/v0.1.25/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.module.html
+++ b/archive/v0.1.25/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -201,7 +204,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.prop.html
+++ b/archive/v0.1.25/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.redraw.html
+++ b/archive/v0.1.25/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -220,7 +223,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.render.html
+++ b/archive/v0.1.25/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.request.html
+++ b/archive/v0.1.25/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.route.html
+++ b/archive/v0.1.25/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.sync.html
+++ b/archive/v0.1.25/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.trust.html
+++ b/archive/v0.1.25/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.withAttr.html
+++ b/archive/v0.1.25/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/mithril.xhr.html
+++ b/archive/v0.1.25/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/optimizing-performance.html
+++ b/archive/v0.1.25/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/practices.html
+++ b/archive/v0.1.25/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/refactoring.html
+++ b/archive/v0.1.25/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/roadmap.html
+++ b/archive/v0.1.25/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/routing.html
+++ b/archive/v0.1.25/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/style.css
+++ b/archive/v0.1.25/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.25/style.css
+++ b/archive/v0.1.25/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.25/tools.html
+++ b/archive/v0.1.25/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.25/web-services.html
+++ b/archive/v0.1.25/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/auto-redrawing.html
+++ b/archive/v0.1.26/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/benchmarks.html
+++ b/archive/v0.1.26/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/change-log.html
+++ b/archive/v0.1.26/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -419,7 +422,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/community.html
+++ b/archive/v0.1.26/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/comparison.html
+++ b/archive/v0.1.26/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/comparisons/angular.rendering.html
+++ b/archive/v0.1.26/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.26/comparisons/angular.safety.html
+++ b/archive/v0.1.26/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.26/components.html
+++ b/archive/v0.1.26/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/getting-started.html
+++ b/archive/v0.1.26/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/how-to-read-signatures.html
+++ b/archive/v0.1.26/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/index.html
+++ b/archive/v0.1.26/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.26/installation.html
+++ b/archive/v0.1.26/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/integration.html
+++ b/archive/v0.1.26/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.computation.html
+++ b/archive/v0.1.26/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.deferred.html
+++ b/archive/v0.1.26/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.deps.html
+++ b/archive/v0.1.26/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.html
+++ b/archive/v0.1.26/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.module.html
+++ b/archive/v0.1.26/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -201,7 +204,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.prop.html
+++ b/archive/v0.1.26/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.redraw.html
+++ b/archive/v0.1.26/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -220,7 +223,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.render.html
+++ b/archive/v0.1.26/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.request.html
+++ b/archive/v0.1.26/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.route.html
+++ b/archive/v0.1.26/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.sync.html
+++ b/archive/v0.1.26/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.trust.html
+++ b/archive/v0.1.26/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.withAttr.html
+++ b/archive/v0.1.26/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/mithril.xhr.html
+++ b/archive/v0.1.26/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/optimizing-performance.html
+++ b/archive/v0.1.26/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/practices.html
+++ b/archive/v0.1.26/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/refactoring.html
+++ b/archive/v0.1.26/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/roadmap.html
+++ b/archive/v0.1.26/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/routing.html
+++ b/archive/v0.1.26/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/style.css
+++ b/archive/v0.1.26/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.26/style.css
+++ b/archive/v0.1.26/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.26/tools.html
+++ b/archive/v0.1.26/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.26/web-services.html
+++ b/archive/v0.1.26/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/auto-redrawing.html
+++ b/archive/v0.1.27/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/benchmarks.html
+++ b/archive/v0.1.27/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -85,7 +88,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/change-log.html
+++ b/archive/v0.1.27/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -428,7 +431,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/community.html
+++ b/archive/v0.1.27/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/comparison.html
+++ b/archive/v0.1.27/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/comparisons/angular.rendering.html
+++ b/archive/v0.1.27/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.27/comparisons/angular.safety.html
+++ b/archive/v0.1.27/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.27/components.html
+++ b/archive/v0.1.27/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/getting-started.html
+++ b/archive/v0.1.27/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/how-to-read-signatures.html
+++ b/archive/v0.1.27/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/index.html
+++ b/archive/v0.1.27/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.27/installation.html
+++ b/archive/v0.1.27/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/integration.html
+++ b/archive/v0.1.27/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.computation.html
+++ b/archive/v0.1.27/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.deferred.html
+++ b/archive/v0.1.27/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.deps.html
+++ b/archive/v0.1.27/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.html
+++ b/archive/v0.1.27/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.module.html
+++ b/archive/v0.1.27/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -201,7 +204,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.prop.html
+++ b/archive/v0.1.27/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.redraw.html
+++ b/archive/v0.1.27/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -224,7 +227,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.render.html
+++ b/archive/v0.1.27/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.request.html
+++ b/archive/v0.1.27/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.route.html
+++ b/archive/v0.1.27/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.sync.html
+++ b/archive/v0.1.27/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.trust.html
+++ b/archive/v0.1.27/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.withAttr.html
+++ b/archive/v0.1.27/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/mithril.xhr.html
+++ b/archive/v0.1.27/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/optimizing-performance.html
+++ b/archive/v0.1.27/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/practices.html
+++ b/archive/v0.1.27/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/refactoring.html
+++ b/archive/v0.1.27/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/roadmap.html
+++ b/archive/v0.1.27/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/routing.html
+++ b/archive/v0.1.27/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/style.css
+++ b/archive/v0.1.27/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.27/style.css
+++ b/archive/v0.1.27/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.27/tools.html
+++ b/archive/v0.1.27/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.27/web-services.html
+++ b/archive/v0.1.27/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/auto-redrawing.html
+++ b/archive/v0.1.28/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/benchmarks.html
+++ b/archive/v0.1.28/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/change-log.html
+++ b/archive/v0.1.28/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -438,7 +441,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/community.html
+++ b/archive/v0.1.28/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/comparison.html
+++ b/archive/v0.1.28/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/comparisons/angular.rendering.html
+++ b/archive/v0.1.28/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.28/comparisons/angular.safety.html
+++ b/archive/v0.1.28/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.28/components.html
+++ b/archive/v0.1.28/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/getting-started.html
+++ b/archive/v0.1.28/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/how-to-read-signatures.html
+++ b/archive/v0.1.28/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/index.html
+++ b/archive/v0.1.28/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.28/installation.html
+++ b/archive/v0.1.28/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/integration.html
+++ b/archive/v0.1.28/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.computation.html
+++ b/archive/v0.1.28/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.deferred.html
+++ b/archive/v0.1.28/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.deps.html
+++ b/archive/v0.1.28/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.html
+++ b/archive/v0.1.28/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.module.html
+++ b/archive/v0.1.28/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -201,7 +204,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.prop.html
+++ b/archive/v0.1.28/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -190,7 +193,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.redraw.html
+++ b/archive/v0.1.28/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -224,7 +227,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.render.html
+++ b/archive/v0.1.28/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.request.html
+++ b/archive/v0.1.28/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -423,7 +426,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -459,10 +462,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -471,10 +474,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,7 +508,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -550,7 +553,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -565,7 +568,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.route.html
+++ b/archive/v0.1.28/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.sync.html
+++ b/archive/v0.1.28/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.trust.html
+++ b/archive/v0.1.28/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.withAttr.html
+++ b/archive/v0.1.28/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/mithril.xhr.html
+++ b/archive/v0.1.28/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/optimizing-performance.html
+++ b/archive/v0.1.28/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/practices.html
+++ b/archive/v0.1.28/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/refactoring.html
+++ b/archive/v0.1.28/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/roadmap.html
+++ b/archive/v0.1.28/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/routing.html
+++ b/archive/v0.1.28/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/style.css
+++ b/archive/v0.1.28/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.28/style.css
+++ b/archive/v0.1.28/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.28/tools.html
+++ b/archive/v0.1.28/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.28/web-services.html
+++ b/archive/v0.1.28/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/auto-redrawing.html
+++ b/archive/v0.1.29/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/benchmarks.html
+++ b/archive/v0.1.29/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/change-log.html
+++ b/archive/v0.1.29/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -453,7 +456,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/community.html
+++ b/archive/v0.1.29/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/comparison.html
+++ b/archive/v0.1.29/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/comparisons/angular.rendering.html
+++ b/archive/v0.1.29/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.29/comparisons/angular.safety.html
+++ b/archive/v0.1.29/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.29/components.html
+++ b/archive/v0.1.29/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/getting-started.html
+++ b/archive/v0.1.29/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/how-to-read-signatures.html
+++ b/archive/v0.1.29/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/index.html
+++ b/archive/v0.1.29/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.29/installation.html
+++ b/archive/v0.1.29/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/integration.html
+++ b/archive/v0.1.29/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.computation.html
+++ b/archive/v0.1.29/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.deferred.html
+++ b/archive/v0.1.29/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.deps.html
+++ b/archive/v0.1.29/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.html
+++ b/archive/v0.1.29/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.module.html
+++ b/archive/v0.1.29/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.prop.html
+++ b/archive/v0.1.29/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -190,7 +193,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.redraw.html
+++ b/archive/v0.1.29/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -224,7 +227,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.render.html
+++ b/archive/v0.1.29/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.request.html
+++ b/archive/v0.1.29/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -423,7 +426,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -459,10 +462,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -471,10 +474,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,7 +508,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -550,7 +553,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -565,7 +568,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.route.html
+++ b/archive/v0.1.29/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.sync.html
+++ b/archive/v0.1.29/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.trust.html
+++ b/archive/v0.1.29/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.withAttr.html
+++ b/archive/v0.1.29/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/mithril.xhr.html
+++ b/archive/v0.1.29/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/optimizing-performance.html
+++ b/archive/v0.1.29/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/practices.html
+++ b/archive/v0.1.29/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/refactoring.html
+++ b/archive/v0.1.29/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/roadmap.html
+++ b/archive/v0.1.29/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/routing.html
+++ b/archive/v0.1.29/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/style.css
+++ b/archive/v0.1.29/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.29/style.css
+++ b/archive/v0.1.29/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.29/tools.html
+++ b/archive/v0.1.29/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.29/web-services.html
+++ b/archive/v0.1.29/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/auto-redrawing.html
+++ b/archive/v0.1.3/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/change-log.html
+++ b/archive/v0.1.3/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/community.html
+++ b/archive/v0.1.3/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -60,7 +63,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/comparison.html
+++ b/archive/v0.1.3/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/comparisons/angular.rendering.html
+++ b/archive/v0.1.3/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.3/comparisons/angular.safety.html
+++ b/archive/v0.1.3/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.3/compiling-templates.html
+++ b/archive/v0.1.3/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/components.html
+++ b/archive/v0.1.3/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/getting-started.html
+++ b/archive/v0.1.3/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/how-to-read-signatures.html
+++ b/archive/v0.1.3/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/index.html
+++ b/archive/v0.1.3/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.3/installation.html
+++ b/archive/v0.1.3/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -94,7 +97,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/integration.html
+++ b/archive/v0.1.3/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.computation.html
+++ b/archive/v0.1.3/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.deferred.html
+++ b/archive/v0.1.3/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.html
+++ b/archive/v0.1.3/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -276,7 +279,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.module.html
+++ b/archive/v0.1.3/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.prop.html
+++ b/archive/v0.1.3/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.redraw.html
+++ b/archive/v0.1.3/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.render.html
+++ b/archive/v0.1.3/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.request.html
+++ b/archive/v0.1.3/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -254,7 +257,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -262,10 +265,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -274,10 +277,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -304,7 +307,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -339,7 +342,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.route.html
+++ b/archive/v0.1.3/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.sync.html
+++ b/archive/v0.1.3/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.trust.html
+++ b/archive/v0.1.3/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.withAttr.html
+++ b/archive/v0.1.3/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/mithril.xhr.html
+++ b/archive/v0.1.3/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/practices.html
+++ b/archive/v0.1.3/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/refactoring.html
+++ b/archive/v0.1.3/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/roadmap.html
+++ b/archive/v0.1.3/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/routing.html
+++ b/archive/v0.1.3/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/style.css
+++ b/archive/v0.1.3/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.3/style.css
+++ b/archive/v0.1.3/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.3/tools.html
+++ b/archive/v0.1.3/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.3/web-services.html
+++ b/archive/v0.1.3/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/auto-redrawing.html
+++ b/archive/v0.1.30/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/benchmarks.html
+++ b/archive/v0.1.30/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/change-log.html
+++ b/archive/v0.1.30/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -460,7 +463,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/community.html
+++ b/archive/v0.1.30/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -76,7 +79,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/comparison.html
+++ b/archive/v0.1.30/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/comparisons/angular.rendering.html
+++ b/archive/v0.1.30/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.30/comparisons/angular.safety.html
+++ b/archive/v0.1.30/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.30/components.html
+++ b/archive/v0.1.30/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/getting-started.html
+++ b/archive/v0.1.30/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -499,7 +502,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/how-to-read-signatures.html
+++ b/archive/v0.1.30/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -198,7 +201,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/index.html
+++ b/archive/v0.1.30/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.30/installation.html
+++ b/archive/v0.1.30/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/integration.html
+++ b/archive/v0.1.30/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.computation.html
+++ b/archive/v0.1.30/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.deferred.html
+++ b/archive/v0.1.30/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -268,7 +271,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.deps.html
+++ b/archive/v0.1.30/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.html
+++ b/archive/v0.1.30/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -487,7 +490,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.module.html
+++ b/archive/v0.1.30/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.prop.html
+++ b/archive/v0.1.30/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -190,7 +193,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.redraw.html
+++ b/archive/v0.1.30/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -224,7 +227,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.render.html
+++ b/archive/v0.1.30/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -179,7 +182,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.request.html
+++ b/archive/v0.1.30/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -423,7 +426,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -459,10 +462,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -471,10 +474,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,7 +508,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -550,7 +553,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -565,7 +568,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.route.html
+++ b/archive/v0.1.30/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -210,7 +213,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -332,7 +335,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.sync.html
+++ b/archive/v0.1.30/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -121,7 +124,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.trust.html
+++ b/archive/v0.1.30/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.withAttr.html
+++ b/archive/v0.1.30/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -136,7 +139,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/mithril.xhr.html
+++ b/archive/v0.1.30/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -84,7 +87,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/optimizing-performance.html
+++ b/archive/v0.1.30/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/practices.html
+++ b/archive/v0.1.30/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/refactoring.html
+++ b/archive/v0.1.30/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/roadmap.html
+++ b/archive/v0.1.30/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/routing.html
+++ b/archive/v0.1.30/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/style.css
+++ b/archive/v0.1.30/style.css
@@ -96,3 +96,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.30/style.css
+++ b/archive/v0.1.30/style.css
@@ -89,4 +89,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.30/tools.html
+++ b/archive/v0.1.30/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.30/web-services.html
+++ b/archive/v0.1.30/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/auto-redrawing.html
+++ b/archive/v0.1.31/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/benchmarks.html
+++ b/archive/v0.1.31/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/change-log.html
+++ b/archive/v0.1.31/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -483,7 +486,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/community.html
+++ b/archive/v0.1.31/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -80,7 +83,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/comparison.html
+++ b/archive/v0.1.31/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/comparisons/angular.rendering.html
+++ b/archive/v0.1.31/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.31/comparisons/angular.safety.html
+++ b/archive/v0.1.31/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.31/components.html
+++ b/archive/v0.1.31/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/getting-started.html
+++ b/archive/v0.1.31/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -497,7 +500,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/how-to-read-signatures.html
+++ b/archive/v0.1.31/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -200,7 +203,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/index.html
+++ b/archive/v0.1.31/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.31/installation.html
+++ b/archive/v0.1.31/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/integration.html
+++ b/archive/v0.1.31/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.computation.html
+++ b/archive/v0.1.31/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.deferred.html
+++ b/archive/v0.1.31/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.deps.html
+++ b/archive/v0.1.31/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.html
+++ b/archive/v0.1.31/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -544,7 +547,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.module.html
+++ b/archive/v0.1.31/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -207,7 +210,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.prop.html
+++ b/archive/v0.1.31/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -192,7 +195,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.redraw.html
+++ b/archive/v0.1.31/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.render.html
+++ b/archive/v0.1.31/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -181,7 +184,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.request.html
+++ b/archive/v0.1.31/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.route.html
+++ b/archive/v0.1.31/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -212,7 +215,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -363,7 +366,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.sync.html
+++ b/archive/v0.1.31/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -123,7 +126,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.trust.html
+++ b/archive/v0.1.31/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.withAttr.html
+++ b/archive/v0.1.31/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -138,7 +141,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/mithril.xhr.html
+++ b/archive/v0.1.31/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/optimizing-performance.html
+++ b/archive/v0.1.31/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/practices.html
+++ b/archive/v0.1.31/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/refactoring.html
+++ b/archive/v0.1.31/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/roadmap.html
+++ b/archive/v0.1.31/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/routing.html
+++ b/archive/v0.1.31/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/style.css
+++ b/archive/v0.1.31/style.css
@@ -97,3 +97,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.31/style.css
+++ b/archive/v0.1.31/style.css
@@ -90,3 +90,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.1.31/tools.html
+++ b/archive/v0.1.31/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.31/web-services.html
+++ b/archive/v0.1.31/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/auto-redrawing.html
+++ b/archive/v0.1.32/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/benchmarks.html
+++ b/archive/v0.1.32/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/change-log.html
+++ b/archive/v0.1.32/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -483,7 +486,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/community.html
+++ b/archive/v0.1.32/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -80,7 +83,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/comparison.html
+++ b/archive/v0.1.32/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/comparisons/angular.rendering.html
+++ b/archive/v0.1.32/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.32/comparisons/angular.safety.html
+++ b/archive/v0.1.32/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.32/components.html
+++ b/archive/v0.1.32/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/getting-started.html
+++ b/archive/v0.1.32/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -497,7 +500,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/how-to-read-signatures.html
+++ b/archive/v0.1.32/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -200,7 +203,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/index.html
+++ b/archive/v0.1.32/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.32/installation.html
+++ b/archive/v0.1.32/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/integration.html
+++ b/archive/v0.1.32/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.computation.html
+++ b/archive/v0.1.32/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.deferred.html
+++ b/archive/v0.1.32/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.deps.html
+++ b/archive/v0.1.32/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.html
+++ b/archive/v0.1.32/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -544,7 +547,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.module.html
+++ b/archive/v0.1.32/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -207,7 +210,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.prop.html
+++ b/archive/v0.1.32/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -192,7 +195,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.redraw.html
+++ b/archive/v0.1.32/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.render.html
+++ b/archive/v0.1.32/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -181,7 +184,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.request.html
+++ b/archive/v0.1.32/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -462,10 +465,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -474,10 +477,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -508,7 +511,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -553,7 +556,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -568,7 +571,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.route.html
+++ b/archive/v0.1.32/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -212,7 +215,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -363,7 +366,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.sync.html
+++ b/archive/v0.1.32/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -123,7 +126,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.trust.html
+++ b/archive/v0.1.32/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.withAttr.html
+++ b/archive/v0.1.32/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -138,7 +141,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/mithril.xhr.html
+++ b/archive/v0.1.32/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/optimizing-performance.html
+++ b/archive/v0.1.32/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/practices.html
+++ b/archive/v0.1.32/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/refactoring.html
+++ b/archive/v0.1.32/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/roadmap.html
+++ b/archive/v0.1.32/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/routing.html
+++ b/archive/v0.1.32/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/style.css
+++ b/archive/v0.1.32/style.css
@@ -97,3 +97,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.32/style.css
+++ b/archive/v0.1.32/style.css
@@ -90,3 +90,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.1.32/tools.html
+++ b/archive/v0.1.32/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.32/web-services.html
+++ b/archive/v0.1.32/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/auto-redrawing.html
+++ b/archive/v0.1.33/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/benchmarks.html
+++ b/archive/v0.1.33/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/change-log.html
+++ b/archive/v0.1.33/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -497,7 +500,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/community.html
+++ b/archive/v0.1.33/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -80,7 +83,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/comparison.html
+++ b/archive/v0.1.33/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/comparisons/angular.rendering.html
+++ b/archive/v0.1.33/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.33/comparisons/angular.safety.html
+++ b/archive/v0.1.33/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.33/components.html
+++ b/archive/v0.1.33/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/getting-started.html
+++ b/archive/v0.1.33/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -497,7 +500,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/how-to-read-signatures.html
+++ b/archive/v0.1.33/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -200,7 +203,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/index.html
+++ b/archive/v0.1.33/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.33/installation.html
+++ b/archive/v0.1.33/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/integration.html
+++ b/archive/v0.1.33/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.computation.html
+++ b/archive/v0.1.33/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.deferred.html
+++ b/archive/v0.1.33/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.deps.html
+++ b/archive/v0.1.33/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.html
+++ b/archive/v0.1.33/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -544,7 +547,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.module.html
+++ b/archive/v0.1.33/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -207,7 +210,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.prop.html
+++ b/archive/v0.1.33/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -192,7 +195,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.redraw.html
+++ b/archive/v0.1.33/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.render.html
+++ b/archive/v0.1.33/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -182,7 +185,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.request.html
+++ b/archive/v0.1.33/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -463,10 +466,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -475,10 +478,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -509,7 +512,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -554,7 +557,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -569,7 +572,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.route.html
+++ b/archive/v0.1.33/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -212,7 +215,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -363,7 +366,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.sync.html
+++ b/archive/v0.1.33/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -123,7 +126,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.trust.html
+++ b/archive/v0.1.33/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.withAttr.html
+++ b/archive/v0.1.33/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -138,7 +141,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/mithril.xhr.html
+++ b/archive/v0.1.33/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/optimizing-performance.html
+++ b/archive/v0.1.33/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/practices.html
+++ b/archive/v0.1.33/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/refactoring.html
+++ b/archive/v0.1.33/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/roadmap.html
+++ b/archive/v0.1.33/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/routing.html
+++ b/archive/v0.1.33/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/style.css
+++ b/archive/v0.1.33/style.css
@@ -97,3 +97,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.33/style.css
+++ b/archive/v0.1.33/style.css
@@ -90,3 +90,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.1.33/tools.html
+++ b/archive/v0.1.33/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.33/web-services.html
+++ b/archive/v0.1.33/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/auto-redrawing.html
+++ b/archive/v0.1.34/auto-redrawing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/benchmarks.html
+++ b/archive/v0.1.34/benchmarks.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -90,7 +93,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/change-log.html
+++ b/archive/v0.1.34/change-log.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -503,7 +506,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/community.html
+++ b/archive/v0.1.34/community.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -80,7 +83,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/comparison.html
+++ b/archive/v0.1.34/comparison.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/comparisons/angular.rendering.html
+++ b/archive/v0.1.34/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.34/comparisons/angular.safety.html
+++ b/archive/v0.1.34/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.34/components.html
+++ b/archive/v0.1.34/components.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -244,7 +247,7 @@ m.module(document.body, dashboard);
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/getting-started.html
+++ b/archive/v0.1.34/getting-started.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -498,7 +501,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/how-to-read-signatures.html
+++ b/archive/v0.1.34/how-to-read-signatures.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -200,7 +203,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/index.html
+++ b/archive/v0.1.34/index.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -35,7 +38,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 				</div>
 			</section>
 			
@@ -190,11 +193,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -251,14 +254,14 @@ m.module(document.getElementById("example"), app);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Mithril: The newest JavaScript MVC library 3Kb. <a href="http://twitter.com/LeoHorie">@LeoHorie</a> got it right: It's all about good guides/docs: <a href="http://lhorie.github.io/mithril/comparison.html">lhorie.github.io/mithril/comparison.html</a></p> &mdash; David Corbacho (@dcorbacho) <a href="https://twitter.com/dcorbacho/status/446926407843991552">March 21, 2014</a></blockquote>
 						
-						<script async src="https://platform.twitter.com/widgets.js"></script>
+						<script async="" src="https://platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.34/installation.html
+++ b/archive/v0.1.34/installation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -116,7 +119,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/integration.html
+++ b/archive/v0.1.34/integration.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -154,7 +157,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.computation.html
+++ b/archive/v0.1.34/mithril.computation.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.deferred.html
+++ b/archive/v0.1.34/mithril.deferred.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -270,7 +273,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.deps.html
+++ b/archive/v0.1.34/mithril.deps.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.html
+++ b/archive/v0.1.34/mithril.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -544,7 +547,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.module.html
+++ b/archive/v0.1.34/mithril.module.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.module - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -207,7 +210,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.prop.html
+++ b/archive/v0.1.34/mithril.prop.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -192,7 +195,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.redraw.html
+++ b/archive/v0.1.34/mithril.redraw.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.render.html
+++ b/archive/v0.1.34/mithril.render.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -182,7 +185,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.request.html
+++ b/archive/v0.1.34/mithril.request.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -426,7 +429,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -463,10 +466,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -475,10 +478,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -509,7 +512,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -554,7 +557,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -569,7 +572,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.route.html
+++ b/archive/v0.1.34/mithril.route.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -212,7 +215,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -363,7 +366,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.sync.html
+++ b/archive/v0.1.34/mithril.sync.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -123,7 +126,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.trust.html
+++ b/archive/v0.1.34/mithril.trust.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.withAttr.html
+++ b/archive/v0.1.34/mithril.withAttr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -138,7 +141,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/mithril.xhr.html
+++ b/archive/v0.1.34/mithril.xhr.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/optimizing-performance.html
+++ b/archive/v0.1.34/optimizing-performance.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -114,7 +117,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/practices.html
+++ b/archive/v0.1.34/practices.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -110,7 +113,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/refactoring.html
+++ b/archive/v0.1.34/refactoring.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/roadmap.html
+++ b/archive/v0.1.34/roadmap.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/routing.html
+++ b/archive/v0.1.34/routing.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -126,7 +129,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/style.css
+++ b/archive/v0.1.34/style.css
@@ -97,3 +97,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.34/style.css
+++ b/archive/v0.1.34/style.css
@@ -90,3 +90,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.1.34/tools.html
+++ b/archive/v0.1.34/tools.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.34/web-services.html
+++ b/archive/v0.1.34/web-services.html
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -223,7 +226,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/auto-redrawing.html
+++ b/archive/v0.1.4/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/change-log.html
+++ b/archive/v0.1.4/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -134,7 +137,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/community.html
+++ b/archive/v0.1.4/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -60,7 +63,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/comparison.html
+++ b/archive/v0.1.4/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/comparisons/angular.rendering.html
+++ b/archive/v0.1.4/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.4/comparisons/angular.safety.html
+++ b/archive/v0.1.4/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.4/compiling-templates.html
+++ b/archive/v0.1.4/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/components.html
+++ b/archive/v0.1.4/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/getting-started.html
+++ b/archive/v0.1.4/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/how-to-read-signatures.html
+++ b/archive/v0.1.4/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/index.html
+++ b/archive/v0.1.4/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.4/installation.html
+++ b/archive/v0.1.4/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/integration.html
+++ b/archive/v0.1.4/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.computation.html
+++ b/archive/v0.1.4/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.deferred.html
+++ b/archive/v0.1.4/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.html
+++ b/archive/v0.1.4/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.module.html
+++ b/archive/v0.1.4/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.prop.html
+++ b/archive/v0.1.4/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.redraw.html
+++ b/archive/v0.1.4/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.render.html
+++ b/archive/v0.1.4/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.request.html
+++ b/archive/v0.1.4/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -262,7 +265,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -270,10 +273,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -282,10 +285,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -312,7 +315,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -347,7 +350,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.route.html
+++ b/archive/v0.1.4/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.sync.html
+++ b/archive/v0.1.4/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.trust.html
+++ b/archive/v0.1.4/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.withAttr.html
+++ b/archive/v0.1.4/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/mithril.xhr.html
+++ b/archive/v0.1.4/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/practices.html
+++ b/archive/v0.1.4/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/refactoring.html
+++ b/archive/v0.1.4/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/roadmap.html
+++ b/archive/v0.1.4/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/routing.html
+++ b/archive/v0.1.4/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/style.css
+++ b/archive/v0.1.4/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.4/style.css
+++ b/archive/v0.1.4/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.4/tools.html
+++ b/archive/v0.1.4/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.4/web-services.html
+++ b/archive/v0.1.4/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/auto-redrawing.html
+++ b/archive/v0.1.5/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/change-log.html
+++ b/archive/v0.1.5/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -144,7 +147,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/community.html
+++ b/archive/v0.1.5/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/comparison.html
+++ b/archive/v0.1.5/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/comparisons/angular.rendering.html
+++ b/archive/v0.1.5/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.5/comparisons/angular.safety.html
+++ b/archive/v0.1.5/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.5/compiling-templates.html
+++ b/archive/v0.1.5/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/components.html
+++ b/archive/v0.1.5/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/getting-started.html
+++ b/archive/v0.1.5/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/how-to-read-signatures.html
+++ b/archive/v0.1.5/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/index.html
+++ b/archive/v0.1.5/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.5/installation.html
+++ b/archive/v0.1.5/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/integration.html
+++ b/archive/v0.1.5/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.computation.html
+++ b/archive/v0.1.5/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.deferred.html
+++ b/archive/v0.1.5/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.html
+++ b/archive/v0.1.5/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.module.html
+++ b/archive/v0.1.5/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.prop.html
+++ b/archive/v0.1.5/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.redraw.html
+++ b/archive/v0.1.5/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.render.html
+++ b/archive/v0.1.5/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.request.html
+++ b/archive/v0.1.5/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -262,7 +265,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -270,10 +273,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -282,10 +285,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -312,7 +315,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -347,7 +350,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.route.html
+++ b/archive/v0.1.5/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.sync.html
+++ b/archive/v0.1.5/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.trust.html
+++ b/archive/v0.1.5/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.withAttr.html
+++ b/archive/v0.1.5/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/mithril.xhr.html
+++ b/archive/v0.1.5/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/practices.html
+++ b/archive/v0.1.5/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/refactoring.html
+++ b/archive/v0.1.5/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/roadmap.html
+++ b/archive/v0.1.5/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/routing.html
+++ b/archive/v0.1.5/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/style.css
+++ b/archive/v0.1.5/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.5/style.css
+++ b/archive/v0.1.5/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.5/tools.html
+++ b/archive/v0.1.5/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.5/web-services.html
+++ b/archive/v0.1.5/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/auto-redrawing.html
+++ b/archive/v0.1.6/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/change-log.html
+++ b/archive/v0.1.6/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/community.html
+++ b/archive/v0.1.6/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/comparison.html
+++ b/archive/v0.1.6/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/comparisons/angular.rendering.html
+++ b/archive/v0.1.6/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.6/comparisons/angular.safety.html
+++ b/archive/v0.1.6/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.6/compiling-templates.html
+++ b/archive/v0.1.6/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/components.html
+++ b/archive/v0.1.6/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/getting-started.html
+++ b/archive/v0.1.6/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/how-to-read-signatures.html
+++ b/archive/v0.1.6/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/index.html
+++ b/archive/v0.1.6/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.6/installation.html
+++ b/archive/v0.1.6/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/integration.html
+++ b/archive/v0.1.6/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.computation.html
+++ b/archive/v0.1.6/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.deferred.html
+++ b/archive/v0.1.6/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.html
+++ b/archive/v0.1.6/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.module.html
+++ b/archive/v0.1.6/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.prop.html
+++ b/archive/v0.1.6/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.redraw.html
+++ b/archive/v0.1.6/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.render.html
+++ b/archive/v0.1.6/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.request.html
+++ b/archive/v0.1.6/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -262,7 +265,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -270,10 +273,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -282,10 +285,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -312,7 +315,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -347,7 +350,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.route.html
+++ b/archive/v0.1.6/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.sync.html
+++ b/archive/v0.1.6/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.trust.html
+++ b/archive/v0.1.6/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.withAttr.html
+++ b/archive/v0.1.6/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/mithril.xhr.html
+++ b/archive/v0.1.6/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/practices.html
+++ b/archive/v0.1.6/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/refactoring.html
+++ b/archive/v0.1.6/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/roadmap.html
+++ b/archive/v0.1.6/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/routing.html
+++ b/archive/v0.1.6/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/style.css
+++ b/archive/v0.1.6/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.6/style.css
+++ b/archive/v0.1.6/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.6/tools.html
+++ b/archive/v0.1.6/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.6/web-services.html
+++ b/archive/v0.1.6/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/auto-redrawing.html
+++ b/archive/v0.1.7/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/change-log.html
+++ b/archive/v0.1.7/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -160,7 +163,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/community.html
+++ b/archive/v0.1.7/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/comparison.html
+++ b/archive/v0.1.7/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/comparisons/angular.rendering.html
+++ b/archive/v0.1.7/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.7/comparisons/angular.safety.html
+++ b/archive/v0.1.7/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.7/compiling-templates.html
+++ b/archive/v0.1.7/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/components.html
+++ b/archive/v0.1.7/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/getting-started.html
+++ b/archive/v0.1.7/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/how-to-read-signatures.html
+++ b/archive/v0.1.7/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/index.html
+++ b/archive/v0.1.7/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.7/installation.html
+++ b/archive/v0.1.7/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/integration.html
+++ b/archive/v0.1.7/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.computation.html
+++ b/archive/v0.1.7/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.deferred.html
+++ b/archive/v0.1.7/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.html
+++ b/archive/v0.1.7/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.module.html
+++ b/archive/v0.1.7/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.prop.html
+++ b/archive/v0.1.7/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.redraw.html
+++ b/archive/v0.1.7/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.render.html
+++ b/archive/v0.1.7/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.request.html
+++ b/archive/v0.1.7/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -262,7 +265,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -270,10 +273,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -282,10 +285,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -312,7 +315,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -347,7 +350,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.route.html
+++ b/archive/v0.1.7/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.sync.html
+++ b/archive/v0.1.7/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.trust.html
+++ b/archive/v0.1.7/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.withAttr.html
+++ b/archive/v0.1.7/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/mithril.xhr.html
+++ b/archive/v0.1.7/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/practices.html
+++ b/archive/v0.1.7/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/refactoring.html
+++ b/archive/v0.1.7/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/roadmap.html
+++ b/archive/v0.1.7/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/routing.html
+++ b/archive/v0.1.7/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/style.css
+++ b/archive/v0.1.7/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.7/style.css
+++ b/archive/v0.1.7/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.7/tools.html
+++ b/archive/v0.1.7/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.7/web-services.html
+++ b/archive/v0.1.7/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/auto-redrawing.html
+++ b/archive/v0.1.8/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/change-log.html
+++ b/archive/v0.1.8/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -170,7 +173,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/community.html
+++ b/archive/v0.1.8/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/comparison.html
+++ b/archive/v0.1.8/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/comparisons/angular.rendering.html
+++ b/archive/v0.1.8/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.8/comparisons/angular.safety.html
+++ b/archive/v0.1.8/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.8/compiling-templates.html
+++ b/archive/v0.1.8/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/components.html
+++ b/archive/v0.1.8/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/getting-started.html
+++ b/archive/v0.1.8/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/how-to-read-signatures.html
+++ b/archive/v0.1.8/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/index.html
+++ b/archive/v0.1.8/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -161,10 +164,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -188,7 +191,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.8/installation.html
+++ b/archive/v0.1.8/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/integration.html
+++ b/archive/v0.1.8/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.computation.html
+++ b/archive/v0.1.8/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.deferred.html
+++ b/archive/v0.1.8/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.html
+++ b/archive/v0.1.8/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.module.html
+++ b/archive/v0.1.8/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.prop.html
+++ b/archive/v0.1.8/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.redraw.html
+++ b/archive/v0.1.8/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.render.html
+++ b/archive/v0.1.8/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.request.html
+++ b/archive/v0.1.8/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -262,7 +265,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -270,10 +273,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -282,10 +285,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -312,7 +315,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -347,7 +350,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.route.html
+++ b/archive/v0.1.8/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.sync.html
+++ b/archive/v0.1.8/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.trust.html
+++ b/archive/v0.1.8/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.withAttr.html
+++ b/archive/v0.1.8/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/mithril.xhr.html
+++ b/archive/v0.1.8/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/practices.html
+++ b/archive/v0.1.8/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/refactoring.html
+++ b/archive/v0.1.8/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/roadmap.html
+++ b/archive/v0.1.8/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/routing.html
+++ b/archive/v0.1.8/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/style.css
+++ b/archive/v0.1.8/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.8/style.css
+++ b/archive/v0.1.8/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.8/tools.html
+++ b/archive/v0.1.8/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.8/web-services.html
+++ b/archive/v0.1.8/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/auto-redrawing.html
+++ b/archive/v0.1.9/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -131,7 +134,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/change-log.html
+++ b/archive/v0.1.9/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -189,7 +192,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/community.html
+++ b/archive/v0.1.9/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -64,7 +67,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/comparison.html
+++ b/archive/v0.1.9/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -121,7 +124,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/comparisons/angular.rendering.html
+++ b/archive/v0.1.9/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1.9/comparisons/angular.safety.html
+++ b/archive/v0.1.9/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1.9/compiling-templates.html
+++ b/archive/v0.1.9/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -103,7 +106,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/components.html
+++ b/archive/v0.1.9/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/getting-started.html
+++ b/archive/v0.1.9/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -439,7 +442,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/how-to-read-signatures.html
+++ b/archive/v0.1.9/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -146,7 +149,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/index.html
+++ b/archive/v0.1.9/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -92,8 +95,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -121,7 +124,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -163,11 +166,11 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -191,7 +194,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1.9/installation.html
+++ b/archive/v0.1.9/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -106,7 +109,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/integration.html
+++ b/archive/v0.1.9/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.computation.html
+++ b/archive/v0.1.9/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -163,7 +166,7 @@ m.endComputation()</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.deferred.html
+++ b/archive/v0.1.9/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -155,7 +158,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.html
+++ b/archive/v0.1.9/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -282,7 +285,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.module.html
+++ b/archive/v0.1.9/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -168,7 +171,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.prop.html
+++ b/archive/v0.1.9/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -139,7 +142,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.redraw.html
+++ b/archive/v0.1.9/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.render.html
+++ b/archive/v0.1.9/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -150,7 +153,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.request.html
+++ b/archive/v0.1.9/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>any unwrapSuccess(any data)</strong> (optional)</p>
@@ -280,10 +283,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -292,10 +295,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -326,7 +329,7 @@ where:
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is <code>function(xhr, options) {return xhr.responseText}</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -361,7 +364,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.route.html
+++ b/archive/v0.1.9/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -123,7 +126,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -214,7 +217,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.sync.html
+++ b/archive/v0.1.9/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -87,7 +90,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -104,7 +107,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.trust.html
+++ b/archive/v0.1.9/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.withAttr.html
+++ b/archive/v0.1.9/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/mithril.xhr.html
+++ b/archive/v0.1.9/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -69,7 +72,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/practices.html
+++ b/archive/v0.1.9/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/refactoring.html
+++ b/archive/v0.1.9/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -56,7 +59,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/roadmap.html
+++ b/archive/v0.1.9/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -96,7 +99,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/routing.html
+++ b/archive/v0.1.9/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -120,7 +123,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/style.css
+++ b/archive/v0.1.9/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1.9/style.css
+++ b/archive/v0.1.9/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1.9/tools.html
+++ b/archive/v0.1.9/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1.9/web-services.html
+++ b/archive/v0.1.9/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -16,7 +16,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -205,7 +208,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/auto-redrawing.html
+++ b/archive/v0.1/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -129,7 +132,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/change-log.html
+++ b/archive/v0.1/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -70,7 +73,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/comparison.html
+++ b/archive/v0.1/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -119,7 +122,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/comparisons/angular.rendering.html
+++ b/archive/v0.1/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.1/comparisons/angular.safety.html
+++ b/archive/v0.1/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.1/compiling-templates.html
+++ b/archive/v0.1/compiling-templates.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -101,7 +104,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/components.html
+++ b/archive/v0.1/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -182,7 +185,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/getting-started.html
+++ b/archive/v0.1/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -437,7 +440,7 @@ this.description = function(value) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/how-to-read-signatures.html
+++ b/archive/v0.1/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -145,7 +148,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })</
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/index.html
+++ b/archive/v0.1/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -91,8 +94,8 @@ m.module(document.getElementById("example"), app);</code></pre>
 						<div id="example" class="example output">
 							<noscript>
 								<a href="getting-started.html">Getting Started</a>
-								<a href="mithril.html">Documentation</a></div>
-							</noscript>
+								<a href="mithril.html">Documentation</a></noscript></div>
+							
 							<script src="mithril.min.js"></script>
 							<script>
 //namespace
@@ -120,7 +123,7 @@ m.module(document.getElementById("example"), app);
 							</script>
 						</div>
 					</div>
-				</div>
+				
 			</section>
 
 			<section class="performance">
@@ -160,10 +163,10 @@ m.module(document.getElementById("example"), app);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -187,7 +190,7 @@ m.module(document.getElementById("example"), app);
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.1/integration.html
+++ b/archive/v0.1/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -138,7 +141,7 @@ m.module(document.body, dashboard);</code></pre>
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.computation.html
+++ b/archive/v0.1/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -151,7 +154,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.deferred.html
+++ b/archive/v0.1/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -128,7 +131,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.html
+++ b/archive/v0.1/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ m(&quot;a[href=&#39;/dashboard&#39;]&quot;, {config: m.route}, &quot;Dashboard&q
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.module.html
+++ b/archive/v0.1/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.prop.html
+++ b/archive/v0.1/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -132,7 +135,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.redraw.html
+++ b/archive/v0.1/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.render.html
+++ b/archive/v0.1/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -113,7 +116,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.request.html
+++ b/archive/v0.1/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -253,7 +256,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Response unwrapSuccess(Response data)</strong> (optional)</p>
@@ -261,10 +264,10 @@ where:
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -273,10 +276,10 @@ where:
 <p>A preprocessor function to extract the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -303,7 +306,7 @@ where:
 </li>
 </ul>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -338,7 +341,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.route.html
+++ b/archive/v0.1/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Module> routes</strong></p>
+<li><p><strong>Object<module> routes</module></strong></p>
 <p>A key-value map of possible routes and their respective modules. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageModule}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageModule}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -213,7 +216,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.sync.html
+++ b/archive/v0.1/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -86,7 +89,7 @@ where:
     Promise :: GetterSetter { Promise then(any successCallback(any value), any errorCallback(any value)) }
     GetterSetter :: any getterSetter([any value])</code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -103,7 +106,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.trust.html
+++ b/archive/v0.1/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -112,7 +115,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.withAttr.html
+++ b/archive/v0.1/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/mithril.xhr.html
+++ b/archive/v0.1/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -68,7 +71,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/practices.html
+++ b/archive/v0.1/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -109,7 +112,7 @@ app.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/refactoring.html
+++ b/archive/v0.1/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -54,7 +57,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/roadmap.html
+++ b/archive/v0.1/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -95,7 +98,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/routing.html
+++ b/archive/v0.1/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -118,7 +121,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});</code
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/style.css
+++ b/archive/v0.1/style.css
@@ -88,4 +88,10 @@ background-size: 20px 20px;
 @-webkit-keyframes logo {
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
+}.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
 }

--- a/archive/v0.1/style.css
+++ b/archive/v0.1/style.css
@@ -95,3 +95,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.1/tools.html
+++ b/archive/v0.1/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -71,7 +74,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.1/web-services.html
+++ b/archive/v0.1/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<link href="http://fonts.googleapis.com/css?family=Open+Sans:300italic" rel="stylesheet">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -15,7 +15,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -203,7 +206,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/auto-redrawing.html
+++ b/archive/v0.2.0/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/benchmarks.html
+++ b/archive/v0.2.0/benchmarks.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/change-log.html
+++ b/archive/v0.2.0/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -525,7 +528,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/community.html
+++ b/archive/v0.2.0/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/comparison.html
+++ b/archive/v0.2.0/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/comparisons/angular.rendering.html
+++ b/archive/v0.2.0/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.2.0/comparisons/angular.safety.html
+++ b/archive/v0.2.0/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.2.0/components.html
+++ b/archive/v0.2.0/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -548,7 +551,7 @@ var Demo2 = {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/getting-started.html
+++ b/archive/v0.2.0/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -500,7 +503,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/how-to-read-signatures.html
+++ b/archive/v0.2.0/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/index.html
+++ b/archive/v0.2.0/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -36,7 +39,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 					<a class="changelog" href="change-log.html"><small>Change Log</small></a>
 				</div>
 			</section>
@@ -197,11 +200,11 @@ m.mount(document.getElementById("example"), Demo);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -258,14 +261,14 @@ m.mount(document.getElementById("example"), Demo);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Ported my angularjs based WebGL ui editor to mithril and got a big speed boost. <a href="https://twitter.com/hashtag/mithriljs">#<b>mithriljs</b></a> love the small api and docs!</p> &mdash; geekrelief (@geekrelief) <a href="https://twitter.com/geekrelief/status/554214299460435969">January 11, 2015</a></blockquote>
 						
-						<script async src="//platform.twitter.com/widgets.js"></script>
+						<script async="" src="//platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.2.0/installation.html
+++ b/archive/v0.2.0/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/integration.html
+++ b/archive/v0.2.0/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -158,7 +161,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.component.html
+++ b/archive/v0.2.0/mithril.component.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.component - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -561,7 +564,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.computation.html
+++ b/archive/v0.2.0/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.deferred.html
+++ b/archive/v0.2.0/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -272,7 +275,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.deps.html
+++ b/archive/v0.2.0/mithril.deps.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.html
+++ b/archive/v0.2.0/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -550,7 +553,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.module.html
+++ b/archive/v0.2.0/mithril.module.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.mount.html
+++ b/archive/v0.2.0/mithril.mount.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.mount - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -142,7 +145,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.prop.html
+++ b/archive/v0.2.0/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -194,7 +197,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.redraw.html
+++ b/archive/v0.2.0/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -235,7 +238,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.render.html
+++ b/archive/v0.2.0/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.request.html
+++ b/archive/v0.2.0/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -430,7 +433,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -493,10 +496,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,10 +508,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -539,7 +542,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -584,7 +587,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -599,7 +602,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.route.html
+++ b/archive/v0.2.0/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -221,7 +224,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Component> routes</strong></p>
+<li><p><strong>Object<component> routes</component></strong></p>
 <p>A key-value map of possible routes and their respective components. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageComponent}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageComponent}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -378,7 +381,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.sync.html
+++ b/archive/v0.2.0/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -125,7 +128,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.trust.html
+++ b/archive/v0.2.0/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -135,7 +138,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.withAttr.html
+++ b/archive/v0.2.0/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/mithril.xhr.html
+++ b/archive/v0.2.0/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/optimizing-performance.html
+++ b/archive/v0.2.0/optimizing-performance.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/practices.html
+++ b/archive/v0.2.0/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/refactoring.html
+++ b/archive/v0.2.0/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/roadmap.html
+++ b/archive/v0.2.0/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/routing.html
+++ b/archive/v0.2.0/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -127,7 +130,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/style.css
+++ b/archive/v0.2.0/style.css
@@ -98,3 +98,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.2.0/style.css
+++ b/archive/v0.2.0/style.css
@@ -91,3 +91,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.2.0/tools.html
+++ b/archive/v0.2.0/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.0/web-services.html
+++ b/archive/v0.2.0/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="mithril.min.zip">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/auto-redrawing.html
+++ b/archive/v0.2.1/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/benchmarks.html
+++ b/archive/v0.2.1/benchmarks.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/change-log.html
+++ b/archive/v0.2.1/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -541,7 +544,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/community.html
+++ b/archive/v0.2.1/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/comparison.html
+++ b/archive/v0.2.1/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/comparisons/angular.rendering.html
+++ b/archive/v0.2.1/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.2.1/comparisons/angular.safety.html
+++ b/archive/v0.2.1/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.2.1/components.html
+++ b/archive/v0.2.1/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -553,7 +556,7 @@ var Demo2 = {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/getting-started.html
+++ b/archive/v0.2.1/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -501,7 +504,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/how-to-read-signatures.html
+++ b/archive/v0.2.1/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/index.html
+++ b/archive/v0.2.1/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -36,7 +39,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 					<a class="changelog" href="change-log.html"><small>Change Log</small></a>
 				</div>
 			</section>
@@ -197,11 +200,11 @@ m.mount(document.getElementById("example"), Demo);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -258,14 +261,14 @@ m.mount(document.getElementById("example"), Demo);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Ported my angularjs based WebGL ui editor to mithril and got a big speed boost. <a href="https://twitter.com/hashtag/mithriljs">#<b>mithriljs</b></a> love the small api and docs!</p> &mdash; geekrelief (@geekrelief) <a href="https://twitter.com/geekrelief/status/554214299460435969">January 11, 2015</a></blockquote>
 						
-						<script async src="//platform.twitter.com/widgets.js"></script>
+						<script async="" src="//platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.2.1/installation.html
+++ b/archive/v0.2.1/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/integration.html
+++ b/archive/v0.2.1/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.component.html
+++ b/archive/v0.2.1/mithril.component.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.component - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -579,7 +582,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.computation.html
+++ b/archive/v0.2.1/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.deferred.html
+++ b/archive/v0.2.1/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.deps.html
+++ b/archive/v0.2.1/mithril.deps.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.html
+++ b/archive/v0.2.1/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -570,7 +573,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.mount.html
+++ b/archive/v0.2.1/mithril.mount.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.mount - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -142,7 +145,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.prop.html
+++ b/archive/v0.2.1/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -194,7 +197,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.redraw.html
+++ b/archive/v0.2.1/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -235,7 +238,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.render.html
+++ b/archive/v0.2.1/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.request.html
+++ b/archive/v0.2.1/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -430,7 +433,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -493,10 +496,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,10 +508,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -539,7 +542,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -584,7 +587,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -599,7 +602,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.route.html
+++ b/archive/v0.2.1/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -221,7 +224,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Component> routes</strong></p>
+<li><p><strong>Object<component> routes</component></strong></p>
 <p>A key-value map of possible routes and their respective components. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageComponent}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageComponent}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -378,7 +381,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.sync.html
+++ b/archive/v0.2.1/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -125,7 +128,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.trust.html
+++ b/archive/v0.2.1/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -135,7 +138,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.withAttr.html
+++ b/archive/v0.2.1/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -140,7 +143,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/mithril.xhr.html
+++ b/archive/v0.2.1/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/optimizing-performance.html
+++ b/archive/v0.2.1/optimizing-performance.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/practices.html
+++ b/archive/v0.2.1/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/refactoring.html
+++ b/archive/v0.2.1/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/roadmap.html
+++ b/archive/v0.2.1/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/routing.html
+++ b/archive/v0.2.1/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -130,7 +133,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/style.css
+++ b/archive/v0.2.1/style.css
@@ -98,3 +98,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.2.1/style.css
+++ b/archive/v0.2.1/style.css
@@ -91,3 +91,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.2.1/tools.html
+++ b/archive/v0.2.1/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.1/web-services.html
+++ b/archive/v0.2.1/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/auto-redrawing.html
+++ b/archive/v0.2.2-rc.1/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/benchmarks.html
+++ b/archive/v0.2.2-rc.1/benchmarks.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/change-log.html
+++ b/archive/v0.2.2-rc.1/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -546,7 +549,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/community.html
+++ b/archive/v0.2.2-rc.1/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/comparison.html
+++ b/archive/v0.2.2-rc.1/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/comparisons/angular.rendering.html
+++ b/archive/v0.2.2-rc.1/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.2.2-rc.1/comparisons/angular.safety.html
+++ b/archive/v0.2.2-rc.1/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.2.2-rc.1/components.html
+++ b/archive/v0.2.2-rc.1/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -553,7 +556,7 @@ var Demo2 = {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/getting-started.html
+++ b/archive/v0.2.2-rc.1/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -501,7 +504,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/how-to-read-signatures.html
+++ b/archive/v0.2.2-rc.1/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/index.html
+++ b/archive/v0.2.2-rc.1/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -36,7 +39,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 					<a class="changelog" href="change-log.html"><small>Change Log</small></a>
 				</div>
 			</section>
@@ -197,11 +200,11 @@ m.mount(document.getElementById("example"), Demo);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -258,14 +261,14 @@ m.mount(document.getElementById("example"), Demo);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Ported my angularjs based WebGL ui editor to mithril and got a big speed boost. <a href="https://twitter.com/hashtag/mithriljs">#<b>mithriljs</b></a> love the small api and docs!</p> &mdash; geekrelief (@geekrelief) <a href="https://twitter.com/geekrelief/status/554214299460435969">January 11, 2015</a></blockquote>
 						
-						<script async src="//platform.twitter.com/widgets.js"></script>
+						<script async="" src="//platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.2.2-rc.1/installation.html
+++ b/archive/v0.2.2-rc.1/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/integration.html
+++ b/archive/v0.2.2-rc.1/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.component.html
+++ b/archive/v0.2.2-rc.1/mithril.component.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.component - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -579,7 +582,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.computation.html
+++ b/archive/v0.2.2-rc.1/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.deferred.html
+++ b/archive/v0.2.2-rc.1/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.deps.html
+++ b/archive/v0.2.2-rc.1/mithril.deps.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.html
+++ b/archive/v0.2.2-rc.1/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -570,7 +573,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.mount.html
+++ b/archive/v0.2.2-rc.1/mithril.mount.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.mount - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -142,7 +145,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.prop.html
+++ b/archive/v0.2.2-rc.1/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -194,7 +197,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.redraw.html
+++ b/archive/v0.2.2-rc.1/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -235,7 +238,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.render.html
+++ b/archive/v0.2.2-rc.1/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.request.html
+++ b/archive/v0.2.2-rc.1/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -430,7 +433,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -493,10 +496,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,10 +508,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -539,7 +542,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -584,7 +587,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -599,7 +602,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.route.html
+++ b/archive/v0.2.2-rc.1/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -221,7 +224,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Component> routes</strong></p>
+<li><p><strong>Object<component> routes</component></strong></p>
 <p>A key-value map of possible routes and their respective components. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageComponent}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageComponent}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -384,7 +387,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.sync.html
+++ b/archive/v0.2.2-rc.1/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -125,7 +128,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.trust.html
+++ b/archive/v0.2.2-rc.1/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -135,7 +138,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.withAttr.html
+++ b/archive/v0.2.2-rc.1/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -143,7 +146,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/mithril.xhr.html
+++ b/archive/v0.2.2-rc.1/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/optimizing-performance.html
+++ b/archive/v0.2.2-rc.1/optimizing-performance.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/practices.html
+++ b/archive/v0.2.2-rc.1/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/refactoring.html
+++ b/archive/v0.2.2-rc.1/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/roadmap.html
+++ b/archive/v0.2.2-rc.1/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/routing.html
+++ b/archive/v0.2.2-rc.1/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -130,7 +133,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/style.css
+++ b/archive/v0.2.2-rc.1/style.css
@@ -98,3 +98,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.2.2-rc.1/style.css
+++ b/archive/v0.2.2-rc.1/style.css
@@ -91,3 +91,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.2.2-rc.1/tools.html
+++ b/archive/v0.2.2-rc.1/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.2-rc.1/web-services.html
+++ b/archive/v0.2.2-rc.1/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/auto-redrawing.html
+++ b/archive/v0.2.3/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/benchmarks.html
+++ b/archive/v0.2.3/benchmarks.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/change-log.html
+++ b/archive/v0.2.3/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -556,7 +559,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/community.html
+++ b/archive/v0.2.3/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/comparison.html
+++ b/archive/v0.2.3/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/comparisons/angular.rendering.html
+++ b/archive/v0.2.3/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.2.3/comparisons/angular.safety.html
+++ b/archive/v0.2.3/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.2.3/components.html
+++ b/archive/v0.2.3/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -553,7 +556,7 @@ var Demo2 = {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/getting-started.html
+++ b/archive/v0.2.3/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -501,7 +504,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/how-to-read-signatures.html
+++ b/archive/v0.2.3/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/index.html
+++ b/archive/v0.2.3/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -36,7 +39,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 					<a class="changelog" href="change-log.html"><small>Change Log</small></a>
 				</div>
 			</section>
@@ -197,11 +200,11 @@ m.mount(document.getElementById("example"), Demo);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -258,14 +261,14 @@ m.mount(document.getElementById("example"), Demo);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Ported my angularjs based WebGL ui editor to mithril and got a big speed boost. <a href="https://twitter.com/hashtag/mithriljs">#<b>mithriljs</b></a> love the small api and docs!</p> &mdash; geekrelief (@geekrelief) <a href="https://twitter.com/geekrelief/status/554214299460435969">January 11, 2015</a></blockquote>
 						
-						<script async src="//platform.twitter.com/widgets.js"></script>
+						<script async="" src="//platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.2.3/installation.html
+++ b/archive/v0.2.3/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/integration.html
+++ b/archive/v0.2.3/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.component.html
+++ b/archive/v0.2.3/mithril.component.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.component - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -579,7 +582,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.computation.html
+++ b/archive/v0.2.3/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.deferred.html
+++ b/archive/v0.2.3/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.deps.html
+++ b/archive/v0.2.3/mithril.deps.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.html
+++ b/archive/v0.2.3/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -570,7 +573,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.mount.html
+++ b/archive/v0.2.3/mithril.mount.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.mount - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -142,7 +145,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.prop.html
+++ b/archive/v0.2.3/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -194,7 +197,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.redraw.html
+++ b/archive/v0.2.3/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -235,7 +238,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.render.html
+++ b/archive/v0.2.3/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.request.html
+++ b/archive/v0.2.3/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -430,7 +433,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -493,10 +496,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,10 +508,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -539,7 +542,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -584,7 +587,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -599,7 +602,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.route.html
+++ b/archive/v0.2.3/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -221,7 +224,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Component> routes</strong></p>
+<li><p><strong>Object<component> routes</component></strong></p>
 <p>A key-value map of possible routes and their respective components. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageComponent}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageComponent}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -384,7 +387,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.sync.html
+++ b/archive/v0.2.3/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -125,7 +128,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.trust.html
+++ b/archive/v0.2.3/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -135,7 +138,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.withAttr.html
+++ b/archive/v0.2.3/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -143,7 +146,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/mithril.xhr.html
+++ b/archive/v0.2.3/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/optimizing-performance.html
+++ b/archive/v0.2.3/optimizing-performance.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/practices.html
+++ b/archive/v0.2.3/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/refactoring.html
+++ b/archive/v0.2.3/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/roadmap.html
+++ b/archive/v0.2.3/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/routing.html
+++ b/archive/v0.2.3/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -130,7 +133,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/style.css
+++ b/archive/v0.2.3/style.css
@@ -98,3 +98,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.2.3/style.css
+++ b/archive/v0.2.3/style.css
@@ -91,3 +91,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.2.3/tools.html
+++ b/archive/v0.2.3/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.3/web-services.html
+++ b/archive/v0.2.3/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/auto-redrawing.html
+++ b/archive/v0.2.4/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/benchmarks.html
+++ b/archive/v0.2.4/benchmarks.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/change-log.html
+++ b/archive/v0.2.4/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -563,7 +566,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/community.html
+++ b/archive/v0.2.4/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/comparison.html
+++ b/archive/v0.2.4/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/comparisons/angular.rendering.html
+++ b/archive/v0.2.4/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.2.4/comparisons/angular.safety.html
+++ b/archive/v0.2.4/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.2.4/components.html
+++ b/archive/v0.2.4/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -553,7 +556,7 @@ var Demo2 = {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/getting-started.html
+++ b/archive/v0.2.4/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -501,7 +504,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/how-to-read-signatures.html
+++ b/archive/v0.2.4/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/index.html
+++ b/archive/v0.2.4/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -36,7 +39,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 					<a class="changelog" href="change-log.html"><small>Change Log</small></a>
 				</div>
 			</section>
@@ -197,11 +200,11 @@ m.mount(document.getElementById("example"), Demo);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -258,14 +261,14 @@ m.mount(document.getElementById("example"), Demo);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Ported my angularjs based WebGL ui editor to mithril and got a big speed boost. <a href="https://twitter.com/hashtag/mithriljs">#<b>mithriljs</b></a> love the small api and docs!</p> &mdash; geekrelief (@geekrelief) <a href="https://twitter.com/geekrelief/status/554214299460435969">January 11, 2015</a></blockquote>
 						
-						<script async src="//platform.twitter.com/widgets.js"></script>
+						<script async="" src="//platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.2.4/installation.html
+++ b/archive/v0.2.4/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/integration.html
+++ b/archive/v0.2.4/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.component.html
+++ b/archive/v0.2.4/mithril.component.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.component - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -579,7 +582,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.computation.html
+++ b/archive/v0.2.4/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.deferred.html
+++ b/archive/v0.2.4/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.deps.html
+++ b/archive/v0.2.4/mithril.deps.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.html
+++ b/archive/v0.2.4/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -570,7 +573,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.mount.html
+++ b/archive/v0.2.4/mithril.mount.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.mount - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -142,7 +145,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.prop.html
+++ b/archive/v0.2.4/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -194,7 +197,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.redraw.html
+++ b/archive/v0.2.4/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -235,7 +238,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.render.html
+++ b/archive/v0.2.4/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.request.html
+++ b/archive/v0.2.4/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -430,7 +433,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -493,10 +496,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -505,10 +508,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -539,7 +542,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -584,7 +587,7 @@ demo.view = function(ctrl) {
 <p>The name of the querystring key that defines the name of the callback function to be called by the response. Defaults to &quot;callback&quot;</p>
 <p>This option is useful for web services that use uncommon conventions for defining jsonp callbacks (e.g. foo.com/?jsonpCallback=doSomething)</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -599,7 +602,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.route.html
+++ b/archive/v0.2.4/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -221,7 +224,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Component> routes</strong></p>
+<li><p><strong>Object<component> routes</component></strong></p>
 <p>A key-value map of possible routes and their respective components. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageComponent}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageComponent}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -384,7 +387,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.sync.html
+++ b/archive/v0.2.4/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -125,7 +128,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.trust.html
+++ b/archive/v0.2.4/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -135,7 +138,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.withAttr.html
+++ b/archive/v0.2.4/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -143,7 +146,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/mithril.xhr.html
+++ b/archive/v0.2.4/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/optimizing-performance.html
+++ b/archive/v0.2.4/optimizing-performance.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/practices.html
+++ b/archive/v0.2.4/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/refactoring.html
+++ b/archive/v0.2.4/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/roadmap.html
+++ b/archive/v0.2.4/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/routing.html
+++ b/archive/v0.2.4/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -130,7 +133,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/style.css
+++ b/archive/v0.2.4/style.css
@@ -98,3 +98,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.2.4/style.css
+++ b/archive/v0.2.4/style.css
@@ -91,3 +91,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.2.4/tools.html
+++ b/archive/v0.2.4/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.4/web-services.html
+++ b/archive/v0.2.4/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/auto-redrawing.html
+++ b/archive/v0.2.5/auto-redrawing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>The Auto-Redrawing System - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -152,7 +155,7 @@ var doBoth = function(callback) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/benchmarks.html
+++ b/archive/v0.2.5/benchmarks.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Benchmarks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -91,7 +94,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/change-log.html
+++ b/archive/v0.2.5/change-log.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Change Log - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -576,7 +579,7 @@ m.request({method: &quot;GET&quot;, url: &quot;http://foo.com/api&quot;, config:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/community.html
+++ b/archive/v0.2.5/community.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Community - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -81,7 +84,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/comparison.html
+++ b/archive/v0.2.5/comparison.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How is Mithril Different from Other Frameworks - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -122,7 +125,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/comparisons/angular.rendering.html
+++ b/archive/v0.2.5/comparisons/angular.rendering.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<p>To run an execution time test on this page, run the profiler from your browser's developer tools and measure the running time of a page refresh. (Lower is better)</p>

--- a/archive/v0.2.5/comparisons/angular.safety.html
+++ b/archive/v0.2.5/comparisons/angular.safety.html
@@ -1,4 +1,4 @@
-<html ng-app>
+<html ng-app="">
 	<head><script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.2.10/angular.min.js"></script></head>
 	<body ng-controller="TestCtrl">
 		<div id="container">

--- a/archive/v0.2.5/components.html
+++ b/archive/v0.2.5/components.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Components - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -553,7 +556,7 @@ var Demo2 = {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/getting-started.html
+++ b/archive/v0.2.5/getting-started.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Getting Started - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -501,7 +504,7 @@ this.description(data.description)
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/how-to-read-signatures.html
+++ b/archive/v0.2.5/how-to-read-signatures.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How to Read Signatures - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -202,7 +205,7 @@ test({ first: &quot;first&quot;, config: function(element) { /*do stuff*/ } })
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/index.html
+++ b/archive/v0.2.5/index.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		
 		<main>
 			<section class="cta">
@@ -36,7 +39,7 @@
 					<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://lhorie.github.io/mithril" data-via="LeoHorie">Tweet</a>
 					<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src='//platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 					
-					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0" /></a>
+					<a href="http://flattr.com/thing/2778375/lhoriemithril-js-on-GitHub" target="_blank"><img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr" title="Flattr" border="0"></a>
 					<a class="changelog" href="change-log.html"><small>Change Log</small></a>
 				</div>
 			</section>
@@ -197,11 +200,11 @@ m.mount(document.getElementById("example"), Demo);
 						</div>
 						<div class="col(4,4,12)">
 							<h3>Test Summary</h3>
-							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br />
-							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br />
-							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br />
+							<a href="comparisons/mithril.safety.html">Mithril</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/jquery.safety.html">jQuery</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/backbone.safety.html">Backbone</a> <em class="error">(fail) &#x2717;</em><br>
+							<a href="comparisons/angular.safety.html">Angular</a> <em class="success">(pass) &#x2713;</em><br>
+							<a href="comparisons/react.safety.html">React</a> <em class="success">(pass) &#x2713;</em><br>
 						</div>
 					</div>
 				</div>
@@ -258,14 +261,14 @@ m.mount(document.getElementById("example"), Demo);
 						
 						<blockquote class="twitter-tweet" lang="en"><p>Ported my angularjs based WebGL ui editor to mithril and got a big speed boost. <a href="https://twitter.com/hashtag/mithriljs">#<b>mithriljs</b></a> love the small api and docs!</p> &mdash; geekrelief (@geekrelief) <a href="https://twitter.com/geekrelief/status/554214299460435969">January 11, 2015</a></blockquote>
 						
-						<script async src="//platform.twitter.com/widgets.js"></script>
+						<script async="" src="//platform.twitter.com/widgets.js"></script>
 					</div>
 				</div>
 			</section>
 		</main>
 		<footer>
 			<div class="container">
-				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br />
+				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a><br>
 				&copy; 2014 Leo Horie
 			</div>
 		</footer>

--- a/archive/v0.2.5/installation.html
+++ b/archive/v0.2.5/installation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Installation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -117,7 +120,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/integration.html
+++ b/archive/v0.2.5/integration.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Integrating with Other Libraries - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -167,7 +170,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.component.html
+++ b/archive/v0.2.5/mithril.component.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.component - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -579,7 +582,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.computation.html
+++ b/archive/v0.2.5/mithril.computation.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.startComputation / m.endComputation - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -285,7 +288,7 @@ m.endComputation()
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.deferred.html
+++ b/archive/v0.2.5/mithril.deferred.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deferred - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -273,7 +276,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.deps.html
+++ b/archive/v0.2.5/mithril.deps.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.deps - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -133,7 +136,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.html
+++ b/archive/v0.2.5/mithril.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -570,7 +573,7 @@ m.render(document, m(&quot;a&quot;)); //logs `unloaded the div` and `alert` neve
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.mount.html
+++ b/archive/v0.2.5/mithril.mount.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.mount - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -142,7 +145,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.prop.html
+++ b/archive/v0.2.5/mithril.prop.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.prop - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -194,7 +197,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.redraw.html
+++ b/archive/v0.2.5/mithril.redraw.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.redraw - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -235,7 +238,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.render.html
+++ b/archive/v0.2.5/mithril.render.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.render - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -184,7 +187,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.request.html
+++ b/archive/v0.2.5/mithril.request.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.request - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -432,7 +435,7 @@ where:
 <li><p><strong>String password</strong> (optional)</p>
 <p>A password for HTTP authentication. Defaults to <code>undefined</code></p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 <li><p><strong>Boolean background</strong> (optional)</p>
@@ -495,10 +498,10 @@ demo.view = function(ctrl) {
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <p>For example, if the response is <code>{data: [{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]}</code> and the unwrap function is <code>function(response) {return response.data}</code>, then the response will be considered to be <code>[{name: &quot;John&quot;}, {name: &quot;Mary&quot;}]</code> when processing the <code>type</code> parameter</p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -507,10 +510,10 @@ demo.view = function(ctrl) {
 <p>A preprocessor function to unwrap the data from an error response in case the response contains metadata wrapping the data.</p>
 <p>The default value (if this parameter is falsy) is the identity function <code>function(value) {return value}</code></p>
 <ul>
-<li><p><strong>Object<any> | Array<any> data</strong></p>
+<li><p><strong>Object<any> | Array<any> data</any></any></strong></p>
 <p>The data to unwrap</p>
 </li>
-<li><p><strong>returns Object<any> | Array<any> unwrappedData</strong></p>
+<li><p><strong>returns Object<any> | Array<any> unwrappedData</any></any></strong></p>
 <p>The unwrapped data</p>
 </li>
 </ul>
@@ -541,7 +544,7 @@ demo.view = function(ctrl) {
 <p>Method to use to extract the data from the raw XMLHttpRequest. This is useful when the relevant data is either in a response header or the status field.</p>
 <p>If this parameter is falsy, the default value is a function that returns <code>xhr.responseText</code>.</p>
 </li>
-<li><p><strong>void type(Object<any> data)</strong> (optional)</p>
+<li><p><strong>void type(Object<any> data)</any></strong> (optional)</p>
 <p>The response object (or the child items if this object is an Array) will be passed as a parameter to the class constructor defined by <code>type</code></p>
 <p>If this parameter is falsy, the deserialized data will not be wrapped.</p>
 <p>For example, if <code>type</code> is the following class:</p>
@@ -590,7 +593,7 @@ demo.view = function(ctrl) {
 <p>The name of callback function to be called by the response. Defaults to a unique auto-generated name</p>
 <p>This option is useful for web services serving static files and to prevent cache busting.</p>
 </li>
-<li><p><strong>Object<any> data</strong> (optional)</p>
+<li><p><strong>Object<any> data</any></strong> (optional)</p>
 <p>Data to be sent. It&#39;s automatically placed in the appropriate section of the request with the appropriate serialization based on <code>method</code></p>
 </li>
 </ul>
@@ -605,7 +608,7 @@ demo.view = function(ctrl) {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.route.html
+++ b/archive/v0.2.5/mithril.route.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.route - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -221,7 +224,7 @@ where:
 <li><p><strong>String defaultRoute</strong></p>
 <p>The route to redirect to if the current URL does not match any of the defined routes</p>
 </li>
-<li><p><strong>Object<Component> routes</strong></p>
+<li><p><strong>Object<component> routes</component></strong></p>
 <p>A key-value map of possible routes and their respective components. Keys are expected to be absolute pathnames, but can include dynamic parameters. Dynamic parameters are words preceded by a colon <code>:</code></p>
 <p><code>{&#39;/path/to/page/&#39;: pageComponent}</code> - a route with a basic pathname</p>
 <p><code>{&#39;/path/to/page/:id&#39;: pageComponent}</code> - a route with a pathname that contains a dynamic parameter called <code>id</code>. This route would be selected if the URL was <code>/path/to/page/1</code>, <code>/path/to/page/test</code>, etc</p>
@@ -384,7 +387,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.sync.html
+++ b/archive/v0.2.5/mithril.sync.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.sync - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -108,7 +111,7 @@ where:
     GetterSetter :: any getterSetter([any value])
 </code></pre>
 <ul>
-<li><p><strong>Array<Promise> promises</strong></p>
+<li><p><strong>Array<promise> promises</promise></strong></p>
 <p>A list of promises to synchronize</p>
 </li>
 <li><p><strong>return Promise promise</strong></p>
@@ -125,7 +128,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.trust.html
+++ b/archive/v0.2.5/mithril.trust.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.trust - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -135,7 +138,7 @@ m.render(&quot;body&quot;, [
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.withAttr.html
+++ b/archive/v0.2.5/mithril.withAttr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>m.withAttr - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -143,7 +146,7 @@ where:
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/mithril.xhr.html
+++ b/archive/v0.2.5/mithril.xhr.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -88,7 +91,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/optimizing-performance.html
+++ b/archive/v0.2.5/optimizing-performance.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Optimizing Performance - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -82,7 +85,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/practices.html
+++ b/archive/v0.2.5/practices.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>How Should Code Be Organized - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -111,7 +114,7 @@ app.view = function() {
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/refactoring.html
+++ b/archive/v0.2.5/refactoring.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -55,7 +58,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/roadmap.html
+++ b/archive/v0.2.5/roadmap.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Roadmap - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -115,7 +118,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/routing.html
+++ b/archive/v0.2.5/routing.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Routing - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -130,7 +133,7 @@ m(&quot;a[href=&#39;/dashboard/alicesmith&#39;]&quot;, {config: m.route});
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/style.css
+++ b/archive/v0.2.5/style.css
@@ -98,3 +98,9 @@ background-size: 20px 20px;
     background: #F00;
     color: #FFF;
 }
+.deprecated a {
+	padding: 5px;
+	background: #800;
+	color: #FFF;
+	border-radius: 5px;
+}

--- a/archive/v0.2.5/style.css
+++ b/archive/v0.2.5/style.css
@@ -91,3 +91,10 @@ background-size: 20px 20px;
 	from {opacity:0;-webkit-transform:scale(2) rotate(359deg);}
 	to {opacity:1;-webkit-transform:scale(1) rotate(0deg);}
 }
+.deprecated {
+    padding: 15px 10px;
+    text-align: center;
+    font-weight: bold;
+    background: #F00;
+    color: #FFF;
+}

--- a/archive/v0.2.5/tools.html
+++ b/archive/v0.2.5/tools.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Tools - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -104,7 +107,7 @@
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>

--- a/archive/v0.2.5/web-services.html
+++ b/archive/v0.2.5/web-services.html
@@ -2,9 +2,9 @@
 <html>
 	<head>
 		<title>Web Services - Mithril</title>
-		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications" />
-		<link href="lib/prism/prism.css" rel="stylesheet" />
-		<link href="style.css" rel="stylesheet" />
+		<meta name="description" value="Mithril.js - a Javascript Framework for Building Brilliant Applications">
+		<link href="lib/prism/prism.css" rel="stylesheet">
+		<link href="style.css" rel="stylesheet">
 	</head>
 	<body>
 		<header>
@@ -17,7 +17,10 @@
 				<a href="installation.html">Download</a>
 				<a href="http://github.com/lhorie/mithril.js" target="_blank">Github</a>
 			</nav>
-		</header>
+		<div class="deprecated">
+    WARNING: This documentation is for an old version of mithril!
+    Please see the <a href="https://mithril.js.org/">current docs</a> for more accurate info.
+</div></header>
 		<main>
 			<section class="content">
 				<div class="container">
@@ -226,7 +229,7 @@ var users = User.list();
 		<footer>
 			<div class="container">
 				Released under the <a href="http://opensource.org/licenses/MIT" target="_blank">MIT license</a>
-				<br />&copy; 2014 Leo Horie
+				<br>&copy; 2014 Leo Horie
 			</div>
 		</footer>
 		<script src="lib/prism/prism.js"></script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wrote a [script](https://gist.github.com/tivac/849ed547597536554f07b18394ef12fc) which uses `posthtml` to update all the `<headers>` with a deprecation banner.

## Motivation and Context
Fixes #2013 
Fixes #2028

## How Has This Been Tested?
Opened at least one page in every archive version.

## Preview
![image](https://user-images.githubusercontent.com/49545/33308432-48d25010-d412-11e7-8c6c-2bcbe650a51b.png)
