### PR TITLE
feat(ospec): Accept list of filenames through stdin

### DIFF
--- a/ospec/README.md
+++ b/ospec/README.md
@@ -301,7 +301,7 @@ NOTE: `o.run()` is automatically called by the cli - no need to call it in your 
 	"scripts": {
 		...
 		"test": "ospec",
-		"test-custom": "find module/**/*.test.js | ospec",
+		"test-custom": "find module/*.test.js | ospec",
 		...
 	}
 ```

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -290,15 +290,18 @@ _o.run()
 
 ### Running the test suite from the command-line
 
-ospec will automatically evaluate all `*.js` files in any folder named `/tests`.
+The `ospec` command will automatically evaluate all `*.js` files in all sub-folders named `/tests` by default.
 
-`o.run()` is automatically called by the cli - no need to call it in your test code.
+`ospec` also accepts a list of filenames to evaluate piped through stdin, if you need control over the file- or folder-names.
+
+NOTE: `o.run()` is automatically called by the cli - no need to call it in your test code.
 
 #### Create an npm script in your package:
 ```
 	"scripts": {
 		...
 		"test": "ospec",
+		"test-custom": "find module/**/*.test.js | ospec",
 		...
 	}
 ```

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -53,16 +53,12 @@ else {
 		let chunk
 		while ((chunk = process.stdin.read()) !== null) fileList += chunk
 
-		try {
-			fileList.toString().split(/\r?\n/).forEach(function(fileName) {
-				if (fileName) {
-					require(path.normalize(process.cwd()) + "/" + fileName) // eslint-disable-line global-require
-				}
-			})
-			o.run()
-		} catch (e) {
-			console.log(e.stack)
-		}
+		fileList.toString().split(/\r?\n/).forEach(function(fileName) {
+			if (fileName) {
+				require(path.normalize(process.cwd()) + "/" + fileName) // eslint-disable-line global-require
+			}
+		})
+		o.run()
 	})
 }
 

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -33,15 +33,39 @@ function traverseDirectory(pathname, callback) {
 	})
 }
 
-traverseDirectory(".", function(pathname) {
-	if (pathname.match(/(?:^|\/)tests\/.*\.js$/)) {
-		require(path.normalize(process.cwd()) + "/" + pathname) // eslint-disable-line global-require
-	}
-})
-.then(o.run)
-.catch(function(e) {
-	console.log(e.stack)
-})
+
+if (process.stdin.isTTY) {
+	// Normal command-line invocation
+	traverseDirectory(".", function(pathname) {
+		if (pathname.match(/(?:^|\/)tests\/.*\.js$/)) {
+			require(path.normalize(process.cwd()) + "/" + pathname) // eslint-disable-line global-require
+		}
+	})
+		.then(o.run)
+		.catch(function(e) {
+			console.log(e.stack)
+		})
+}
+else {
+	// Filenames piped through stdin
+	process.stdin.on("readable", function() {
+		let fileList = ""
+		let chunk
+		while ((chunk = process.stdin.read()) !== null) fileList += chunk
+
+		try {
+			fileList.toString().split(/\r?\n/).forEach(function(fileName) {
+				if (fileName) {
+					require(path.normalize(process.cwd()) + "/" + fileName) // eslint-disable-line global-require
+				}
+			})
+			o.run()
+		} catch (e) {
+			console.log(e.stack)
+		}
+	})
+}
+
 
 process.on("unhandledRejection", function(e) {
 	console.log("Uncaught (in promise) " + e.stack)

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -43,7 +43,7 @@ if (process.stdin.isTTY) {
 	})
 		.then(o.run)
 		.catch(function(e) {
-			console.log(e.stack)
+			console.error(e.stack)
 		})
 }
 else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In response to suggestions made in #2133 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

See rationale in #2133 ...plus add support for custom file-name and folder patterns.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

(Same as #2133 except with piping)
Tested on the command line within the mithril repo itself.

```
> cd mithril.js
> find {stream,ospec}/**/tests/**/*.js | node ospec/bin/ospec
1 assertions completed in 13ms, of which 0 failed
377 assertions completed in 19ms, of which 0 failed
> cd docs
> find ../stream/**/tests/**/*.js | node ../ospec/bin/ospec
95 assertions completed in 11ms, of which 0 failed
```
etc. etc...

It should be safe to pass multiple instances of the same file as multiple `require()` calls to the same file only result in a single invocation of their side-effects.

```
> cd mithril.js
> find stream/tests/*.js stream/**/tests/*.js | node ospec/bin/ospec
95 assertions completed in 11ms, of which 0 failed
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
