### PR TITLE
Fix stack trace edge case

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -67,7 +67,7 @@ else window.o = m()
 		}
 		if (ospecFileName == null) return stack.join("\n")
 		// skip ospec-related entries on the stack
-		while (stack[i].indexOf(ospecFileName) !== -1) i++
+		while (stack[i] && stack[i].indexOf(ospecFileName) !== -1) i++
 		// now we're in user code
 		return stack[i]
 	}


### PR DESCRIPTION
Ospec is crashing in one of my projects when the stack returns `-1` for *all* invocations of `.indexOf(ospecFileName)`. This causes `i` to eventually increment past the length of the array and spit out the following error:

```
TypeError: Cannot read property 'indexOf' of undefined
    at Function.o.cleanStackTrace (./node_modules/ospec/ospec.js:70:19)
    at Function.o.report (./node_modules/ospec/ospec.js:269:24)
    at Timeout._onTimeout (./node_modules/ospec/ospec.js:81:23)
    at ontimeout (timers.js:482:11)
    at tryOnTimeout (timers.js:317:5)
    at Timer.listOnTimeout (timers.js:277:5)
```

This change prevents this from happening, spitting out the true error from the test failure instead.