### PR TITLE
[ospec] pinpoint the o.only() call site

### DIFF
--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -3,6 +3,7 @@
 
 ## Upcoming...
 <!-- Add new lines here. Version number will be decided later -->
+- Pinpoint the `o.only()` call site
 - Improved wording, spacing and color-coding of report messages and errors ([#2147](https://github.com/MithrilJS/mithril.js/pull/2147), [@maranomynet](https://github.com/maranomynet))
 
 

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -34,7 +34,12 @@ else window.o = m()
 		ctx = parent
 	}
 	o.only = function(subject, predicate, silent) {
-		if (!silent) console.log(highlight("/!\\ WARNING /!\\ o.only() mode"))
+		if (!silent) {
+			console.log(highlight("/!\\ WARNING /!\\ o.only() mode"))
+			try {throw new Error} catch (e) {
+				console.log(this.cleanStackTrace(e) + "\n")
+			}
+		}
 		o(subject, only = predicate)
 	}
 	o.spy = function(fn) {


### PR DESCRIPTION
## Description
This adds a cleaned up stack trace after the `o.only()` warning.

I'll update the change log once #2147 is merged

## Motivation and Context
Makes it easier to find the place you added that `.only()` call.

## How Has This Been Tested?
Manually

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
