### PR TITLE
test: fix broken test after ospec update

### DIFF
--- a/promise/tests/test-promise.js
+++ b/promise/tests/test-promise.js
@@ -131,7 +131,7 @@ o.spec("promise", function() {
 				callAsync(function() {resolve(promise)})
 			})
 
-			promise.then(null, done)
+			promise.then(null, function() { done() })
 		})
 		o("non-function onFulfilled is ignored", function(done) {
 			var promise = Promise.resolve(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`ospec` changed to support `done(err)` in 39be9134f94f78da635a6ad86d1722f047326c01 and that broke a test. This fixes it.

## Motivation and Context
`master` was broken.

## How Has This Been Tested?

`npm test`, all tests passed.

PS we have a few lint errors that nobody caught because they don't break builds. Maybe they should?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
