### PR TITLE
docs: Fix inconsistent path in router.md variadic routes example

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -323,7 +323,7 @@ It's also possible to have variadic routes, i.e. a route with an argument that c
 
 ```javascript
 m.route(document.body, "/edit/pictures/image.jpg", {
-	"/files/:file...": Edit,
+	"/edit/:file...": Edit,
 })
 ```
 


### PR DESCRIPTION
The default URL supplied in the current docs for variadic paths `/edit/pictures/image.jpg` does not match the router path starting with `/files/:file...`:
```
m.route(document.body, "/edit/pictures/image.jpg", {
    "/files/:file...": Edit,
})
```

This changes the router path to match the "Edit" idea of the example, resulting in:
```
m.route(document.body, "/edit/pictures/image.jpg", {
    "/edit/:file...": Edit,
})
```

Related test:
https://github.com/MithrilJS/mithril.js/blob/next/router/tests/test-defineRoutes.js#L116-L117

This PR is an update for this prior PR changing the derived html file and not the md file: https://github.com/MithrilJS/mithril.js/pull/2081