### PR TITLE
Ospec tweaks 2018 6

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -4,7 +4,7 @@
 if (typeof module !== "undefined") module["exports"] = m()
 else window.o = m()
 })(function init(name) {
-	var spec = {}, subjects = [], results, only = null, ctx = spec, start, stack = 0, nextTickish, hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
+	var spec = {}, subjects = [], results, only = [], ctx = spec, start, stack = 0, nextTickish, hasProcess = typeof process === "object", hasOwn = ({}).hasOwnProperty
 	var ospecFileName = getStackName(ensureStackTrace(new Error), /[\/\\](.*?):\d+:\d+/), timeoutStackName
 	var globalTimeout = noTimeoutRightNow
 	var currentTestError = null
@@ -43,7 +43,8 @@ else window.o = m()
 			highlight("/!\\ WARNING /!\\ o.only() mode") + "\n" + o.cleanStackTrace(ensureStackTrace(new Error)) + "\n",
 			cStyle("red"), ""
 		)
-		o(subject, only = predicate)
+		only.push(predicate)
+		o(subject, predicate)
 	}
 	o.spy = function(fn) {
 		var spy = function() {
@@ -101,7 +102,7 @@ else window.o = m()
 			pre = [].concat(pre, spec["\x01beforeEach"] || [])
 			post = [].concat(spec["\x01afterEach"] || [], post)
 			series([].concat(spec["\x01before"] || [], Object.keys(spec).reduce(function(tasks, key) {
-				if (key.charCodeAt(0) !== 1 && (only === null || spec[key].fn === only || !(spec[key] instanceof Task))) {
+				if (key.charCodeAt(0) !== 1 && (only.length === 0 || only.indexOf(spec[key].fn) !== -1 || !(spec[key] instanceof Task))) {
 					tasks.push(new Task(function(done) {
 						o.timeout(Infinity)
 						subjects.push(key)

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -101,20 +101,13 @@ else window.o = m()
 			pre = [].concat(pre, spec["\x01beforeEach"] || [])
 			post = [].concat(spec["\x01afterEach"] || [], post)
 			series([].concat(spec["\x01before"] || [], Object.keys(spec).reduce(function(tasks, key) {
-				if (key.charCodeAt(0) !== 1) {
-					tasks.push(new Task(function(done, timeout) {
-						timeout(Infinity)
-						if (only !== null && spec[key].fn !== only && spec[key] instanceof Task) return done()
-
+				if (key.charCodeAt(0) !== 1 && (only === null || spec[key].fn === only || !(spec[key] instanceof Task))) {
+					tasks.push(new Task(function(done) {
+						o.timeout(Infinity)
 						subjects.push(key)
-						var pop = new Task(function pop() {
-							subjects.pop()
-							done()
-						}, null)
-
+						var pop = new Task(function pop() {subjects.pop(), done()}, null)
 						if (spec[key] instanceof Task) series([].concat(pre, spec[key], post, pop), defaultDelay)
 						else test(spec[key], pre, post, pop, defaultDelay)
-
 					}, null))
 				}
 				return tasks

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -179,12 +179,18 @@ else window.o = m()
 						startTimer()
 					}
 				} else {
-					var p = fn()
-					if (p && p.then) {
-						startTimer()
-						p.then(function() { done() }, done)
-					} else {
-						nextTickish(next)
+					try{
+						var p = fn()
+						if (p && p.then) {
+							startTimer()
+							p.then(function() { done() }, done)
+						} else {
+							nextTickish(next)
+						}
+					} catch (e) {
+						if (task.err != null) finalizeAsync(e)
+						// The errors of internal tasks (which don't have an Err) are ospec bugs and must be rethrown.
+						else throw e
 					}
 				}
 				globalTimeout = noTimeoutRightNow

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -37,8 +37,14 @@ if (typeof process !== "undefined") {
 o("o.only", function(done) {
 	var oo = o.new()
 
+	oo.spec("won't run", function() {
+		oo("nope, skipped", function() {
+			o(true).equals(false)
+		})
+	})
+
 	oo.spec("ospec", function() {
-		oo("skipped", function() {
+		oo("skipped as well", function() {
 			oo(true).equals(false)
 		})
 		oo.only(".only()", function() {

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -50,11 +50,16 @@ o("o.only", function(done) {
 		oo.only(".only()", function() {
 			oo(2).equals(2)
 		}, true)
+		oo.only("another .only()", function(done) {
+			done("that fails")
+		}, true)
 	})
 
 	oo.run(function(results){
-		o(results.length).equals(1)
+		o(results.length).equals(2)
 		o(results[0].pass).equals(true)
+		o(results[1].pass).equals(false)
+
 		done()
 	})
 })

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -281,6 +281,26 @@ o.spec("ospec", function() {
 		})
 	})
 
+	o.spec("throwing in test context is recoreded as a failure", function() {
+		var oo
+		o.beforeEach(function(){oo = o.new()})
+		o.afterEach(function() {
+			oo.run(function(results) {
+				o(results.length).equals(1)
+				o(results[0].pass).equals(false)
+			})
+		})
+		o("sync test", function() {
+			oo("throw in sync test", function() {throw new Error})
+		})
+		o("async test", function() {
+			oo("throw in async test", function(done) {
+				throw new Error
+				done() // eslint-disable-line no-unreachable
+			})
+		})
+	})
+
 	o.spec("timeout", function () {
 		o("when using done()", function(done) {
 			var oo = o.new()


### PR DESCRIPTION
This:

- fixes a bug where an exception thrown in the body of a sync test was not caught and reported as an assertion failure (as documented)
- fixes a stack overflow when using `o.only()` with a large test suite (we reached that threshold with the LIS fuzzer)
- adds the possibility select more than one test with `o.only`.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
