### PR TITLE
fix(ospec): Only run o.run() once

### DIFF
--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -27,11 +27,17 @@ const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.
 const ignore = ["**/node_modules/**"].concat(args.ignore||[])
 const cwd = process.cwd()
 
+let pending = globList.length
 globList.forEach((globPattern) => {
 	glob(globPattern, {ignore})
 		.on("match", (fileName) => { require(path.join(cwd, fileName)) }) // eslint-disable-line global-require
 		.on("error", (e) => console.error(e))
-		.on("end", o.run)
+		.on("end", () => {
+			pending--
+			if (pending === 0) {
+				o.run()
+			}
+		})
 });
 
 process.on("unhandledRejection", (e) => { console.log("Uncaught (in promise) " + e.stack) })


### PR DESCRIPTION
My bad. #2141 was broken when merged

Multiple globs, caused multiple calls to `o.run()` so some of the tests were run multiple times.