### PR TITLE
fix: Bundler tests only pass when run from project root

### DIFF
--- a/bundler/tests/test-bundler.js
+++ b/bundler/tests/test-bundler.js
@@ -5,7 +5,7 @@ var bundle = require("../bundle")
 
 var fs = require("fs")
 
-var ns = "bundler/tests/"
+var ns = "./"
 function read(filepath) {
 	try {return fs.readFileSync(ns + filepath, "utf8")} catch (e) {/* ignore */}
 }


### PR DESCRIPTION
Discovered while testing #2133 

```
> cd mithril.js
> node ospec/bin/ospec
1 assertions completed in 95ms, of which 0 failed
7992 assertions completed in 1730ms, of which 0 failed
> cd bundler
> node ../ospec/bin/ospec
bundler > relative imports works:
ENOENT: no such file or directory, open 'bundler/tests/a.js'

    at Object.fs.openSync (fs.js:646:18)


bundler > relative imports works with semicolons:
ENOENT: no such file or directory, open 'bundler/tests/a.js'

    at Object.fs.openSync (fs.js:646:18)

[...]
31 assertions completed in 20ms, of which 31 failed
```


## How Has This Been Tested?

From the command line

```
> cd mithril.js/bundler
> node ../ospec/bin/ospec
31 assertions completed in 240ms, of which 0 failed
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
