### PR TITLE
#2025 array of querystring without number

### DIFF
--- a/docs/buildQueryString.md
+++ b/docs/buildQueryString.md
@@ -47,6 +47,5 @@ Deep data structures are serialized in a way that is understood by popular web a
 ```javascript
 var querystring = m.buildQueryString({a: ["hello", "world"]})
 
-// querystring is "a[0]=hello&a[1]=world"
+// querystring is "a[]=hello&a[]=world"
 ```
-

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -22,6 +22,7 @@
 - API: `m.mount()` will only render its own root when called, it will not trigger a `redraw()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Assigning to `vnode.state` (as in `vnode.state = ...`) is no longer supported. Instead, an error is thrown if `vnode.state` changes upon the invocation of a lifecycle hook.
 - API: `m.request` will no longer reject the Promise on server errors (eg. status >= 400) if the caller supplies an `extract` callback. This gives applications more control over handling server responses.
+- API: `m.buildQueryString` and `m.parseQueryString` are changed to remove index of array ([#2025](https://github.com/MithrilJS/mithril.js/pull/2025))
 
 #### News
 

--- a/docs/parseQueryString.md
+++ b/docs/parseQueryString.md
@@ -65,7 +65,7 @@ var data = m.parseQueryString("?a=hello&b=world")
 Querystrings that contain bracket notation are correctly parsed into deep data structures
 
 ```javascript
-m.parseQueryString("a[0]=hello&a[1]=world")
+m.parseQueryString("a[]=hello&a[]=world")
 
 // data is {a: ["hello", "world"]}
 ```

--- a/querystring/build.js
+++ b/querystring/build.js
@@ -13,7 +13,7 @@ module.exports = function(object) {
 	function destructure(key, value) {
 		if (Array.isArray(value)) {
 			for (var i = 0; i < value.length; i++) {
-				destructure(key + "[" + i + "]", value[i])
+				destructure(key + "[]", value[i])
 			}
 		}
 		else if (Object.prototype.toString.call(value) === "[object Object]") {

--- a/querystring/parse.js
+++ b/querystring/parse.js
@@ -4,7 +4,7 @@ module.exports = function(string) {
 	if (string === "" || string == null) return {}
 	if (string.charAt(0) === "?") string = string.slice(1)
 
-	var entries = string.split("&"), data = {}, counters = {}
+	var entries = string.split("&"), data = {}
 	for (var i = 0; i < entries.length; i++) {
 		var entry = entries[i].split("=")
 		var key = decodeURIComponent(entry[0])
@@ -18,17 +18,20 @@ module.exports = function(string) {
 		if (key.indexOf("[") > -1) levels.pop()
 		for (var j = 0; j < levels.length; j++) {
 			var level = levels[j], nextLevel = levels[j + 1]
-			var isNumber = nextLevel == "" || !isNaN(parseInt(nextLevel, 10))
+			var isArray = nextLevel == ""
 			var isValue = j === levels.length - 1
-			if (level === "") {
-				var key = levels.slice(0, j).join()
-				if (counters[key] == null) counters[key] = 0
-				level = counters[key]++
+			var levelValue = isValue ? value : isArray ? [] : {}
+
+			if (cursor instanceof Array) {
+				cursor.push(levelValue)
+			} else {
+				if (cursor[level] == null) {
+					cursor[level] = levelValue
+				} else {
+					levelValue = cursor[level]
+				}
 			}
-			if (cursor[level] == null) {
-				cursor[level] = isValue ? value : isNumber ? [] : {}
-			}
-			cursor = cursor[level]
+			cursor = levelValue
 		}
 	}
 	return data

--- a/querystring/tests/test-buildQueryString.js
+++ b/querystring/tests/test-buildQueryString.js
@@ -32,27 +32,22 @@ o.spec("buildQueryString", function() {
 	o("handles nested array", function() {
 		var string = buildQueryString({a: ["x", "y"]})
 
-		o(string).equals("a%5B0%5D=x&a%5B1%5D=y")
+		o(string).equals("a%5B%5D=x&a%5B%5D=y")
 	})
 	o("handles array w/ dupe values", function() {
 		var string = buildQueryString({a: ["x", "x"]})
 
-		o(string).equals("a%5B0%5D=x&a%5B1%5D=x")
-	})
-	o("handles deep nested array", function() {
-		var string = buildQueryString({a: [["x", "y"]]})
-
-		o(string).equals("a%5B0%5D%5B0%5D=x&a%5B0%5D%5B1%5D=y")
+		o(string).equals("a%5B%5D=x&a%5B%5D=x")
 	})
 	o("handles deep nested array in object", function() {
 		var string = buildQueryString({a: {b: ["x", "y"]}})
 
-		o(string).equals("a%5Bb%5D%5B0%5D=x&a%5Bb%5D%5B1%5D=y")
+		o(string).equals("a%5Bb%5D%5B%5D=x&a%5Bb%5D%5B%5D=y")
 	})
 	o("handles deep nested object in array", function() {
 		var string = buildQueryString({a: [{b: 1, c: 2}]})
 
-		o(string).equals("a%5B0%5D%5Bb%5D=1&a%5B0%5D%5Bc%5D=2")
+		o(string).equals("a%5B%5D%5Bb%5D=1&a%5B%5D%5Bc%5D=2")
 	})
 	o("handles date", function() {
 		var string = buildQueryString({a: new Date(0)})

--- a/querystring/tests/test-parseQueryString.js
+++ b/querystring/tests/test-parseQueryString.js
@@ -48,23 +48,19 @@ o.spec("parseQueryString", function() {
 		var data = parseQueryString("a[b][c]=x&a[b][d]=y")
 		o(data).deepEquals({a: {b: {c: "x", d: "y"}}})
 	})
-	o("parses nested array", function() {
+	o("parses object with number key", function() {
 		var data = parseQueryString("a[0]=x&a[1]=y")
-		o(data).deepEquals({a: ["x", "y"]})
+		o(data).deepEquals({a: {"0": "x", "1": "y"}})
 	})
-	o("parses deep nested array", function() {
+	o("parses deep nested object with number key", function() {
 		var data = parseQueryString("a[0][0]=x&a[0][1]=y")
-		o(data).deepEquals({a: [["x", "y"]]})
-	})
-	o("parses deep nested object in array", function() {
-		var data = parseQueryString("a[0][c]=x&a[0][d]=y")
-		o(data).deepEquals({a: [{c: "x", d: "y"}]})
+		o(data).deepEquals({a: {"0": {"0": "x", "1": "y"}}})
 	})
 	o("parses deep nested array in object", function() {
-		var data = parseQueryString("a[b][0]=x&a[b][1]=y")
-		o(data).deepEquals({a: {b: ["x", "y"]}})
+		var data = parseQueryString("a[b][]=x&a[b][]=y&a[c][]=z")
+		o(data).deepEquals({a: {b: ["x", "y"], c: ["z"]}})
 	})
-	o("parses array without index", function() {
+	o("parses array", function() {
 		var data = parseQueryString("a[]=x&a[]=y&b[]=w&b[]=z")
 		o(data).deepEquals({a: ["x", "y"], b: ["w", "z"]})
 	})


### PR DESCRIPTION
## Description
This is WIP about issue #2025.

## Motivation and Context
Please reference issue #2025.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```javascript
var querystring = m.buildQueryString({a: ["hello", "world"]})
// querystring is "a[]=hello&a[]=world"

m.parseQueryString("a[]=hello&a[]=world")
// data is {a: ["hello", "world"]}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - remove index from array querystring
  - unsupport nest array `ex) { a: [["x"], ["y"]] }   // a[0][0]=x&a[1][0]=y`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
