### PR TITLE
Introduce longest increasing subsequence-based node moves in keyed diff

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -33,7 +33,8 @@
 - API: `m.request` supports `timeout` as attr - ([#1966](https://github.com/MithrilJS/mithril.js/pull/1966))
 - Mocks: add limited support for the DOMParser API ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
 - API: add support for raw SVG in `m.trust()` string ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
-- Internals: remove the DOM nodes recycling pool ([#2122](https://github.com/MithrilJS/mithril.js/pull/2122))
+- render/core: remove the DOM nodes recycling pool ([#2122](https://github.com/MithrilJS/mithril.js/pull/2122))
+- render/core: revamp the core diff engine, and introduce a longest-increasing-subsequence-based logic to minimize DOM operations when re-ordering keyed nodes.
 
 #### Bug fixes
 

--- a/render/render.js
+++ b/render/render.js
@@ -221,13 +221,13 @@ module.exports = function($window) {
 	// The fourth section does keyed diff for the situations not covered by the other three. It
 	// builds a {key: oldIndex} dictionary and uses it to find old nodes that match the keys of
 	// new ones.
-	// The nodes from the `old` array that have a match in the new `vnodes` one are marked as
-	// `vnode.skip: true`.
+	// The nodes from the `old` array that have a match in the new `vnodes` one are removed from
+	// the old list (set to `null`).
 	//
 	// If there are still nodes in the new `vnodes` array that haven't been matched to old ones,
 	// they are created.
 	// The range of old nodes that wasn't covered by the first three sections is passed to
-	// `removeNodes()`. Those nodes are removed unless marked as `.skip: true`.
+	// `removeNodes()`. The nodes that remain in the list are removed  from the DOM.
 	//
 	// It should be noted that the description of the four sections above is not perfect, because those
 	// parts are actually implemented as only two loops, one for the first two parts, and one for
@@ -380,7 +380,7 @@ module.exports = function($window) {
 								pos = (oldIndex < pos) ? oldIndex : -1 // becomes -1 if nodes were re-ordered
 								oldIndices[i-start] = oldIndex
 								o = old[oldIndex]
-								o.skip = true
+								old[oldIndex] = null
 								if (o !== v) updateNode(parent, o, v, hooks, nextSibling, ns)
 								if (v.dom != null) nextSibling = v.dom
 								matched = true
@@ -605,10 +605,7 @@ module.exports = function($window) {
 	function removeNodes(vnodes, start, end) {
 		for (var i = start; i < end; i++) {
 			var vnode = vnodes[i]
-			if (vnode != null) {
-				if (vnode.skip) vnode.skip = false
-				else removeNode(vnode)
-			}
+			if (vnode != null) removeNode(vnode)
 		}
 	}
 	function removeNode(vnode) {

--- a/render/render.js
+++ b/render/render.js
@@ -200,39 +200,47 @@ module.exports = function($window) {
 
 	// ## Diffing
 	//
-	// If one list is keyed and the other is unkeyed, the old is removed, and the new one is
-	// inserted (since the keys are guaranteed to differ).
+	// Reading https://github.com/localvoid/ivi/blob/ddc09d06abaef45248e6133f7040d00d3c6be853/packages/ivi/src/vdom/implementation.ts#L617-L837
+	// may be good for context on longest increasing subsequence-based logic for moving nodes.
 	//
-	// Then comes the unkeyed diff algo, and at last, the keyed diff algorithm that is split
-	// in four parts (simplifying a bit).
+	// In order to diff keyed lists, one has to
 	//
-	// The first part goes through both lists top-down as long as the nodes at each level have
-	// the same key.
+	// 1) match nodes in both lists, per key, and update them accordingly
+	// 2) create the nodes present in the new list, but absent in the old one
+	// 3) remove the nodes present in the old list, but absent in the new one
+	// 4) figure out what nodes in 1) to move in order to minimize the DOM operations.
 	//
-	// The second part deals with lists reversals, and traverses one list top-down and the other
-	// bottom-up (as long as the keys match).
+	// To achieve 1) one can create a dictionary of keys => index (for the old list), then iterate
+	// over the new list and for each new vnode, find the corresponding vnode in the old list using
+	// the map.
+	// 2) is achieved in the same step: if a new node has no corresponding entry in the map, it is new
+	// and must be created.
+	// For the removals, we actually remove the nodes that have been updated from the old list.
+	// The nodes that remain in that list after 1) and 2) have been performed can be safely removed.
+	// The fourth step is a bit more complex and relies on the longest increasing subsequence (LIS)
+	// algorithm.
 	//
-	// The third part goes through both lists bottom up as long as the keys match.
+	// the longest increasing subsequence is the list of nodes that can remain in place. Imagine going
+	// from `1,2,3,4,5` to `4,5,1,2,3` where the numbers are not necessarily the keys, but the indices
+	// corresponding to the keyed nodes in the old list (keyed nodes `e,d,c,b,a` => `b,a,e,d,c` would
+	//  match the above lists, for example).
 	//
-	// The first and third sections allow us to deal efficiently with situations where one or
-	// more contiguous nodes were either inserted into, removed from or re-ordered in an otherwise
-	// sorted list. They may reduce the number of nodes to be processed in the fourth section.
+	// In there are two increasing subsequences: `4,5` and `1,2,3`, the latter being the longest. We
+	// can update those nodes without moving them, and only call `insertNode` on `4` and `5`.
 	//
-	// The fourth section does keyed diff for the situations not covered by the other three. It
-	// builds a {key: oldIndex} dictionary and uses it to find old nodes that match the keys of
-	// new ones.
-	// The nodes from the `old` array that have a match in the new `vnodes` one are removed from
-	// the old list (set to `null`).
+	// @localvoid adapted the algo to also support node deletions and insertions (the `lis` is actually
+	// the longest increasing subsequence *of old nodes still present in the new list*).
 	//
-	// If there are still nodes in the new `vnodes` array that haven't been matched to old ones,
-	// they are created.
-	// The range of old nodes that wasn't covered by the first three sections is passed to
-	// `removeNodes()`. The nodes that remain in the list are removed  from the DOM.
+	// It is a general algorithm that is fireproof in all circumstances, but it requires the allocation
+	// and the construction of a `key => oldIndex` map, and three arrays (one with `newIndex => oldIndex`,
+	// the `LIS` and a temporary one to create the LIS).
 	//
-	// It should be noted that the description of the four sections above is not perfect, because those
-	// parts are actually implemented as only two loops, one for the first two parts, and one for
-	// the other two. I'm not sure it wins us anything except maybe a few bytes of file size.
-
+	// So we cheat where we can: if the tails of the lists are identical, they are guaranteed to be part of
+	// the LIS and can be updated without moving them.
+	//
+	// If two nodes are swapped, they are guaranteed not to be part of the LIS, and must be moved (with
+	// the exception of the last node if the list is fully reversed).
+	//
 	// ## Finding the next sibling.
 	//
 	// `updateNode()` and `createNode()` expect a nextSibling parameter to perform DOM operations.
@@ -301,6 +309,7 @@ module.exports = function($window) {
 				// keyed diff
 				var oldEnd = old.length - 1, end = vnodes.length - 1, map, o, v, oe, ve, topSibling
 
+				// bottom-up
 				while (oldEnd >= oldStart && end >= start) {
 					oe = old[oldEnd]
 					ve = vnodes[end]
@@ -314,6 +323,7 @@ module.exports = function($window) {
 						break
 					}
 				}
+				// top-down
 				while (oldEnd >= oldStart && end >= start) {
 					o = old[oldStart]
 					v = vnodes[start]
@@ -326,11 +336,8 @@ module.exports = function($window) {
 						break
 					}
 				}
-
-				//swaps and list reversals
+				// swaps and list reversals
 				while (oldEnd >= oldStart && end >= start) {
-					o = old[oldStart]
-					v = vnodes[start]
 					if (o == null) oldStart++
 					else if (v == null) start++
 					else if (oe == null) oldEnd--
@@ -348,7 +355,10 @@ module.exports = function($window) {
 					}
 					oe = old[oldEnd]
 					ve = vnodes[end]
+					o = old[oldStart]
+					v = vnodes[start]
 				}
+				// bottom up once again
 				while (oldEnd >= oldStart && end >= start) {
 					if (oe == null) oldEnd--
 					else if (ve == null) end--
@@ -365,47 +375,48 @@ module.exports = function($window) {
 				if (start > end) removeNodes(old, oldStart, oldEnd + 1)
 				else if (oldStart > oldEnd) createNodes(parent, vnodes, start, end + 1, hooks, nextSibling, ns)
 				else {
-					// inspired by ivi
-					var originalNextSibling = nextSibling, vnodesLength = end - start + 1, map, i, lis
-					var oldIndices = new Array(end - start + 1)
+					// inspired by ivi https://github.com/ivijs/ivi/ by Boris Kaul
+					var originalNextSibling = nextSibling, vnodesLength = end - start + 1, oldIndices = new Array(vnodesLength), li=0, i=0, pos = 2147483647, matched = 0, map, lisIndices
 					for (i = 0; i < vnodesLength; i++) oldIndices[i] = -1
-					var pos = 2147483647, matched = false
-
 					for (i = end; i >= start; i--) {
 						if (map == null) map = getKeyMap(old, oldStart, oldEnd + 1)
-						v = vnodes[i]
-						if (v != null) {
-							var oldIndex = map[v.key]
+						ve = vnodes[i]
+						if (ve != null) {
+							var oldIndex = map[ve.key]
 							if (oldIndex != null) {
 								pos = (oldIndex < pos) ? oldIndex : -1 // becomes -1 if nodes were re-ordered
 								oldIndices[i-start] = oldIndex
-								o = old[oldIndex]
+								oe = old[oldIndex]
 								old[oldIndex] = null
-								if (o !== v) updateNode(parent, o, v, hooks, nextSibling, ns)
-								if (v.dom != null) nextSibling = v.dom
-								matched = true
+								if (oe !== ve) updateNode(parent, oe, ve, hooks, nextSibling, ns)
+								if (ve.dom != null) nextSibling = ve.dom
+								matched++
 							}
 						}
 					}
 					nextSibling = originalNextSibling
-					removeNodes(old, oldStart, oldEnd + 1)
-					if (!matched) createNodes(parent, vnodes, start, end + 1, hooks, nextSibling, ns)
+					if (matched !== oldEnd - oldStart + 1) removeNodes(old, oldStart, oldEnd + 1)
+					if (matched === 0) createNodes(parent, vnodes, start, end + 1, hooks, nextSibling, ns)
 					else {
 						if (pos === -1) {
-							lis = makeLis(oldIndices)
-							var lisi = lis.length - 1
+							// the indices of the indices of the items that are part of the
+							// longest increasing subsequence in the oldIndices list
+							lisIndices = makeLisIndices(oldIndices)
+							li = lisIndices.length - 1
 							for (i = end; i >= start; i--) {
-								if (oldIndices[i-start] === -1) createNode(parent, vnodes[i], hooks, ns, nextSibling)
+								v = vnodes[i]
+								if (oldIndices[i-start] === -1) createNode(parent, v, hooks, ns, nextSibling)
 								else {
-									if (lis[lisi] === i - start) lisi--
-									else insertNode(parent, toFragment(vnodes[i]), nextSibling)
+									if (lisIndices[li] === i - start) li--
+									else insertNode(parent, toFragment(v), nextSibling)
 								}
-								if (vnodes[i].dom != null) nextSibling = vnodes[i].dom
+								if (v.dom != null) nextSibling = vnodes[i].dom
 							}
 						} else {
 							for (i = end; i >= start; i--) {
-								if (oldIndices[i-start] === -1) createNode(parent, vnodes[i], hooks, ns, nextSibling)
-								if (vnodes[i].dom != null) nextSibling = vnodes[i].dom
+								v = vnodes[i]
+								if (oldIndices[i-start] === -1) createNode(parent, v, hooks, ns, nextSibling)
+								if (v.dom != null) nextSibling = vnodes[i].dom
 							}
 						}
 					}
@@ -522,7 +533,11 @@ module.exports = function($window) {
 		return map
 	}
 	// Lifted from ivi https://github.com/ivijs/ivi/
-	function makeLis(a) {
+	// takes a list of unique numbers (-1 is special and can
+	// occur multiple times) and returns an array with the indices
+	// of the items that are part of the longest increasing
+	// subsequece
+	function makeLisIndices(a) {
 		var p = a.slice()
 		var result = []
 		result.push(0)

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -134,17 +134,17 @@ o.spec("updateNodes", function() {
 	o("reverses els w/ odd count", function() {
 		var vnodes = [{tag: "a", key: 1}, {tag: "b", key: 2}, {tag: "i", key: 3}]
 		var updated = [{tag: "i", key: 3}, {tag: "b", key: 2}, {tag: "a", key: 1}]
-
+		var expectedTags = updated.map(function(vn) {return vn.tag})
 		render(root, vnodes)
 		render(root, updated)
 
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
 		o(root.childNodes.length).equals(3)
 		o(updated[0].dom.nodeName).equals("I")
-		o(updated[0].dom).equals(root.childNodes[0])
 		o(updated[1].dom.nodeName).equals("B")
-		o(updated[1].dom).equals(root.childNodes[1])
 		o(updated[2].dom.nodeName).equals("A")
-		o(updated[2].dom).equals(root.childNodes[2])
+		o(tagNames).deepEquals(expectedTags)
 	})
 	o("creates el at start", function() {
 		var vnodes = [{tag: "a", key: 1}]
@@ -1100,6 +1100,149 @@ o.spec("updateNodes", function() {
 
 		o([].map.call(root.childNodes, function(el) {return el.nodeName})).deepEquals(["DIV", "DIV", "P"])
 	})
+	o("minimizes DOM operations when scrambling a keyed lists", function() {
+		var vnodes = [{tag: "a", key: "a"}, {tag: "b", key: "b"}, {tag: "c", key: "c"}, {tag: "d", key: "d"}]
+		var updated = [{tag: "b", key: "b"}, {tag: "a", key: "a"}, {tag: "d", key: "d"}, {tag: "c", key: "c"}]
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(2)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("minimizes DOM operations when reversing a keyed lists with an odd number of items", function() {
+		var vnodes = [{tag: "a", key: "a"}, {tag: "b", key: "b"}, {tag: "c", key: "c"}, {tag: "d", key: "d"}]
+		var updated = [{tag: "d", key: "d"}, {tag: "c", key: "c"}, {tag: "b", key: "b"}, {tag: "a", key: "a"}]
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(3)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("minimizes DOM operations when reversing a keyed lists with an even number of items", function() {
+		var vnodes = [{tag: "a", key: "a"}, {tag: "b", key: "b"}, {tag: "c", key: "c"}]
+		var updated = [{tag: "c", key: "c"}, {tag: "b", key: "b"}, {tag: "a", key: "a"}]
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(2)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("minimizes DOM operations when scrambling a keyed lists with prefixes and suffixes", function() {
+		var vnodes = [{tag: "i", key: "i"}, {tag: "a", key: "a"}, {tag: "b", key: "b"}, {tag: "c", key: "c"}, {tag: "d", key: "d"}, {tag: "j", key: "j"}]
+		var updated = [{tag: "i", key: "i"}, {tag: "b", key: "b"}, {tag: "a", key: "a"}, {tag: "d", key: "d"}, {tag: "c", key: "c"}, {tag: "j", key: "j"}]
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(2)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("minimizes DOM operations when reversing a keyed lists with an odd number of items with prefixes and suffixes", function() {
+		var vnodes = [{tag: "i", key: "i"}, {tag: "a", key: "a"}, {tag: "b", key: "b"}, {tag: "c", key: "c"}, {tag: "d", key: "d"}, {tag: "j", key: "j"}]
+		var updated = [{tag: "i", key: "i"}, {tag: "d", key: "d"}, {tag: "c", key: "c"}, {tag: "b", key: "b"}, {tag: "a", key: "a"}, {tag: "j", key: "j"}]
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(3)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("minimizes DOM operations when reversing a keyed lists with an even number of items with prefixes and suffixes", function() {
+		var vnodes = [{tag: "i", key: "i"}, {tag: "a", key: "a"}, {tag: "b", key: "b"}, {tag: "c", key: "c"}, {tag: "j", key: "j"}]
+		var updated = [{tag: "i", key: "i"}, {tag: "c", key: "c"}, {tag: "b", key: "b"}, {tag: "a", key: "a"}, {tag: "j", key: "j"}]
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(2)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("scrambling sample 1", function() {
+		function vnodify(str) {
+			return str.split(",").map(function(k) {return {tag: k, key: k}})
+		}
+		var vnodes = vnodify("k0,k1,k2,k3,k4,k5,k6,k7,k8,k9")
+		var updated = vnodify("k4,k1,k2,k9,k0,k3,k6,k5,k8,k7")
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(5)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	o("scrambling sample 2", function() {
+		function vnodify(str) {
+			return str.split(",").map(function(k) {return {tag: k, key: k}})
+		}
+		var vnodes = vnodify("k0,k1,k2,k3,k4,k5,k6,k7,k8,k9")
+		var updated = vnodify("b,d,k1,k0,k2,k3,k4,a,c,k5,k6,k7,k8,k9")
+		var expectedTagNames = updated.map(function(vn) {return vn.tag})
+
+		render(root, vnodes)
+
+		root.appendChild = o.spy(root.appendChild)
+		root.insertBefore = o.spy(root.insertBefore)
+
+		render(root, updated)
+
+		var tagNames = [].map.call(root.childNodes, function(n) {return n.nodeName.toLowerCase()})
+
+		o(root.appendChild.callCount + root.insertBefore.callCount).equals(5)
+		o(tagNames).deepEquals(expectedTagNames)
+	})
+	
 	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create

--- a/render/tests/test-updateNodesFuzzer.js
+++ b/render/tests/test-updateNodesFuzzer.js
@@ -1,0 +1,159 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var domMock = require("../../test-utils/domMock")
+var vdom = require("../../render/render")
+
+// pilfered and adapted from https://github.com/domvm/domvm/blob/7aaec609e4c625b9acf9a22d035d6252a5ca654f/test/src/flat-list-keyed-fuzz.js
+o.spec("updateNodes keyed list Fuzzer", function() {
+	var i = 0, $window, root, render
+	o.beforeEach(function() {
+		$window = domMock()
+		root = $window.document.createElement("div")
+		render = vdom($window).render
+	})
+
+	
+	void [
+		{delMax: 0, movMax: 50, insMax: 9},
+		{delMax: 3, movMax: 5, insMax: 5},
+		{delMax: 7, movMax: 15, insMax: 0},
+		{delMax: 5, movMax: 100, insMax: 3},
+		{delMax: 5, movMax: 0, insMax: 3},
+	].forEach(function(c) {
+		var tests = 250
+
+		while (tests--) {
+			var test = fuzzTest(c.delMax, c.movMax, c.insMax)
+			o(i++ + ": " + test.list.join() + " -> " + test.updated.join(), function() {
+				render(root, test.list.map(function(x){return {tag: x, key: x}}))
+				addSpies(root)
+				render(root, test.updated.map(function(x){return {tag: x, key: x}}))
+
+				if (root.appendChild.callCount + root.insertBefore.callCount !== test.expected.creations + test.expected.moves) console.log(test, {aC: root.appendChild.callCount, iB: root.insertBefore.callCount}, [].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()}))
+				
+				o(root.appendChild.callCount + root.insertBefore.callCount).equals(test.expected.creations + test.expected.moves)("moves")
+				o(root.removeChild.callCount).equals(test.expected.deletions)("deletions")
+				o([].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()})).deepEquals(test.updated)
+			})
+		}
+	})
+})
+
+// https://en.wikipedia.org/wiki/Longest_increasing_subsequence
+// impl borrowed from https://github.com/ivijs/ivi
+function longestIncreasingSubsequence(a) {
+	var p = a.slice()
+	var result = []
+	result.push(0)
+	var u
+	var v
+
+	for (var i = 0, il = a.length; i < il; ++i) {
+		var j = result[result.length - 1]
+		if (a[j] < a[i]) {
+			p[i] = j
+			result.push(i)
+			continue
+		}
+
+		u = 0
+		v = result.length - 1
+
+		while (u < v) {
+			/*eslint-disable no-bitwise*/
+			var c = ((u + v) / 2) | 0
+			/*eslint-enable no-bitwise*/
+			if (a[result[c]] < a[i]) {
+				u = c + 1
+			} else {
+				v = c
+			}
+		}
+
+		if (a[i] < a[result[u]]) {
+			if (u > 0) {
+				p[i] = result[u - 1]
+			}
+			result[u] = i
+		}
+	}
+
+	u = result.length
+	v = result[u - 1]
+
+	while (u-- > 0) {
+		result[u] = v
+		v = p[v]
+	}
+
+	return result
+}
+
+function rand(min, max) {
+	return Math.floor(Math.random() * (max - min + 1)) + min
+}
+
+function ins(arr, qty) {
+	var p = ["a","b","c","d","e","f","g","h","i"]
+
+	while (qty-- > 0)
+		arr.splice(rand(0, arr.length - 1), 0, p.shift())
+}
+
+function del(arr, qty) {
+	while (qty-- > 0)
+		arr.splice(rand(0, arr.length - 1), 1)
+}
+
+function mov(arr, qty) {
+	while (qty-- > 0) {
+		var from = rand(0, arr.length - 1)
+		var to = rand(0, arr.length - 1)
+
+		arr.splice(to, 0, arr.splice(from, 1)[0])
+	}
+}
+
+function fuzzTest(delMax, movMax, insMax) {
+	var list = ["k0","k1","k2","k3","k4","k5","k6","k7","k8","k9"]
+	var copy = list.slice()
+
+	var delCount = rand(0, delMax),
+		movCount = rand(0, movMax),
+		insCount = rand(0, insMax)
+
+	del(copy, delCount)
+	mov(copy, movCount)
+
+	var expected = {
+		creations: insCount,
+		deletions: delCount,
+		moves: 0
+	}
+
+	if (movCount > 0) {
+		var newPos = copy.map(function(v) {
+			return list.indexOf(v)
+		}).filter(function(i) {
+			return i != -1
+		})
+		var lis = longestIncreasingSubsequence(newPos)
+		expected.moves = copy.length - lis.length
+	}
+
+	ins(copy, insCount)
+
+	return {
+		expected: expected,
+		list: list,
+		updated: copy
+	}
+}
+
+function addSpies(node) {
+	node.appendChild = o.spy(node.appendChild)
+	node.insertBefore = o.spy(node.insertBefore)
+	node.removeChild = o.spy(node.removeChild)
+}
+

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,7 +1,7 @@
 "use strict"
 
 function Vnode(tag, key, attrs, children, text, dom) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: undefined, events: undefined, instance: undefined, skip: false}
+	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: undefined, events: undefined, instance: undefined}
 }
 Vnode.normalize = function(node) {
 	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -71,7 +71,7 @@ module.exports = function(options) {
 		var index = this.childNodes.indexOf(child)
 		if (index > -1) this.childNodes.splice(index, 1)
 		if (child.nodeType === 11) {
-			while (child.firstChild != null) this.appendChild(child.firstChild)
+			while (child.firstChild != null) appendChild.call(this, child.firstChild)
 			child.childNodes = []
 		}
 		else {
@@ -99,7 +99,7 @@ module.exports = function(options) {
 		var index = this.childNodes.indexOf(child)
 		if (reference !== null && refIndex < 0) throw new TypeError("Invalid argument")
 		if (index > -1) this.childNodes.splice(index, 1)
-		if (reference === null) this.appendChild(child)
+		if (reference === null) appendChild.call(this, child)
 		else {
 			if (index !== -1 && refIndex > index) refIndex--
 			if (child.nodeType === 11) {
@@ -276,7 +276,7 @@ module.exports = function(options) {
 					},
 					set textContent(value) {
 						this.childNodes = []
-						if (value !== "") this.appendChild($window.document.createTextNode(value))
+						if (value !== "") appendChild.call(this, $window.document.createTextNode(value))
 					},
 					set innerHTML(value) {
 						var voidElements = ["area", "base", "br", "col", "command", "embed", "hr", "img", "input", "keygen", "link", "meta", "param", "source", "track", "wbr"]
@@ -286,7 +286,7 @@ module.exports = function(options) {
 							var value = match[1]
 							root = $window.document.createElementNS("http://www.w3.org/2000/svg", "svg")
 							ns = "http://www.w3.org/2000/svg"
-							this.appendChild(root)
+							appendChild.call(this, root)
 						} else {
 							root = this
 						}


### PR DESCRIPTION
## Description

This has been a long time coming. This changes the core keyed diff algo as follows.

Previously we were

1) traversing the list top down as long as keyed were matching
2) moving nodes from top to bottom if the top of the old list matched the end of the new one (list reversal)
3) traversing both lists bottom-up as long as the keys match
4) creating a `{[key]: index}` map for the old list, and using it to match old and new nodes when the order was scrambled.

This was sometimes causing unneeded DOM node moves.

This PR takes a page from [ivi](https://github.com/localvoid/ivi/blob/e933fbef767961382c6d8c87c33679005fba08ba/packages/ivi/src/vdom/implementation.ts#L637-L863) and changes the way step 2 and 4 work.

Now we first perform step 1 and 3. 

Then we do symmetric swaps (asymetric ones as we were doing have pathological corner cases).

Then we create an array that has the size of the new vnodes array and fill it with the indices of the nodes with the corresponding key in the old list `oldIndices` (a {[key]: index} map is also created), and determine if the nodes have moved between lists.

Then we try 1) once again (for cases where two nodes were swapped in a list that otherwise didn't change).

If they have moved, we compute the list of the nodes that should be left in place (the `lis`, the longest increasing subsequence), and only move the other ones.

Ivi has an additional optimisation where it uses brute force rather than a map to create the `oldIndices` array for small lists.

The code here is already 400 bytes larger than before so I didn't implement it.

I'll have little time this weekend, I'd appreciate if someone could run https://github.com/krausest/js-framework-benchmark/ before/after this patch and report back.

I haven't benchmarked it at all (@tivac' benchmarks don't cover keyed diff) there may be regressions...

## Motivation and Context

fix #1791, fix #2026, hopefully improve perf.

## How Has This Been Tested?
The current test suite passes as is, I've added a new test that checks that the DOM operations are minimized. More should follow though, to cover all the branches of the new algo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [/] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`

I'll update the change log once I'm done with the tests and ready for merging as it will otherwise introduce potential conflicts.
