### PR TITLE
[ospec] don't output colors when pipe or file redirection is used

### DIFF
--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -8,9 +8,10 @@
 
 ## 2.0.0
 _2018-05-xx_
+- In Node.js, ospec only uses colors when the output is sent to a terminal ([#2143](https://github.com/MithrilJS/mithril.js/pull/2143))
 - the CLI runner now accepts globs as arguments ([#2141](https://github.com/MithrilJS/mithril.js/pull/2141), [@maranomynet](https://github.com/maranomynet))
 - Added support for custom reporters ([#2020](https://github.com/MithrilJS/mithril.js/pull/2020))
-- Make Ospec more [Flems](https://flems.io)-friendly ([#2034](https://github.com/MithrilJS/mithril.js/pull/2034))
+- Make ospec more [Flems](https://flems.io)-friendly ([#2034](https://github.com/MithrilJS/mithril.js/pull/2034))
     - Works either as a global or in CommonJS environments
     - the o.run() report is always printed asynchronously (it could be synchronous before if none of the tests were async).
     - Properly point to the assertion location of async errors [#2036](https://github.com/MithrilJS/mithril.js/issues/2036)

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -259,7 +259,7 @@ else window.o = m()
 		try {return JSON.stringify(value)} catch (e) {return String(value)}
 	}
 	function highlight(message) {
-		return hasProcess ? "\x1b[31m" + message + "\x1b[0m" : "%c" + message + "%c "
+		return hasProcess ? (process.stdout.isTTY ? "\x1b[31m" + message + "\x1b[0m" : message) : "%c" + message + "%c "
 	}
 
 	o.report = function (results) {


### PR DESCRIPTION
Colored output was up to this point unconditional...
