### PR TITLE
Access document.activeElement through a function that eats errors for IE

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -13,6 +13,13 @@
 
 ---
 
+### v1.1.7
+
+#### Bug fixes
+
+- core: Workaround for [Internet Explorer bug](https://www.tjvantoll.com/2013/08/30/bugs-with-document-activeelement-in-internet-explorer/) when running in an iframe
+
+
 ### v1.1.6
 
 #### Bug fixes

--- a/render/render.js
+++ b/render/render.js
@@ -19,12 +19,12 @@ module.exports = function($window) {
 	}
 
 	// IE9 - IE11 (at least) throw an UnspecifiedError when accessing document.activeElement when
-	// inside an iframe. Catch and swallow this error, and heavy-handidly return document.body.
+	// inside an iframe. Catch and swallow this error, and heavy-handidly return null.
 	function activeElement() {
 		try {
 			return $doc.activeElement
 		} catch (e) {
-			return document.body
+			return null
 		}
 	}
 	//create

--- a/render/render.js
+++ b/render/render.js
@@ -18,6 +18,15 @@ module.exports = function($window) {
 		return vnode.attrs && vnode.attrs.xmlns || nameSpace[vnode.tag]
 	}
 
+	// IE9 - IE11 (at least) throw an UnspecifiedError when accessing document.activeElement when
+	// inside an iframe.
+	function activeElement() {
+		try {
+			return $doc.activeElement
+		} catch (e) {
+			return document.body
+		}
+	}
 	//create
 	function createNodes(parent, vnodes, start, end, hooks, nextSibling, ns) {
 		for (var i = start; i < end; i++) {
@@ -484,13 +493,13 @@ module.exports = function($window) {
 			if (key === "value") {
 				var normalized = "" + value // eslint-disable-line no-implicit-coercion
 				//setting input[value] to same value by typing on focused element moves cursor to end in Chrome
-				if ((vnode.tag === "input" || vnode.tag === "textarea") && vnode.dom.value === normalized && vnode.dom === $doc.activeElement) return
+				if ((vnode.tag === "input" || vnode.tag === "textarea") && vnode.dom.value === normalized && vnode.dom === activeElement()) return
 				//setting select[value] to same value while having select open blinks select dropdown in Chrome
 				if (vnode.tag === "select") {
 					if (value === null) {
-						if (vnode.dom.selectedIndex === -1 && vnode.dom === $doc.activeElement) return
+						if (vnode.dom.selectedIndex === -1 && vnode.dom === activeElement()) return
 					} else {
-						if (old !== null && vnode.dom.value === normalized && vnode.dom === $doc.activeElement) return
+						if (old !== null && vnode.dom.value === normalized && vnode.dom === activeElement()) return
 					}
 				}
 				//setting option[value] to same value while having select open blinks select dropdown in Chrome
@@ -535,7 +544,7 @@ module.exports = function($window) {
 		}
 	}
 	function isFormAttribute(vnode, attr) {
-		return attr === "value" || attr === "checked" || attr === "selectedIndex" || attr === "selected" && vnode.dom === $doc.activeElement
+		return attr === "value" || attr === "checked" || attr === "selectedIndex" || attr === "selected" && vnode.dom === activeElement()
 	}
 	function isLifecycleMethod(attr) {
 		return attr === "oninit" || attr === "oncreate" || attr === "onupdate" || attr === "onremove" || attr === "onbeforeremove" || attr === "onbeforeupdate"
@@ -613,7 +622,7 @@ module.exports = function($window) {
 	function render(dom, vnodes) {
 		if (!dom) throw new Error("Ensure the DOM element being passed to m.route/m.mount/m.render is not undefined.")
 		var hooks = []
-		var active = $doc.activeElement
+		var active = activeElement()
 		var namespace = dom.namespaceURI
 
 		// First time rendering into a node clears it out
@@ -623,7 +632,7 @@ module.exports = function($window) {
 		updateNodes(dom, dom.vnodes, Vnode.normalizeChildren(vnodes), false, hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
 		dom.vnodes = vnodes
 		// document.activeElement can return null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
-		if (active != null && $doc.activeElement !== active) active.focus()
+		if (active != null && activeElement() !== active) active.focus()
 		for (var i = 0; i < hooks.length; i++) hooks[i]()
 	}
 

--- a/render/render.js
+++ b/render/render.js
@@ -19,7 +19,7 @@ module.exports = function($window) {
 	}
 
 	// IE9 - IE11 (at least) throw an UnspecifiedError when accessing document.activeElement when
-	// inside an iframe.
+	// inside an iframe. Catch and swallow this error, and heavy-handidly return document.body.
 	function activeElement() {
 		try {
 			return $doc.activeElement

--- a/render/tests/manual/iframe.html
+++ b/render/tests/manual/iframe.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <div id="root"></div>
+        <script src="../../../mithril.js"></script>
+        <script src="./iframe.js"></script>
+    </body>
+</html>

--- a/render/tests/manual/iframe.js
+++ b/render/tests/manual/iframe.js
@@ -1,0 +1,12 @@
+var count = 0
+
+var Button = {
+    view: function() {
+        return m(
+            "button",
+            {onclick: function() { count += 1 }},
+            "Inside the iframe: " + count)
+    }
+}
+
+m.mount(document.getElementById("root"), Button)

--- a/render/tests/manual/index.html
+++ b/render/tests/manual/index.html
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        Various parent website content.
+        There should be a clickable button below, which is inside an iframe containing a mithril app:
+        <div>
+            <iframe src="./iframe.html"></iframe>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Accessing `document.activeElement` when inside an iframe throws an error for Internet Explorer versions 9 through 11 (at least). Catch this error and return `document.body` instead in these cases. I'm not sure what the ramifications are of returning `document.body` but I'm happy to update with any suggested changes.

## Motivation and Context
While mithril apps work in these versions of IE, they'll break when inside an iframe without this fix.

## How Has This Been Tested?
Built locally with `npm run dev` and ran the `render/tests/index.html` and `tests/index.html` tests and saw zero assertion failures.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed
(two tests fail, actually, but they fail in `v1_1_x` as well: `test-jsonp.js:80` and `test-request.js:322`)
- [x] I have updated `docs/change-log.md`
