### PR TITLE
[ospec] Make the default reporting nicer looking

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -840,3 +840,4 @@ Arrays now represent [fragments](fragment.md), which are structurally significan
 ## `vnode` equality checks
 
 If a vnode is strictly equal to the vnode occupying its place in the last draw, v1.x will skip that part of the tree without checking for mutations or triggering any lifecycle methods in the subtree. The component documentation contains [more detail on this issue](components.md#avoid-creating-component-instances-outside-views).
+

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -840,4 +840,3 @@ Arrays now represent [fragments](fragment.md), which are structurally significan
 ## `vnode` equality checks
 
 If a vnode is strictly equal to the vnode occupying its place in the last draw, v1.x will skip that part of the tree without checking for mutations or triggering any lifecycle methods in the subtree. The component documentation contains [more detail on this issue](components.md#avoid-creating-component-instances-outside-views).
-

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -7,7 +7,7 @@ Noiseless testing framework
 
 ## About
 
-- ~330 LOC including the CLI runner
+- ~360 LOC including the CLI runner
 - terser and faster test code than with mocha, jasmine or tape
 - test code reads like bullet points
 - assertion code follows [SVO](https://en.wikipedia.org/wiki/Subject–verb–object) structure in present tense for terseness and readability

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -2,9 +2,8 @@
 
 
 ## Upcoming...
-_2018-xx-xx_
 <!-- Add new lines here. Version number will be decided later -->
-- ... 
+- Improved wording, spacing and color-coding of report messages and errors ([#2147](https://github.com/MithrilJS/mithril.js/pull/2147), [@maranomynet](https://github.com/maranomynet))
 
 
 ## 2.0.0

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -272,6 +272,7 @@ else window.o = m()
 			}
 		}
 		console.log(
+			(hasProcess ? "- - - - -\n" : "") +
 			(name ? name + ": " : "") +
 			results.length + " assertions completed in " + Math.round(new Date - start) + "ms, " +
 			"of which " + results.filter(function(result){return result.error}).length + " failed"

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -290,7 +290,7 @@ else window.o = m()
 		}
 		var pl = results.length === 1 ? "" : "s"
 		var resultSummary = (errCount === 0) ?
-			highlight((pl ? "All " : "") + results.length + " assertion" + pl + " passed", "green"):
+			highlight((pl ? "All " : "The ") + results.length + " assertion" + pl + " passed", "green"):
 			highlight(errCount + " out of " + results.length + " assertion" + pl + " failed", "red2")
 		var runningTime = " in " + Math.round(Date.now() - start) + "ms"
 

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -258,8 +258,14 @@ else window.o = m()
 		else if (typeof value === "function") return value.name || "<anonymous function>"
 		try {return JSON.stringify(value)} catch (e) {return String(value)}
 	}
-	function highlight(message) {
-		return hasProcess ? (process.stdout.isTTY ? "\x1b[31m" + message + "\x1b[0m" : message) : "%c" + message + "%c "
+	const colorCodes = {
+		red: "31m",
+		red2: "31;1m",
+		green: "32m"
+	}
+	function highlight(message, color) {
+		const code = colorCodes[color] || colorCodes.red;
+		return hasProcess ? (process.stdout.isTTY ? "\x1b[" + code + message + "\x1b[0m" : message) : "%c" + message + "%c "
 	}
 
 	o.report = function (results) {
@@ -271,11 +277,15 @@ else window.o = m()
 				errCount++
 			}
 		}
+		const resultSummary = (errCount === 0) ?
+			highlight("All " + results.length + " assertions passed", "green"):
+			highlight(errCount + " out of " + results.length + " assertions failed", "red2")
+		const runningTime = " in " + Math.round(Date.now() - start) + "ms"
+
 		console.log(
 			(hasProcess ? "- - - - -\n" : "") +
-			(name ? name + ": " : "") +
-			results.length + " assertions completed in " + Math.round(new Date - start) + "ms, " +
-			"of which " + results.filter(function(result){return result.error}).length + " failed"
+			(name ? name + ": " : "") + resultSummary + runningTime,
+			hasProcess ? "" : "font-weight:bold;color:"(errCount === 0 ? "green" : "red"), ""
 		)
 		return errCount
 	}

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -258,14 +258,14 @@ else window.o = m()
 		else if (typeof value === "function") return value.name || "<anonymous function>"
 		try {return JSON.stringify(value)} catch (e) {return String(value)}
 	}
-	const colorCodes = {
+	var colorCodes = {
 		red: "31m",
 		red2: "31;1m",
 		green: "32m",
 		cyan: "36m"
 	}
 	function highlight(message, color) {
-		const code = colorCodes[color] || colorCodes.red;
+		var code = colorCodes[color] || colorCodes.red;
 		return hasProcess ? (process.stdout.isTTY ? "\x1b[" + code + message + "\x1b[0m" : message) : "%c" + message + "%c "
 	}
 
@@ -282,11 +282,11 @@ else window.o = m()
 				errCount++
 			}
 		}
-		const pl = results.length === 1 ? "" : "s"
-		const resultSummary = (errCount === 0) ?
+		var pl = results.length === 1 ? "" : "s"
+		var resultSummary = (errCount === 0) ?
 			highlight((pl ? "All " : "") + results.length + " assertion" + pl + " passed", "green"):
 			highlight(errCount + " out of " + results.length + " assertion" + pl + " failed", "red2")
-		const runningTime = " in " + Math.round(Date.now() - start) + "ms"
+		var runningTime = " in " + Math.round(Date.now() - start) + "ms"
 
 		console.log(
 			(hasProcess ? "- - - - -\n" : "") +

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -268,6 +268,9 @@ else window.o = m()
 		var code = colorCodes[color] || colorCodes.red;
 		return hasProcess ? (process.stdout.isTTY ? "\x1b[" + code + message + "\x1b[0m" : message) : "%c" + message + "%c "
 	}
+	function cStyle(color, bold) {
+		return hasProcess||!color ? "" : "color:"+color+(bold ? ";font-weight:bold" : "")
+	}
 
 	o.report = function (results) {
 		var errCount = 0
@@ -276,8 +279,8 @@ else window.o = m()
 				var stackTrace = o.cleanStackTrace(r.error)
 				console.error(
 					r.context + ":\n" + highlight(r.message) + (stackTrace ? "\n" + highlight(stackTrace, "cyan") + "\n" : ""),
-					hasProcess ? "" : "color:red;font-weight:bold", "",
-					hasProcess ? "" : "color:black", ""
+					cStyle("red", true), "",
+					cStyle("black"), ""
 				)
 				errCount++
 			}
@@ -291,7 +294,7 @@ else window.o = m()
 		console.log(
 			(hasProcess ? "- - - - -\n" : "") +
 			(name ? name + ": " : "") + resultSummary + runningTime,
-			hasProcess ? "" : "font-weight:bold;color:"(errCount === 0 ? "green" : "red"), ""
+			cStyle((errCount === 0 ? "green" : "red"), true), ""
 		)
 		return errCount
 	}

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -261,8 +261,7 @@ else window.o = m()
 	var colorCodes = {
 		red: "31m",
 		red2: "31;1m",
-		green: "32;1m",
-		cyan: "36m"
+		green: "32;1m"
 	}
 	function highlight(message, color) {
 		var code = colorCodes[color] || colorCodes.red;
@@ -278,9 +277,13 @@ else window.o = m()
 			if (!r.pass) {
 				var stackTrace = o.cleanStackTrace(r.error)
 				console.error(
-					r.context + ":\n" + highlight(r.message) + (stackTrace ? "\n" + highlight(stackTrace, "cyan") + "\n" : ""),
-					cStyle("red", true), "",
-					cStyle("black"), ""
+					(hasProcess ? "\n" : "") +
+					highlight(r.context + ":", "red2") + "\n" +
+					highlight(r.message, "red") +
+					(stackTrace ? "\n" + stackTrace + "\n" : ""),
+
+					cStyle("black", true), "", // reset to default
+					cStyle("red"), cStyle("black")
 				)
 				errCount++
 			}

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -231,7 +231,7 @@ else window.o = m()
 	function define(name, verb, compare) {
 		Assert.prototype[name] = function assert(value) {
 			if (compare(this.value, value)) record(null)
-			else record(serialize(this.value) + "\n" + verb + "\n" + serialize(value))
+			else record(serialize(this.value) + "\n  " + verb + "\n" + serialize(value))
 			return function(message) {
 				var result = results[results.length - 1]
 				result.message = message + "\n\n" + result.message
@@ -261,7 +261,8 @@ else window.o = m()
 	const colorCodes = {
 		red: "31m",
 		red2: "31;1m",
-		green: "32m"
+		green: "32m",
+		cyan: "36m"
 	}
 	function highlight(message, color) {
 		const code = colorCodes[color] || colorCodes.red;
@@ -273,7 +274,11 @@ else window.o = m()
 		for (var i = 0, r; r = results[i]; i++) {
 			if (!r.pass) {
 				var stackTrace = o.cleanStackTrace(r.error)
-				console.error(r.context + ":\n" + highlight(r.message) + (stackTrace ? "\n\n" + stackTrace + "\n\n" : ""), hasProcess ? "" : "color:red", hasProcess ? "" : "color:black")
+				console.error(
+					r.context + ":\n" + highlight(r.message) + (stackTrace ? "\n" + highlight(stackTrace, "cyan") + "\n" : ""),
+					hasProcess ? "" : "color:red;font-weight:bold", "",
+					hasProcess ? "" : "color:black", ""
+				)
 				errCount++
 			}
 		}

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -282,9 +282,10 @@ else window.o = m()
 				errCount++
 			}
 		}
+		const pl = results.length === 1 ? "" : "s"
 		const resultSummary = (errCount === 0) ?
-			highlight("All " + results.length + " assertions passed", "green"):
-			highlight(errCount + " out of " + results.length + " assertions failed", "red2")
+			highlight((pl ? "All " : "") + results.length + " assertion" + pl + " passed", "green"):
+			highlight(errCount + " out of " + results.length + " assertion" + pl + " failed", "red2")
 		const runningTime = " in " + Math.round(Date.now() - start) + "ms"
 
 		console.log(

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -261,7 +261,7 @@ else window.o = m()
 	var colorCodes = {
 		red: "31m",
 		red2: "31;1m",
-		green: "32m",
+		green: "32;1m",
 		cyan: "36m"
 	}
 	function highlight(message, color) {

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -292,7 +292,7 @@ else window.o = m()
 		var runningTime = " in " + Math.round(Date.now() - start) + "ms"
 
 		console.log(
-			(hasProcess ? "- - - - -\n" : "") +
+			(hasProcess ? "––––––\n" : "") +
 			(name ? name + ": " : "") + resultSummary + runningTime,
 			cStyle((errCount === 0 ? "green" : "red"), true), ""
 		)


### PR DESCRIPTION
I thought the default reporter could be made to look nicer, using more colors, a divider and slight indenting of the `verb` ("should equals" etc) and some rewording of the final result message.

## Before 
<img width="486" alt="screen shot 2018-05-11 at 00 02 30" src="https://user-images.githubusercontent.com/86827/39900096-0d0e12d0-54af-11e8-94f3-e8d207f6a7fd.png">
<img width="508" alt="screen shot 2018-05-11 at 00 03 04" src="https://user-images.githubusercontent.com/86827/39900097-0d399c66-54af-11e8-9ad3-8d73d8596337.png">

**Browser:**
<img width="445" alt="screen shot 2018-05-11 at 00 13 08" src="https://user-images.githubusercontent.com/86827/39900303-7cdc6aac-54b0-11e8-976c-d39d7024bea3.png">
<img width="420" alt="screen shot 2018-05-11 at 00 14 20" src="https://user-images.githubusercontent.com/86827/39900304-7d0f4f9e-54b0-11e8-92a6-7f02a6248b23.png">

## After

**Update:** See **[below comment with updated screenshots](https://github.com/MithrilJS/mithril.js/pull/2147#issuecomment-388315182)**

<img width="466" alt="screen shot 2018-05-11 at 00 01 29" src="https://user-images.githubusercontent.com/86827/39900095-0cdedf38-54af-11e8-8477-dfffd916e307.png">
<img width="462" alt="screen shot 2018-05-11 at 00 00 32" src="https://user-images.githubusercontent.com/86827/39900094-0cab6e78-54af-11e8-8dee-45644c6526af.png">

**Browser:**
<img width="443" alt="screen shot 2018-05-11 at 00 11 26" src="https://user-images.githubusercontent.com/86827/39900316-9c718f64-54b0-11e8-8c70-c1a1097498b5.png">
<img width="434" alt="screen shot 2018-05-11 at 00 14 40" src="https://user-images.githubusercontent.com/86827/39900317-9c9e9f86-54b0-11e8-9017-d177522fae16.png">



## How Has This Been Tested?
Ran tests in node and pasted representative `console.log` and `console.error`strings into the developer console of Chrome and Firefox. (See screenshots below.)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
