### PR TITLE
Ospec async fixes

### DIFF
--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1007,7 +1007,9 @@ o.spec("route", function() {
 					})
 				})
 
-				o("when two async routes are racing, the last one set cancels the finalization of the first", function(done) {
+				o("when two async routes are racing, the last one set cancels the finalization of the first", function(done, timeout) {
+					timeout(30)
+
 					var renderA = o.spy()
 					var renderB = o.spy()
 					var onmatchA = o.spy(function(){

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1007,16 +1007,14 @@ o.spec("route", function() {
 					})
 				})
 
-				o("when two async routes are racing, the last one set cancels the finalization of the first", function(done, timeout) {
-					timeout(30)
-
+				o("when two async routes are racing, the last one set cancels the finalization of the first", function(done) {
 					var renderA = o.spy()
 					var renderB = o.spy()
 					var onmatchA = o.spy(function(){
 						return new Promise(function(fulfill) {
 							setTimeout(function(){
 								fulfill()
-							}, 10)
+							}, 5)
 						})
 					})
 
@@ -1047,7 +1045,7 @@ o.spec("route", function() {
 
 											done()
 										})
-									}, 20)
+									}, 10)
 								})
 								return p
 							},

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -67,7 +67,7 @@ else window.o = m()
 		}
 		if (ospecFileName == null) return stack.join("\n")
 		// skip ospec-related entries on the stack
-		while (stack[i].indexOf(ospecFileName) !== -1) i++
+		while (stack[i+1] && stack[i].indexOf(ospecFileName) !== -1) i++
 		// now we're in user code
 		return stack[i]
 	}
@@ -128,7 +128,7 @@ else window.o = m()
 						timeout = clearTimeout(timeout)
 						if (delay !== Infinity) record(null)
 						if (!isDone) next()
-						else throw new Error("`" + arg + "()` should only be called once")
+						else throw new Error("test has already resolved")
 						isDone = true
 					}
 					else console.log("# elapsed: " + Math.round(new Date - s) + "ms, expected under " + delay + "ms")
@@ -143,9 +143,6 @@ else window.o = m()
 				}
 
 				if (fn.length > 0) {
-					var body = fn.toString()
-					var arg = (body.match(/\(([\w$]+)/) || body.match(/([\w$]+)\s*=>/) || []).pop()
-					if (body.indexOf(arg) === body.lastIndexOf(arg)) throw new Error("`" + arg + "()` should be called at least once")
 					try {
 						fn(done, function(t) {delay = t})
 					}

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -114,7 +114,7 @@ else window.o = m()
 				if (cursor === fns.length) return
 
 				var fn = fns[cursor++]
-				var timeout = 0, delay = 200, s = new Date
+				var timeout = 0, delay = 20, s = new Date
 				var isDone = false
 
 				function done(err) {

--- a/ospec/package.json
+++ b/ospec/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "description": "Noiseless testing framework",
   "main": "ospec.js",
+  "scripts": {
+    "test": "node ./bin/ospec"
+  },
   "directories": {
     "test": "tests"
   },

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -3,7 +3,7 @@
 var callAsync = require("../../test-utils/callAsync")
 var o = require("../ospec")
 
-new function(o) {
+void function(o) {
 	o = o.new()
 
 	o.spec("ospec", function() {
@@ -18,7 +18,7 @@ new function(o) {
 	o.run()
 }(o)
 
-new function(o) {
+void function(o) {
 	var clone = o.new()
 
 	clone.spec("clone", function() {
@@ -75,7 +75,7 @@ new function(o) {
 					{pass: true},
 					{pass: false, error: makeError("ho"), message: "ho"}
 				])
-				
+
 				o(errCount).equals(2)
 				o(console.log.callCount).equals(3)
 				o(console.error.callCount).equals(3)
@@ -178,47 +178,6 @@ o.spec("ospec", function() {
 			o(output).deepEquals({tag: "div", children: children})
 		})
 	})
-	o.spec("async callback", function() {
-		var a = 0, b = 0
-
-		o.before(function(done) {
-			callAsync(function() {
-				a = 1
-				done()
-			})
-		})
-		o.after(function(done) {
-			callAsync(function() {
-				a = 0
-				done()
-			})
-		})
-
-		o.beforeEach(function(done) {
-			callAsync(function() {
-				b = 1
-				done()
-			})
-		})
-		o.afterEach(function(done) {
-			callAsync(function() {
-				b = 0
-				done()
-			})
-		})
-
-		o("async hooks", function(done) {
-			callAsync(function() {
-				var spy = o.spy()
-				spy(a)
-
-				o(a).equals(b)
-				o(a).equals(1)("a and b should be initialized")
-
-				done()
-			})
-		})
-	})
 
 	o.spec("stack trace cleaner", function() {
 		o("handles line breaks", function() {
@@ -232,49 +191,51 @@ o.spec("ospec", function() {
 		})
 	})
 
-	o.spec("async promise", function() {
-		var a = 0, b = 0
+	o.spec("async 'done' argument", function () {
+		o("in test callback", function (done) {
+			var a = 0
 
-		function wrapPromise(fn) {
-			return new Promise((resolve, reject) => {
-				callAsync(() => {
-					try {
-						fn()
-						resolve()
-					} catch(e) {
-						reject(e)
-					}
+			callAsync(function () {
+				a = 1
+
+				o(a).equals(1)("defer test resolution")
+
+				done()
+			})
+		});
+
+		o.spec("in hooks", function () {
+			var a = 0, b = 0
+
+			o.before(function (done) {
+				callAsync(function () {
+					a = 1
+					done()
 				})
 			})
-		}
-
-		o.before(function() {
-			return wrapPromise(() => {
-				a = 1
+			o.after(function (done) {
+				callAsync(function () {
+					a = 0
+					done()
+				})
 			})
-		})
 
-		o.after(function() {
-			return wrapPromise(function() {
-				a = 0
+			o.beforeEach(function (done) {
+				callAsync(function () {
+					b = 1
+					done()
+				})
 			})
-		})
+			o.afterEach(function (done) {
+				callAsync(function () {
+					b = 0
+					done()
+				})
+			})
 
-		o.beforeEach(function() {
-			return wrapPromise(function() {
-				b = 1
-			})
-		})
-		o.afterEach(function() {
-			return wrapPromise(function() {
-				b = 0
-			})
-		})
-
-		o("promise functions", function() {
-			return wrapPromise(function() {
+			o("defer test execution", function () {
 				o(a).equals(b)
-				o(a).equals(1)("a and b should be initialized")
+				o(a).equals(1)
 			})
 		})
 	})

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -239,8 +239,8 @@ o.spec("ospec", function() {
 			})
 		})
 
-		o.spec("won't timeout", function (done) {
-			o("by default, before 200ms", function (done) {
+		o.spec("won't timeout", function () {
+			o("by default, before 20ms", function (done) {
 				setTimeout(done, 20)
 			})
 

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -238,5 +238,17 @@ o.spec("ospec", function() {
 				o(a).equals(1)
 			})
 		})
+
+		o.spec("won't timeout", function (done) {
+			o("by default, before 200ms", function (done) {
+				setTimeout(done, 20)
+			})
+
+			o("or longer, if specified", function (done, timeout) {
+				timeout(21)
+
+				setTimeout(done, 21)
+			})
+		})
 	})
 })

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -157,13 +157,35 @@ o.spec("ospec", function() {
 
 		o.spec("won't timeout", function () {
 			o("by default, before 20ms", function (done) {
-				setTimeout(done, 20)
+				setTimeout(done, 10)
 			})
 
-			o("or longer, if specified", function (done, timeout) {
-				timeout(21)
+			o("if it is resolves before the specified timeout", function (done, timeout) {
+				timeout(40)
 
-				setTimeout(done, 21)
+				setTimeout(done, 30)
+			})
+		})
+
+		o("will timeout", function (done, timeout) {
+			timeout(100)
+
+			var clone = o.new()
+
+			clone("by default, after 20ms", function (done) {
+				setTimeout(done, 30)
+			})
+
+			clone("if it is resolves after the specified timeout", function (done, timeout) {
+				timeout(40)
+
+				setTimeout(done, 50)
+			})
+
+			clone.run(function(results){
+				o(results.every(function(report){return report.pass === true}))
+
+				done()
 			})
 		})
 	})
@@ -194,6 +216,7 @@ o.spec("ospec", function() {
 				o(results[1].pass).equals(true)("Test meant to pass has passed")
 			})
 		})
+
 		o("o.report() returns the number of failures", function () {
 			var log = console.log, error = console.error
 			console.log = o.spy()

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -3,94 +3,8 @@
 var callAsync = require("../../test-utils/callAsync")
 var o = require("../ospec")
 
-void function(o) {
-	o = o.new()
-
-	o.spec("ospec", function() {
-		o("skipped", function() {
-			o(true).equals(false)
-		})
-		o.only(".only()", function() {
-			o(2).equals(2)
-		}, true)
-	})
-
-	o.run()
-}(o)
-
-void function(o) {
-	var clone = o.new()
-
-	clone.spec("clone", function() {
-		clone("fail", function() {
-			clone(true).equals(false)
-		})
-
-		clone("pass", function() {
-			clone(true).equals(true)
-		})
-	})
-
-	// Predicate test passing on clone results
-	o.spec("reporting", function() {
-		o("reports per instance", function(done, timeout) {
-			timeout(100) // Waiting on clone
-
-			clone.run(function(results) {
-				o(typeof results).equals("object")
-				o("length" in results).equals(true)
-				o(results.length).equals(2)("Two results")
-
-				o("error" in results[0] && "pass" in results[0]).equals(true)("error and pass keys present in failing result")
-				o(!("error" in results[1]) && "pass" in results[1]).equals(true)("only pass key present in passing result")
-				o(results[0].pass).equals(false)("Test meant to fail has failed")
-				o(results[1].pass).equals(true)("Test meant to pass has passed")
-
-				done()
-			})
-		})
-		o("o.report() returns the number of failures", function () {
-			var log = console.log, error = console.error
-			console.log = o.spy()
-			console.error = o.spy()
-
-			function makeError(msg) {try{throw msg ? new Error(msg) : new Error} catch(e){return e}}
-			try {
-				var errCount = o.report([{pass: true}, {pass: true}])
-
-				o(errCount).equals(0)
-				o(console.log.callCount).equals(1)
-				o(console.error.callCount).equals(0)
-
-				errCount = o.report([
-					{pass: false, error: makeError("hey"), message: "hey"}
-				])
-
-				o(errCount).equals(1)
-				o(console.log.callCount).equals(2)
-				o(console.error.callCount).equals(1)
-
-				errCount = o.report([
-					{pass: false, error: makeError("hey"), message: "hey"},
-					{pass: true},
-					{pass: false, error: makeError("ho"), message: "ho"}
-				])
-
-				o(errCount).equals(2)
-				o(console.log.callCount).equals(3)
-				o(console.error.callCount).equals(3)
-			} catch (e) {
-				o(1).equals(0)("Error while testing the reporter")
-			}
-
-			console.log = log
-			console.error = error
-		})
-	})
-}(o)
-
 o.spec("ospec", function() {
-	o.spec("sync", function() {
+	o.spec("core", function() {
 		var a = 0, b = 0, illegalAssertionThrows = false
 
 		o.before(function() {a = 1})
@@ -158,6 +72,7 @@ o.spec("ospec", function() {
 			o(spy.args.length).equals(1)
 			o(spy.args[0]).equals(1)
 		})
+
 		o("spy wrapping", function() {
 			var spy = o.spy(function view(vnode){
 				this.drawn = true
@@ -179,16 +94,17 @@ o.spec("ospec", function() {
 		})
 	})
 
-	o.spec("stack trace cleaner", function() {
-		o("handles line breaks", function() {
-			try {
-				throw new Error("line\nbreak")
-			} catch(error) {
-				var trace = o.cleanStackTrace(error)
-				o(trace).notEquals("break")
-				o(trace.includes("test-ospec.js")).equals(true)
-			}
+	o.spec(".only()", function () {
+		var clone = o.new()
+
+		clone("skipped", function () {
+			clone(true).equals(false)
 		})
+
+		clone.only("prevents other tests in the suite executing", function () {
+		}, true)
+
+		clone.run()
 	})
 
 	o.spec("async 'done' argument", function () {
@@ -249,6 +165,83 @@ o.spec("ospec", function() {
 
 				setTimeout(done, 21)
 			})
+		})
+	})
+
+	// Predicate test passing on clone results
+	o.spec("reporting", function () {
+		var clone = o.new()
+
+		clone.spec("clone", function () {
+			clone("fail", function () {
+				clone(true).equals(false)
+			})
+
+			clone("pass", function () {
+				clone(true).equals(true)
+			})
+		})
+
+		o("reports per instance", function () {
+			clone.run(function (results) {
+				o(typeof results).equals("object")
+				o("length" in results).equals(true)
+				o(results.length).equals(2)("Two results")
+
+				o("error" in results[0] && "pass" in results[0]).equals(true)("error and pass keys present in failing result")
+				o(!("error" in results[1]) && "pass" in results[1]).equals(true)("only pass key present in passing result")
+				o(results[0].pass).equals(false)("Test meant to fail has failed")
+				o(results[1].pass).equals(true)("Test meant to pass has passed")
+			})
+		})
+		o("o.report() returns the number of failures", function () {
+			var log = console.log, error = console.error
+			console.log = o.spy()
+			console.error = o.spy()
+
+			function makeError(msg) { try { throw msg ? new Error(msg) : new Error } catch (e) { return e } }
+			try {
+				var errCount = o.report([{ pass: true }, { pass: true }])
+
+				o(errCount).equals(0)
+				o(console.log.callCount).equals(1)
+				o(console.error.callCount).equals(0)
+
+				errCount = o.report([
+					{ pass: false, error: makeError("hey"), message: "hey" }
+				])
+
+				o(errCount).equals(1)
+				o(console.log.callCount).equals(2)
+				o(console.error.callCount).equals(1)
+
+				errCount = o.report([
+					{ pass: false, error: makeError("hey"), message: "hey" },
+					{ pass: true },
+					{ pass: false, error: makeError("ho"), message: "ho" }
+				])
+
+				o(errCount).equals(2)
+				o(console.log.callCount).equals(3)
+				o(console.error.callCount).equals(3)
+			} catch (e) {
+				o(1).equals(0)("Error while testing the reporter")
+			}
+
+			console.log = log
+			console.error = error
+		})
+	})
+
+	o.spec("stack trace cleaner", function() {
+		o("handles line breaks", function() {
+			try {
+				throw new Error("line\nbreak")
+			} catch(error) {
+				var trace = o.cleanStackTrace(error)
+				o(trace).notEquals("break")
+				o(trace.includes("test-ospec.js")).equals(true)
+			}
 		})
 	})
 })


### PR DESCRIPTION
Ospec async is a bit of a mess.

1. [x] The code attempts to sniff for forgotten async test resolutions, but the inference logic is bad #2158
2. [x] Async timeouts blow up the reporter's stack tracer #2154
3. [x] The async test suite is seriously lacking

This branch attempts to sanitize all that.