### PR TITLE
Add Typescript install notes

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 - [CDN](#cdn)
 - [NPM](#npm)
+- [Quick start with Webpack](#quick-start-with-webpack)
+- [Typescript](#typescript)
 
 ### CDN
 
@@ -15,8 +17,13 @@ If you're new to Javascript or just want a very simple setup to get your feet we
 
 ### NPM
 
-#### Quick start with Webpack
+```bash
+$> npm install mithril --save
+```
 
+---
+
+### Quick start with Webpack
 
 1. Initialize the directory as an npm package
 ```bash
@@ -251,3 +258,15 @@ If you don't have the ability to run a bundler script due to company security po
 // if a CommonJS environment is not detected, Mithril will be created in the global scope
 m.render(document.body, "hello world")
 ```
+
+---
+
+### TypeScript
+
+TypeScript type definitions are available from DefinitelyTyped. They can be installed with:
+
+```bash
+$> npm install @types/mithril --save-dev
+```
+
+For example usage, to file issues or to discuss TypeScript related topics visit: https://github.com/MithrilJS/mithril.d.ts


### PR DESCRIPTION
## Description

Added notes about installing TypeScript types to the install.md page.

I also thought for clarity it'd be nice to break out a separate section for npm installation. I realize it's pretty obvious, but I think it's good to have that front and centre rather than burying it within the webpack walkthrough. TOC has been adjusted accordingly

## Motivation and Context
https://github.com/MithrilJS/mithril.js/issues/1985

## Types of changes
- [x] Documentation

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
