### PR TITLE
[ospec/bin] Back to ES5 (and complimentary cleanup)

### DIFF
--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 "use strict"
 
-const o = require("../ospec")
-const path = require("path")
-const glob = require("glob")
+var o = require("../ospec")
+var path = require("path")
+var glob = require("glob")
 
 
-const parseArgs = (argv) => {
+function parseArgs(argv) {
 	argv = ["--globs"].concat(argv.slice(2))
-	const args = {}
-	let name
-	argv.forEach((arg) => {
+	var args = {}
+	var name
+	argv.forEach(function(arg) {
 		if (/^--/.test(arg)) {
 			name = arg.substr(2)
 			args[name] = args[name] || []
@@ -22,26 +22,21 @@ const parseArgs = (argv) => {
 }
 
 
-const args = parseArgs(process.argv)
-const globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
-const ignore = ["**/node_modules/**"].concat(args.ignore||[])
-const cwd = process.cwd()
+var args = parseArgs(process.argv)
+var globList = args.globs && args.globs.length ? args.globs : ["**/tests/**/*.js"]
+var ignore = ["**/node_modules/**"].concat(args.ignore||[])
+var cwd = process.cwd()
 
 args.require && args.require.forEach(function(module) {
 	module && require(require.resolve(module, { basedir: cwd }))
 })
 
-let pending = globList.length
-globList.forEach((globPattern) => {
-	glob(globPattern, {ignore})
-		.on("match", (fileName) => { require(path.join(cwd, fileName)) }) // eslint-disable-line global-require
-		.on("error", (e) => console.error(e))
-		.on("end", () => {
-			pending--
-			if (pending === 0) {
-				o.run()
-			}
-		})
+var pending = globList.length
+globList.forEach(function(globPattern) {
+	glob(globPattern, {ignore: ignore})
+		.on("match", function(fileName) { require(path.join(cwd, fileName)) }) // eslint-disable-line global-require
+		.on("error", function(e) { console.error(e) })
+		.on("end", function() { if (--pending === 0) o.run()})
 });
 
-process.on("unhandledRejection", (e) => { console.log("Uncaught (in promise) " + e.stack) })
+process.on("unhandledRejection", function(e) { console.error("Uncaught (in promise) " + e.stack) })

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -3,8 +3,13 @@
 
 ## Upcoming...
 <!-- Add new lines here. Version number will be decided later -->
-- Pinpoint the `o.only()` call site
+### Features
+>>>>>>> [ospec/bin] Back to ES5 (and complimentary cleanup), fix #2160
+- Pinpoint the `o.only()` call site ([#2157](https://github.com/MithrilJS/mithril.js/pull/2157))
 - Improved wording, spacing and color-coding of report messages and errors ([#2147](https://github.com/MithrilJS/mithril.js/pull/2147), [@maranomynet](https://github.com/maranomynet))
+
+### Bug fixes
+- Convert the exectuable back to plain ES5 [#2160](https://github.com/MithrilJS/mithril.js/issues/2160) ([#2161](https://github.com/MithrilJS/mithril.js/pull/2161))
 
 
 ## 2.0.0


### PR DESCRIPTION
Fix #2160 by reverting to ES5 syntax

## How Has This Been Tested?
`npm run test` works as usual.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
