### PR TITLE
Ospec: nicer binary with support for globs

### DIFF
--- a/ospec/README.md
+++ b/ospec/README.md
@@ -290,22 +290,48 @@ _o.run()
 
 ### Running the test suite from the command-line
 
-ospec will automatically evaluate all `*.js` files in any folder named `/tests`.
-
-`o.run()` is automatically called by the cli - no need to call it in your test code.
-
-#### Create an npm script in your package:
+Create a script in your package.json:
 ```
 	"scripts": {
-		...
 		"test": "ospec",
 		...
 	}
 ```
+...and run it from the command line:
 
 ```
-	$ npm test
+$ npm test
 ```
+
+ospec will by default evaluate all `*.js` files in any sub-folder named `/tests` - ignoring files inside the `node_modules` folder.
+
+So, running ospec without arguments is thus effectively the same as:
+
+```
+ospec '**/tests/**/*.js'
+```
+
+**NOTE:** `o.run()` is automatically called by the cli - no need to call it in your test code.
+
+ospec accepts a list of file-patterns (globs) giving you full control over which files are evaluated:
+
+```
+ospec '**/tests/**/*.js' '**/*.test.js'
+```
+
+Also, if you wish to skip some files (**in addition to** those under `node_modules`) add a `--ignore` flag with a list of file-patterns to ignore, like so:
+
+```
+ospec --ignore 'folder1/**' 'folder2/**'
+```
+
+...or:
+
+```
+ospec '**/*.test.js' '**/*-test.js' --ignore 'folder1/**' 'folder2/**'
+```
+
+
 
 #### Direct use from the command line
 

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -7,7 +7,7 @@ const glob = require("glob")
 
 
 const parseArgs = (argv) => {
-	argv = ["--globs"].concat( argv.slice(2) )
+	argv = ["--globs"].concat(argv.slice(2))
 	const args = {}
 	let name
 	argv.forEach((arg) => {
@@ -16,7 +16,7 @@ const parseArgs = (argv) => {
 			args[name] = []
 		}
 		else {
-			args[name].push( arg )
+			args[name].push(arg)
 		}
 	})
 	return args
@@ -26,21 +26,15 @@ const parseArgs = (argv) => {
 const args = parseArgs(process.argv)
 
 const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
-const ignore = ["**/node_modules/**"].concat( args.ignore||[] )
+const ignore = ["**/node_modules/**"].concat(args.ignore||[])
 
-
-let pending = globList.length
 
 globList.forEach((globPattern) => {
-	glob(globPattern, { ignore }, (err, fileNames) => {
-		fileNames.forEach((fileName) => {
+	glob(globPattern, {ignore})
+		.on("match", (fileName) => {
 			require(path.normalize(process.cwd()) + "/" + fileName) // eslint-disable-line global-require
 		})
-		pending -= 1
-		if (!pending) {
-			o.run()
-		}
-	})
+		.on("end", o.run)
 });
 
 

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -13,9 +13,8 @@ const parseArgs = (argv) => {
 	argv.forEach((arg) => {
 		if (/^--/.test(arg)) {
 			name = arg.substr(2)
-			args[name] = []
-		}
-		else {
+			args[name] = args[name] || []
+		} else {
 			args[name].push(arg)
 		}
 	})
@@ -24,20 +23,15 @@ const parseArgs = (argv) => {
 
 
 const args = parseArgs(process.argv)
-
 const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
 const ignore = ["**/node_modules/**"].concat(args.ignore||[])
-
+const cwd = process.cwd()
 
 globList.forEach((globPattern) => {
 	glob(globPattern, {ignore})
-		.on("match", (fileName) => {
-			require(path.normalize(process.cwd()) + "/" + fileName) // eslint-disable-line global-require
-		})
+		.on("match", (fileName) => { require(path.join(cwd, fileName)) }) // eslint-disable-line global-require
+		.on("error", (e) => console.error(e))
 		.on("end", o.run)
 });
 
-
-process.on("unhandledRejection", (e) => {
-	console.log("Uncaught (in promise) " + e.stack)
-})
+process.on("unhandledRejection", (e) => { console.log("Uncaught (in promise) " + e.stack) })

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -1,48 +1,49 @@
 #!/usr/bin/env node
 "use strict"
 
-var fs = require("fs")
-var path = require("path")
+const o = require("../ospec")
+const path = require("path")
+const glob = require("glob")
 
-var o = require("../ospec")
 
-function traverseDirectory(pathname, callback) {
-	pathname = pathname.replace(/\\/g, "/")
-	return new Promise(function(resolve, reject) {
-		fs.lstat(pathname, function(err, stat) {
-			if (err) reject(err)
-			if (stat && stat.isDirectory()) {
-				fs.readdir(pathname, function(err, pathnames) {
-					if (err) reject(err)
-					var promises = []
-					for (var i = 0; i < pathnames.length; i++) {
-						if (pathnames[i] === "node_modules") continue
-						if (pathnames[i][0] === ".") continue
-						pathnames[i] = path.join(pathname, pathnames[i])
-						promises.push(traverseDirectory(pathnames[i], callback))
-					}
-					callback(pathname, stat, pathnames)
-					resolve(Promise.all(promises))
-				})
-			}
-			else {
-				callback(pathname, stat)
-				resolve(pathname)
-			}
-		})
+const parseArgs = (argv) => {
+	argv = ["--globs"].concat( argv.slice(2) )
+	const args = {}
+	let name
+	argv.forEach((arg) => {
+		if (/^--/.test(arg)) {
+			name = arg.substr(2)
+			args[name] = []
+		}
+		else {
+			args[name].push( arg )
+		}
 	})
+	return args
 }
 
-traverseDirectory(".", function(pathname) {
-	if (pathname.match(/(?:^|\/)tests\/.*\.js$/)) {
-		require(path.normalize(process.cwd()) + "/" + pathname) // eslint-disable-line global-require
-	}
-})
-.then(o.run)
-.catch(function(e) {
-	console.log(e.stack)
-})
 
-process.on("unhandledRejection", function(e) {
+const args = parseArgs(process.argv)
+
+const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
+const ignore = ["**/node_modules/**"].concat( args.ignore||[] )
+
+
+let pending = globList.length
+
+globList.forEach((globPattern) => {
+	glob(globPattern, { ignore }, (err, fileNames) => {
+		fileNames.forEach((fileName) => {
+			require(path.normalize(process.cwd()) + "/" + fileName) // eslint-disable-line global-require
+		})
+		pending -= 1
+		if (!pending) {
+			o.run()
+		}
+	})
+});
+
+
+process.on("unhandledRejection", (e) => {
 	console.log("Uncaught (in promise) " + e.stack)
 })

--- a/ospec/package.json
+++ b/ospec/package.json
@@ -12,5 +12,8 @@
   "bin": {
     "ospec": "./bin/ospec"
   },
-  "repository": "MithrilJS/mithril.js"
+  "repository": "MithrilJS/mithril.js",
+  "devDependencies": {
+    "glob": "^7.1.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dedent": "^0.7.0",
     "eslint": "^3.19.0",
     "gh-pages": "^0.12.0",
+    "glob": "^7.1.2",
     "istanbul": "^0.4.5",
     "lint-staged": "^4.0.4",
     "locater": "^1.3.0",


### PR DESCRIPTION
Feel free to ignore this pull request.
Its sole purpose is to illustrate what an alternative approach to #2137 and #2133 could look like – if only ospec was treated like a first-class package allowing a single dependency for the node.js binary.

Point being, that the CLI binary is hardly ever used unless installed via npm (or yarn) which install the dependency automatically - while ospec the JavaScript module could still be copied around and loaded in browsers without any need for an external dependency.

FWIW: If this PR gets rejected, then I'll publish this binary as a separate npm module, having ospec as its dependency to allow people like me to add a single testing module to their project and not worry about installing separate globbers, like glob-cli, and piping to ospec via stdin...

Needless to say, this would be my preferred binary over the one in #2137.