### PR TITLE
feat: CLI argument list of root-paths to traverse

### DIFF
--- a/ospec/README.md
+++ b/ospec/README.md
@@ -290,15 +290,18 @@ _o.run()
 
 ### Running the test suite from the command-line
 
-ospec will automatically evaluate all `*.js` files in any folder named `/tests`.
+ospec will automatically evaluate all `*.js` files in any sub-folder named `/tests`.
 
-`o.run()` is automatically called by the cli - no need to call it in your test code.
+To only look for `/tests` folders within certain sub-folders, pass their names as arguments to the `ospec` command.
+
+NOTE: `o.run()` is automatically called by the cli - no need to call it in your test code.
 
 #### Create an npm script in your package:
 ```
 	"scripts": {
 		...
 		"test": "ospec",
+		"test-partial": "ospec path/to/module1 path-to/module2"
 		...
 	}
 ```

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -33,11 +33,31 @@ function traverseDirectory(pathname, callback) {
 	})
 }
 
-traverseDirectory(".", function(pathname) {
-	if (pathname.match(/(?:^|\/)tests\/.*\.js$/)) {
-		require(path.normalize(process.cwd()) + "/" + pathname) // eslint-disable-line global-require
-	}
-})
+function parseRootPathArgs(args) {
+	var foundCmd // Raw process.argv starts with the ospec command and commands leading up to it (i.e. `node`)
+	var foundOpt // Stop at first sign of a "-" prefixed option flag
+	var rootPathArgs = args.filter(function(arg) {
+		if (!foundCmd) {
+			foundCmd = (/ospec$/).test(arg)
+		}
+		else if (!foundOpt) {
+			foundOpt = (/^-/.test(arg))
+			return !foundOpt
+		}
+		return false
+	})
+	return rootPathArgs.length ? rootPathArgs : null
+}
+
+var rootPaths = parseRootPathArgs(process.argv) || ["."]
+
+Promise.all(rootPaths.map(function(rootPath) {
+	return traverseDirectory(rootPath, function(pathname) {
+		if (pathname.match(/(?:^|\/)tests\/.*\.js$/)) {
+			require(path.normalize(process.cwd()) + "/" + pathname) // eslint-disable-line global-require
+		}
+	})
+}))
 .then(o.run)
 .catch(function(e) {
 	console.log(e.stack)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This allows adding a list of folder-paths to traverse as arguments to the `ospec` CLI command – like so: `ospec subfolder1 ../other/folder` – and only run tests within those folders.

The default behaviour of traversing the current directory, remains unchanged.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The goal would be to make it easier to write npm/yarn build scripts that run a certain subset of all `ospec` tests. 

So, enabling this:
```
"scripts": { "test-feature": "ospec path/to/feature" },
```
instead of something like this:
```
"scripts": { "test-feature": "cd path/to/feature && node ../../../node_modules/.bin/ospec" },
```


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on the command line within the mithril repo itself.

```
> cd mithril.js
> node ospec/bin/ospec ./stream ospec
1 assertions completed in 9ms, of which 0 failed
377 assertions completed in 17ms, of which 0 failed
> cd docs
> node ../ospec/bin/ospec ../stream
95 assertions completed in 12ms, of which 0 failed
```
etc. etc...

It should be safe to pass multiple instances of the same folder (or an ancestor-decendant pair) as multiple `require()` calls to the same file only result in a single invocation of their side-effects.

```
> cd mithril.js
> node ospec/bin/ospec stream ./stream ./stream/../stream
95 assertions completed in 12ms, of which 0 failed
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`

...There are no tests covering `ospec/bin/ospec` and I'm unsure how/where to add this to the `change-log.md`
