### PR TITLE
fix typo in body background style

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,4 +1,4 @@
-body {bakground:white;-webkit-text-size-adjust: 100%;}
+body {background:white;-webkit-text-size-adjust: 100%;}
 body,table,h5 {font:normal 16px 'Open Sans';}
 header,main {margin:auto;max-width:1000px;}
 header section {position:absolute;width:250px;}


### PR DESCRIPTION

## Description
fix css typo- `bakground` should be `background`

## Motivation and Context
`bakground` is not a valid css property.

## How Has This Been Tested?
Verified that only `background` works (Chrome latest).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
