### PR TITLE
Trust svg

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -29,7 +29,7 @@
 - API: Event handlers may also be objects with `handleEvent` methods ([#1939](https://github.com/MithrilJS/mithril.js/issues/1939)).
 - API: `m.route.link` accepts an optional `options` object ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
 - API: `m.request` supports `timeout` as attr - ([#1966](https://github.com/MithrilJS/mithril.js/pull/1966))
-
+- Mocks: add limited support for the DOMParser API
 
 #### Bug fixes
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -29,7 +29,8 @@
 - API: Event handlers may also be objects with `handleEvent` methods ([#1939](https://github.com/MithrilJS/mithril.js/issues/1939)).
 - API: `m.route.link` accepts an optional `options` object ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
 - API: `m.request` supports `timeout` as attr - ([#1966](https://github.com/MithrilJS/mithril.js/pull/1966))
-- Mocks: add limited support for the DOMParser API
+- Mocks: add limited support for the DOMParser API ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
+- API: add support for raw SVG in `m.trust()` string ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
 
 #### Bug fixes
 

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -11,7 +11,7 @@
 
 ### Description
 
-Turns an HTML string into unescaped HTML. **Do not use `m.trust` on unsanitized user input.**
+Turns an HTML or SVG string into unescaped HTML or SVG. **Do not use `m.trust` on unsanitized user input.**
 
 Always try to use an [alternative method](#avoid-trusting-html) first, before considering using `m.trust`.
 
@@ -23,7 +23,7 @@ Always try to use an [alternative method](#avoid-trusting-html) first, before co
 
 Argument    | Type                 | Required | Description
 ----------- | -------------------- | -------- | ---
-`html`      | `String`             | Yes      | A string containing HTML text
+`html`      | `String`             | Yes      | A string containing HTML or SVG text
 **returns** | `Vnode`              |          | A trusted HTML [vnode](vnodes.md) that represents the input string
 
 [How to read signatures](signatures.md)

--- a/render/render.js
+++ b/render/render.js
@@ -52,7 +52,7 @@ module.exports = function($window) {
 			if (vnode.attrs != null) initLifecycle(vnode.attrs, vnode, hooks)
 			switch (tag) {
 				case "#": return createText(parent, vnode, nextSibling)
-				case "<": return createHTML(parent, vnode, nextSibling)
+				case "<": return createHTML(parent, vnode, ns, nextSibling)
 				case "[": return createFragment(parent, vnode, hooks, ns, nextSibling)
 				default: return createElement(parent, vnode, hooks, ns, nextSibling)
 			}
@@ -64,12 +64,16 @@ module.exports = function($window) {
 		insertNode(parent, vnode.dom, nextSibling)
 		return vnode.dom
 	}
-	function createHTML(parent, vnode, nextSibling) {
+	var possibleParents = {caption: "table", thead: "table", tbody: "table", tfoot: "table", tr: "tbody", th: "tr", td: "tr", colgroup: "table", col: "colgroup"}
+	function createHTML(parent, vnode, ns, nextSibling) {
 		var match = vnode.children.match(/^\s*?<(\w+)/im) || []
-		var parent1 = {caption: "table", thead: "table", tbody: "table", tfoot: "table", tr: "tbody", th: "tr", td: "tr", colgroup: "table", col: "colgroup"}[match[1]] || "div"
-		var temp = $doc.createElement(parent1)
-
-		temp.innerHTML = vnode.children
+		var temp = $doc.createElement(possibleParents[match[1]] || "div")
+		if (ns === "http://www.w3.org/2000/svg") {
+			temp.innerHTML = "<svg xmlns=\"http://www.w3.org/2000/svg\">" + vnode.children + "</svg>"
+			temp = temp.firstChild
+		} else {
+			temp.innerHTML = vnode.children
+		}
 		vnode.dom = temp.firstChild
 		vnode.domSize = temp.childNodes.length
 		var fragment = $doc.createDocumentFragment()
@@ -404,7 +408,7 @@ module.exports = function($window) {
 				}
 				switch (oldTag) {
 					case "#": updateText(old, vnode); break
-					case "<": updateHTML(parent, old, vnode, nextSibling); break
+					case "<": updateHTML(parent, old, vnode, ns, nextSibling); break
 					case "[": updateFragment(parent, old, vnode, recycling, hooks, nextSibling, ns); break
 					default: updateElement(old, vnode, recycling, hooks, ns)
 				}
@@ -422,10 +426,10 @@ module.exports = function($window) {
 		}
 		vnode.dom = old.dom
 	}
-	function updateHTML(parent, old, vnode, nextSibling) {
+	function updateHTML(parent, old, vnode, ns, nextSibling) {
 		if (old.children !== vnode.children) {
 			toFragment(old)
-			createHTML(parent, vnode, nextSibling)
+			createHTML(parent, vnode, ns, nextSibling)
 		}
 		else vnode.dom = old.dom, vnode.domSize = old.domSize
 	}

--- a/render/tests/test-createHTML.js
+++ b/render/tests/test-createHTML.js
@@ -31,7 +31,7 @@ o.spec("createHTML", function() {
 		o(vnode.dom).equals(null)
 		o(vnode.domSize).equals(0)
 	})
-	o("handles multiple children", function() {
+	o("handles multiple children in HTML", function() {
 		var vnode = {tag: "<", children: "<a></a><b></b>"}
 		render(root, [vnode])
 
@@ -50,5 +50,35 @@ o.spec("createHTML", function() {
 
 			o(vnode.dom.nodeName).equals(tag.toUpperCase())
 		})
+	})
+	o("creates SVG", function() {
+		var vnode = {tag: "<", children: "<g></g>"}
+		render(root, [{tag:"svg", children: [vnode]}])
+
+		o(vnode.dom.nodeName).equals("g")
+		o(vnode.dom.namespaceURI).equals("http://www.w3.org/2000/svg")
+	})
+	o("creates text SVG", function() {
+		var vnode = {tag: "<", children: "a"}
+		render(root, [{tag:"svg", children: [vnode]}])
+
+		o(vnode.dom.nodeValue).equals("a")
+	})
+	o("handles empty SVG", function() {
+		var vnode = {tag: "<", children: ""}
+		render(root, [{tag:"svg", children: [vnode]}])
+
+		o(vnode.dom).equals(null)
+		o(vnode.domSize).equals(0)
+	})
+	o("handles multiple children in SVG", function() {
+		var vnode = {tag: "<", children: "<g></g><text></text>"}
+		render(root, [{tag:"svg", children: [vnode]}])
+
+		o(vnode.domSize).equals(2)
+		o(vnode.dom.nodeName).equals("g")
+		o(vnode.dom.namespaceURI).equals("http://www.w3.org/2000/svg")
+		o(vnode.dom.nextSibling.nodeName).equals("text")
+		o(vnode.dom.nextSibling.namespaceURI).equals("http://www.w3.org/2000/svg")
 	})
 })

--- a/test-utils/tests/test-domMock.js
+++ b/test-utils/tests/test-domMock.js
@@ -4,9 +4,10 @@ var o = require("../../ospec/ospec")
 var domMock = require("../../test-utils/domMock")
 
 o.spec("domMock", function() {
-	var $document
+	var $document, $window
 	o.beforeEach(function() {
-		$document = domMock().document
+		$window = domMock()
+		$document = $window.document
 	})
 
 	o.spec("createElement", function() {
@@ -496,6 +497,45 @@ o.spec("domMock", function() {
 			div.innerHTML = "<b></b>"
 
 			o(a.parentNode).equals(null)
+		})
+		o("empty SVG document", function() {
+			var div = $document.createElement("div")
+			div.innerHTML = "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"
+
+			o(typeof div.firstChild).notEquals(undefined)
+			o(div.firstChild.nodeName).equals("svg")
+			o(div.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(div.firstChild.childNodes.length).equals(0)
+		})
+		o("text elements", function() {
+			var div = $document.createElement("div")
+			div.innerHTML =
+				"<svg xmlns=\"http://www.w3.org/2000/svg\">"
+					+ "<text>hello</text>"
+					+ "<text> </text>"
+					+ "<text>world</text>"
+				+ "</svg>"
+
+			o(div.firstChild.nodeName).equals("svg")
+			o(div.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
+
+			var nodes = div.firstChild.childNodes
+			o(nodes.length).equals(3)
+			o(nodes[0].nodeName).equals("text")
+			o(nodes[0].namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(nodes[0].childNodes.length).equals(1)
+			o(nodes[0].childNodes[0].nodeName).equals("#text")
+			o(nodes[0].childNodes[0].nodeValue).equals("hello")
+			o(nodes[1].nodeName).equals("text")
+			o(nodes[1].namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(nodes[1].childNodes.length).equals(1)
+			o(nodes[1].childNodes[0].nodeName).equals("#text")
+			o(nodes[1].childNodes[0].nodeValue).equals(" ")
+			o(nodes[2].nodeName).equals("text")
+			o(nodes[2].namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(nodes[2].childNodes.length).equals(1)
+			o(nodes[2].childNodes[0].nodeName).equals("#text")
+			o(nodes[2].childNodes[0].nodeValue).equals("world")
 		})
 	})
 	o.spec("focus", function() {
@@ -1790,6 +1830,64 @@ o.spec("domMock", function() {
 			o(spies.valueSetter.callCount).equals(1)
 			o(spies.valueSetter.this).equals(textarea)
 			o(spies.valueSetter.args[0]).equals("aaa")
+		})
+	})
+	o.spec("DOMParser for SVG", function(){
+		var $DOMParser
+		o.beforeEach(function() {
+			$DOMParser = $window.DOMParser
+		})
+		o("basics", function(){
+			o(typeof $DOMParser).equals("function")
+
+			var parser = new $DOMParser()
+
+			o(parser instanceof $DOMParser).equals(true)
+			o(typeof parser.parseFromString).equals("function")
+		})
+		o("empty document", function() {
+			var parser = new $DOMParser()
+			var doc = parser.parseFromString(
+				"<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
+				"image/svg+xml"
+			)
+
+			o(typeof doc.documentElement).notEquals(undefined)
+			o(doc.documentElement.nodeName).equals("svg")
+			o(doc.documentElement.namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(doc.documentElement.childNodes.length).equals(0)
+		})
+		o("text elements", function() {
+			var parser = new $DOMParser()
+			var doc = parser.parseFromString(
+				"<svg xmlns=\"http://www.w3.org/2000/svg\">"
+					+ "<text>hello</text>"
+					+ "<text> </text>"
+					+ "<text>world</text>"
+				+ "</svg>",
+				"image/svg+xml"
+			)
+
+			o(doc.documentElement.nodeName).equals("svg")
+			o(doc.documentElement.namespaceURI).equals("http://www.w3.org/2000/svg")
+
+			var nodes = doc.documentElement.childNodes
+			o(nodes.length).equals(3)
+			o(nodes[0].nodeName).equals("text")
+			o(nodes[0].namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(nodes[0].childNodes.length).equals(1)
+			o(nodes[0].childNodes[0].nodeName).equals("#text")
+			o(nodes[0].childNodes[0].nodeValue).equals("hello")
+			o(nodes[1].nodeName).equals("text")
+			o(nodes[1].namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(nodes[1].childNodes.length).equals(1)
+			o(nodes[1].childNodes[0].nodeName).equals("#text")
+			o(nodes[1].childNodes[0].nodeValue).equals(" ")
+			o(nodes[2].nodeName).equals("text")
+			o(nodes[2].namespaceURI).equals("http://www.w3.org/2000/svg")
+			o(nodes[2].childNodes.length).equals(1)
+			o(nodes[2].childNodes[0].nodeName).equals("#text")
+			o(nodes[2].childNodes[0].nodeValue).equals("world")
 		})
 	})
 })


### PR DESCRIPTION
Add support for SVG in `m.trust()` strings, and some `DOMParser` support in the mocks.

## Description

This leverages the `DOMParser` API (IE 10+) to enable users to use `m.trust()` to create raw SVG fragments.

## How Has This Been Tested?
I've added corresponding tests for `render` and the mocks.

The [mocks test](https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J4hcYgAIAJAHcIaACa1ZkgLyT5SlQB00eyZNr44ABxjUAFDpAARAPIBZAAoYATnBhvJYWt4DKAGoA4jYUPgCuaNTEEPSWAJTAejrEqQBu7jIOLu6ebilpxMYARjC+bjAAohjUhJZgUTFxaImSyfpFqdI5rh5e6jJayrL4vXlehamsCVPF1iAlGHAQ1HBhkdGx8UlzqbSWxACe5rRg2U59+Qn4MACOERhQcAuNWy02s-qdqRlZphNvBo0DBVD1LoDEikfkUDgD+t4FBIMNEYGcLrkETd7o9noc3BEYF9frDDic0ed4fl8FSYAAxNy0LD+YhuBQAc2xDyeLxsb2a9E+cxmcwONhgWFMx0kymoERwDA2-O2rQS7T2xEy3lpQMkILB4wRUJhf28ssGOppEwZTJZbLQ7IWAB44Ol2ZIAB5kNBwNQ6f0gEjEUyIAD0odkkfwsgAzPg-OzQwAmAAMadDrvZ-psAD4nRm3TmNjYIFgMOyYAX2QBqL1QIXfEn7Mmnc6y-Cy+UiKqwBXEG5oWjEKrcvFRRTlBQwRTErrzdudvs9iUifCDicAOS4XNxvJAmYbTfntGoHZPXYYy77a64ZlqMAAqgAlACSO55CyDIfDkdGsfjbiJqm6YHiAs4kgcC7nkuvarnU0CKButATnA+CwA6xCEO+eIpuBxAijCYogIwHpSOu8BKk0KptB0R5apIOqDPqGJXF4xp0Vk5oaJatI2syrIctYaCGCJIk2C6bqet6vrZoGxDBmGEZRv+CbJmmKZVrJRYgAYol6dWkjiSRxA5oQMBQFAtD5sZ2m6XpIkGUZMCkTmkjWc5Jk2HZ9mSI5IBOjZsh+FAijuS5XnCT5fn5pm2kUN5oklmWFZVrWZARfZxImsep6Lt2sEMGuyEwFuODYXuoF4c2UFyjBK6FZgOB3tQj6vuVn7yd+Sl-nGqnARplXQhx3jkXAgw1Rew4FcQ+DwSFSEoRqByjWhTDsph7UxlV8yjcgKYALpFZu263KOe7GYec7LcVcB7YdjXwACLXPm+p27h1Ck-spvWAWpIFupdEGWLtB2zYQCELfAq0YVhb0fgAjNt10oXdYMQzdqPkaVRJw3iNgAMQXWBS3AxjoNzYhZP3cVgRPIS7U2GZFm0IDpK7fD1PHWVuPnR5rPNuz923k9rWvTiH6M51im-tGP1AepmnE9lyPwMgHNo-NN3Q+tsPi3iiMk4LGuUyjoNYydet7oTfNK0eKu3erFOQ7dZs03TOOWwshm21dpMo0mnMlRbZ0LETSN+6rAc3k1IsvQzcmfd1ssAfL-1Zj7QO7VHTta+hOvtQbysR7d2fg5rpuB9j8fW6R-M7RjpfoxXR0wLTUD0zzCxBW4IWswR0xZdCxgEqqbAcCAD14LNcACDQ9CMMwPBsPtVBQAoADWCAoJwOB4LQZgWJQIARD3eBfnAilRKY6-srNTKhlgECYWyUAAALw-gH8AGyhvv5jUL-A+1Aj7HHMHgfgy9WBAA) also pass in Firefox, Chrome, Safari IE11 and Edge (thanks to @Yatekii for the last two).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
