### PR TITLE
docs: correct some webpack bitrot

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,15 +33,15 @@ $> npm init --yes
 2. install required tools
 ```bash
 $> npm install mithril --save
-$> npm install webpack --save
+$> npm install webpack webpack-cli --save-dev
 ```
 
-3. Add a "start" entry to the scripts section in `package.json`
+3. Add a "start" entry to the scripts section in `package.json`.
 ```js
 {
   // ...
   "scripts": {
-    "start": "webpack src/index.js bin/app.js --watch"
+    "start": "webpack src/index.js --output bin/app.js -d --watch"
   }
 }
 ```
@@ -56,15 +56,16 @@ m.render(document.body, "hello world");
 4. create `index.html`
 ```html
 <!DOCTYPE html>
-
-<script src="bin/app.js"></script>
+<body>
+    <script src="bin/app.js"></script>
+</body>
 ```
 
 5. run bundler
 ```bash
 $> npm start
 ```
-6. open `index.html` in your (default) browser
+6. open `index.html` in a browser
 
 #### Step by step
 
@@ -105,7 +106,7 @@ Most browser today do not natively support modularization systems (CommonJS or E
 A popular way for creating a bundle is to setup an NPM script for [Webpack](https://webpack.js.org/). To install Webpack, run this from the command line:
 
 ```bash
-npm install webpack --save-dev
+npm install webpack webpack-cli --save-dev
 ```
 
 Open the `package.json` that you created earlier, and add an entry to the `scripts` section:
@@ -114,7 +115,7 @@ Open the `package.json` that you created earlier, and add an entry to the `scrip
 {
 	"name": "my-project",
 	"scripts": {
-		"start": "webpack src/index.js bin/app.js -d --watch"
+		"start": "webpack src/index.js --output bin/app.js -d --watch"
 	}
 }
 ```
@@ -176,8 +177,8 @@ If you open bin/app.js, you'll notice that the Webpack bundle is not minified, s
 {
 	"name": "my-project",
 	"scripts": {
-		"start": "webpack src/index.js bin/app.js -d --watch",
-		"build": "webpack src/index.js bin/app.js -p",
+		"start": "webpack src/index.js --output bin/app.js -d --watch",
+		"build": "webpack src/index.js --output bin/app.js -p",
 	}
 }
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add `webpack-cli`
- Fix usage to include `--output` flag
- Make default use `-d` for debug builds

## Motivation and Context
Came up as part of #2093 but that contained a band-aid docs fix, this fixes the underlying webpack misuse.

## How Has This Been Tested?
Ran through the steps locally in a new folder and verified that it worked
