### PR TITLE
Hyperscript: fix #1773, fix #2172

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -24,6 +24,8 @@
 - API: `m.mount()` will only render its own root when called, it will not trigger a `redraw()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Assigning to `vnode.state` (as in `vnode.state = ...`) is no longer supported. Instead, an error is thrown if `vnode.state` changes upon the invocation of a lifecycle hook.
 - API: `m.request` will no longer reject the Promise on server errors (eg. status >= 400) if the caller supplies an `extract` callback. This gives applications more control over handling server responses.
+- hyperscript: when attributes have a `null` or `undefined` value, they are treated as if they were absent. [#1773](https://github.com/MithrilJS/mithril.js/issues/1773) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
+- hyperscript: when an attribute is defined on both the first and second argument (as a CSS selector and an `attrs` field, respectively), the latter takes precedence, except for `class` attributes that are still added together. [#2172](https://github.com/MithrilJS/mithril.js/issues/2172) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
 
 #### News
 

--- a/docs/hyperscript.md
+++ b/docs/hyperscript.md
@@ -5,6 +5,7 @@
 - [How it works](#how-it-works)
 - [Flexibility](#flexibility)
 - [CSS selectors](#css-selectors)
+- [Attributes passed as the second argument](attributes-passed-as-the-second-argument)
 - [DOM attributes](#dom-attributes)
 - [Style attribute](#style-attribute)
 - [Events](#events)
@@ -144,7 +145,23 @@ m("a.link[href=/]", {
 // <a href="/" class="link selected">Home</a>
 ```
 
-If there are class names in both first and second arguments of `m()`, they are merged together as you would expect.
+### Attributes passed as the second argument
+
+You can pass attributes, properties, events and lifecycle hooks in the second, optional argument (see the next sections for details).
+
+```JS
+m("button", {
+	class: "my-button",
+	onclick: function() {/* ... */},
+	oncreate: function() {/* ... */}
+})
+```
+
+If the value of such an attribute is `null` or `undefined`, it is treated as if the attribute was absent.
+
+If there are class names in both first and second arguments of `m()`, they are merged together as you would expect. If the value of the class in the second argument is `null`or `undefined`, it is ignored.
+
+If another attribute is present in both the first and the second argument, the second one takes precedence even if it is  is `null` or `undefined`.
 
 ---
 

--- a/performance/index.html
+++ b/performance/index.html
@@ -13,7 +13,9 @@
 		<script src="../test-utils/pushStateMock.js"></script>
 		<script src="../test-utils/xhrMock.js"></script>
 		<script src="../test-utils/browserMock.js"></script>
-		<script src="../mithril.js"></script>
+		<script src="../render/vnode.js"></script>
+		<script src="../render/render.js"></script>
+		<script src="../render/hyperscript.js"></script>
 		<script src="../node_modules/lodash/lodash.js"></script>
 		<script src="../node_modules/benchmark/benchmark.js"></script>
 		<script src="test-perf.js"></script>

--- a/performance/test-perf.js
+++ b/performance/test-perf.js
@@ -52,6 +52,7 @@ scratch = doc.createElement("div");
 
 // Initialize benchmark suite
 var suite = new B.Suite("mithril perf")
+var xuite = {add: function(options) {console.log("skipping " + options.name)}} // eslint-disable-line no-unused-vars
 
 suite.on("start", function() {
 	this.start = Date.now();
@@ -228,7 +229,7 @@ suite.add({
 
 suite.add({
 	name : "mutate styles/properties",
-
+	// minSamples: 100,
 	onStart : function () {
 		var counter = 0
 		var keyLooper = function (n) { return function (c) { return c % n ? (c + "px") : c } }
@@ -259,19 +260,19 @@ suite.add({
 
 		this.count = 0
 		this.app = function (index) {
-			return m("div",
+			return m("div.booga",
 				{
 					class: get(classes, index),
 					"data-index": index,
 					title: index.toString(36)
 				},
-				m("input", {type: "checkbox", checked: index % 3 == 0}),
+				m("input.dooga", {type: "checkbox", checked: index % 3 == 0}),
 				m("input", {value: "test " + (Math.floor(index / 4)), disabled: index % 10 ? null : true}),
 				m("div", {class: get(classes, index * 11)},
 					m("p", {style: get(styles, index)}, "p1"),
 					m("p", {style: get(styles, index + 1)}, "p2"),
 					m("p", {style: get(styles, index * 2)}, "p3"),
-					m("p", {style: get(styles, index * 3 + 1)}, "p4")
+					m("p.zooga", {style: get(styles, index * 3 + 1), className: get(classes, index * 7)}, "p4")
 				)
 			)
 		}

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -51,14 +51,16 @@ function execSelector(state, attrs, children) {
 			attrs[key] = state.attrs[key]
 		}
 	}
-	if (className || state.attrs.className) attrs[classAttr] =
-		className
-			? state.attrs.className
+	if (className != null || state.attrs.className != null) attrs.className =
+		className != null
+			? state.attrs.className != null
 				? state.attrs.className + " " + className
 				: className
-			: state.attrs.className
+			: state.attrs.className != null
 				? state.attrs.className
 				: null
+
+	if (classAttr === "class") attrs.class = null
 
 	for (var key in attrs) {
 		if (hasOwn.call(attrs, key) && key !== "key") {

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -31,7 +31,8 @@ function compileSelector(selector) {
 
 function execSelector(state, attrs, children) {
 	var hasAttrs = false, childList, text
-	var className = attrs.className || attrs.class
+	var classAttr = hasOwn.call(attrs, "class") ? "class" : "className"
+	var className = attrs[classAttr]
 
 	if (!isEmpty(state.attrs) && !isEmpty(attrs)) {
 		var newAttrs = {}
@@ -46,21 +47,18 @@ function execSelector(state, attrs, children) {
 	}
 
 	for (var key in state.attrs) {
-		if (hasOwn.call(state.attrs, key)) {
+		if (hasOwn.call(state.attrs, key) && key !== "className" && !hasOwn.call(attrs, key)){
 			attrs[key] = state.attrs[key]
 		}
 	}
-
-	if (className !== undefined) {
-		if (attrs.class !== undefined) {
-			attrs.class = undefined
-			attrs.className = className
-		}
-
-		if (state.attrs.className != null) {
-			attrs.className = state.attrs.className + " " + className
-		}
-	}
+	if (className || state.attrs.className) attrs[classAttr] =
+		className
+			? state.attrs.className
+				? state.attrs.className + " " + className
+				: className
+			: state.attrs.className
+				? state.attrs.className
+				: null
 
 	for (var key in attrs) {
 		if (hasOwn.call(attrs, key) && key !== "key") {
@@ -75,7 +73,7 @@ function execSelector(state, attrs, children) {
 		childList = children
 	}
 
-	return Vnode(state.tag, attrs.key, hasAttrs ? attrs : undefined, childList, text)
+	return Vnode(state.tag, attrs.key, hasAttrs ? attrs : null, childList, text)
 }
 
 function hyperscript(selector) {

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -25,37 +25,43 @@ o.spec("hyperscript", function() {
 			o(m("a", {
 				class: undefined
 			}).attrs).deepEquals({
-				class: undefined
+				class: null
 			})
 			o(m("a", {
 				class: false
 			}).attrs).deepEquals({
-				class: false
+				class: null,
+				className: false
 			})
 			o(m("a", {
 				class: true
 			}).attrs).deepEquals({
-				class: true
+				class: null,
+				className: true
 			})
 			o(m("a.x", {
 				class: null
 			}).attrs).deepEquals({
-				class: "x"
+				class: null,
+				className: "x"
 			})
 			o(m("a.x", {
 				class: undefined
 			}).attrs).deepEquals({
-				class: "x"
+				class: null,
+				className: "x"
 			})
 			o(m("a.x", {
 				class: false
 			}).attrs).deepEquals({
-				class: "x"
+				class: null,
+				className: "x false"
 			})
 			o(m("a.x", {
 				class: true
 			}).attrs).deepEquals({
-				class: "x true"
+				class: null,
+				className: "x true"
 			})
 			o(m("a", {
 				className: null
@@ -90,7 +96,7 @@ o.spec("hyperscript", function() {
 			o(m("a.x", {
 				className: false
 			}).attrs).deepEquals({
-				className: "x"
+				className: "x false"
 			})
 			o(m("a.x", {
 				className: true
@@ -288,7 +294,7 @@ o.spec("hyperscript", function() {
 		o("handles merging classes w/ class property", function() {
 			var vnode = m(".a", {class: "b"})
 
-			o(vnode.attrs.class).equals("a b")
+			o(vnode.attrs.className).equals("a b")
 		})
 		o("handles merging classes w/ className property", function() {
 			var vnode = m(".a", {className: "b"})

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -16,53 +16,46 @@ o.spec("hyperscript", function() {
 
 			o(vnode.tag).equals("a")
 		})
-		o("v1.0.1 bug-for-bug regression suite", function(){
+		o("class and className normalization", function(){
 			o(m("a", {
 				class: null
 			}).attrs).deepEquals({
-				class: undefined,
-				className: null
+				class: null
 			})
 			o(m("a", {
 				class: undefined
 			}).attrs).deepEquals({
-				class: undefined,
+				class: undefined
 			})
 			o(m("a", {
 				class: false
 			}).attrs).deepEquals({
-				class: undefined,
-				className: false
+				class: false
 			})
 			o(m("a", {
 				class: true
 			}).attrs).deepEquals({
-				class: undefined,
-				className: true
+				class: true
 			})
 			o(m("a.x", {
 				class: null
 			}).attrs).deepEquals({
-				class: undefined,
-				className: "x null"
+				class: "x"
 			})
 			o(m("a.x", {
 				class: undefined
 			}).attrs).deepEquals({
-				class: undefined,
-				className: "x"
+				class: "x"
 			})
 			o(m("a.x", {
 				class: false
 			}).attrs).deepEquals({
-				class: undefined,
-				className: "x false"
+				class: "x"
 			})
 			o(m("a.x", {
 				class: true
 			}).attrs).deepEquals({
-				class: undefined,
-				className: "x true"
+				class: "x true"
 			})
 			o(m("a", {
 				className: null
@@ -272,7 +265,7 @@ o.spec("hyperscript", function() {
 			var vnode = m("div", {key:"a"})
 
 			o(vnode.tag).equals("div")
-			o(vnode.attrs).equals(undefined)
+			o(vnode.attrs).equals(null)
 			o(vnode.key).equals("a")
 		})
 		o("handles many attrs", function() {
@@ -295,7 +288,7 @@ o.spec("hyperscript", function() {
 		o("handles merging classes w/ class property", function() {
 			var vnode = m(".a", {class: "b"})
 
-			o(vnode.attrs.className).equals("a b")
+			o(vnode.attrs.class).equals("a b")
 		})
 		o("handles merging classes w/ className property", function() {
 			var vnode = m(".a", {className: "b"})
@@ -490,20 +483,20 @@ o.spec("hyperscript", function() {
 		o("handles children without attr", function() {
 			var vnode = m("div", [m("i"), m("s")])
 
-			o(vnode.attrs).equals(undefined)
+			o(vnode.attrs).equals(null)
 			o(vnode.children[0].tag).equals("i")
 			o(vnode.children[1].tag).equals("s")
 		})
 		o("handles child without attr unwrapped", function() {
 			var vnode = m("div", m("i"))
 
-			o(vnode.attrs).equals(undefined)
+			o(vnode.attrs).equals(null)
 			o(vnode.children[0].tag).equals("i")
 		})
 		o("handles children without attr unwrapped", function() {
 			var vnode = m("div", m("i"), m("s"))
 
-			o(vnode.attrs).equals(undefined)
+			o(vnode.attrs).equals(null)
 			o(vnode.children[0].tag).equals("i")
 			o(vnode.children[1].tag).equals("s")
 		})
@@ -523,6 +516,15 @@ o.spec("hyperscript", function() {
 			var attrs = {a: "b"}
 			m(".a", attrs)
 			o(attrs).deepEquals({a: "b"})
+		})
+		o("non-nullish attr takes precedence over selector", function() {
+			o(m("[a=b]", {a: "c"}).attrs).deepEquals({a: "c"})
+		})
+		o("null attr takes precedence over selector", function() {
+			o(m("[a=b]", {a: null}).attrs).deepEquals({a: null})
+		})
+		o("undefined attr takes precedence over selector", function() {
+			o(m("[a=b]", {a: undefined}).attrs).deepEquals({a: undefined})
 		})
 		o("handles fragment children without attr unwrapped", function() {
 			var vnode = m("div", [m("i")], [m("s")])

--- a/render/tests/test-render-hyperscript-integration.js
+++ b/render/tests/test-render-hyperscript-integration.js
@@ -1,0 +1,614 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var m = require("../../render/hyperscript")
+var domMock = require("../../test-utils/domMock")
+var vdom = require("../../render/render")
+
+o.spec("render/hyperscript integration", function() {
+	var $window, root, render
+	o.beforeEach(function() {
+		$window = domMock()
+		root = $window.document.createElement("div")
+		render = vdom($window).render
+	})
+	o.spec("setting class", function() {
+		o("selector only", function() {
+			render(root, m(".foo"))
+
+			o(root.firstChild.className).equals("foo")
+		})
+		o("class only", function() {
+			render(root, m("div", {class: "foo"}))
+
+			o(root.firstChild.className).equals("foo")
+		})
+		o("className only", function() {
+			render(root, m("div", {className: "foo"}))
+
+			o(root.firstChild.className).equals("foo")
+		})
+		o("selector and class", function() {
+			render(root, m(".bar", {class: "foo"}))
+
+			o(root.firstChild.className.split(" ").sort()).deepEquals(["bar", "foo"])
+		})
+		o("selector and className", function() {
+			render(root, m(".bar", {className: "foo"}))
+
+			o(root.firstChild.className.split(" ").sort()).deepEquals(["bar", "foo"])
+		})
+		o("selector and a null class", function() {
+			render(root, m(".foo", {class: null}))
+
+			o(root.firstChild.className).equals("foo")
+		})
+		o("selector and a null className", function() {
+			render(root, m(".foo", {className: null}))
+
+			o(root.firstChild.className).equals("foo")
+		})
+		o("selector and an undefined class", function() {
+			render(root, m(".foo", {class: undefined}))
+
+			o(root.firstChild.className).equals("foo")
+		})
+		o("selector and an undefined className", function() {
+			render(root, m(".foo", {className: undefined}))
+
+			o(root.firstChild.className).equals("foo")
+		})
+	})
+	o.spec("updating class", function() {
+		o.spec("from selector only", function() {
+			o("to selector only", function() {
+				render(root, m(".foo1"))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".foo1"))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".foo1"))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".foo1"))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".foo1"))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".foo1"))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".foo1"))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".foo1"))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".foo1"))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from class only", function() {
+			o("to selector only", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m("div", {class: "foo2"}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from ", function() {
+			o("to selector only", function() {
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from className only", function() {
+			o("to selector only", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m("div", {className: "foo1"}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from selector and class", function() {
+			o("to selector only", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".bar1", {class: "foo1"}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from selector and className", function() {
+			o("to selector only", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".bar1", {className: "foo1"}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from  and a null class", function() {
+			o("to selector only", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".foo1", {class: null}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from selector and a null className", function() {
+			o("to selector only", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".foo1", {className: null}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from selector and an undefined class", function() {
+			o("to selector only", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".foo1", {class: undefined}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+		o.spec("from selector and an undefined className", function() {
+			o("to selector only", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".foo2"))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to class only", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m("div", {class: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to className only", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m("div", {className: "foo2"}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and class", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".bar2", {class: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and className", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".bar2", {className: "foo2"}))
+
+				o(root.firstChild.className.split(" ").sort()).deepEquals(["bar2", "foo2"])
+			})
+			o("to selector and a null class", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".foo2", {class: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and a null className", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".foo2", {className: null}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined class", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".foo2", {class: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+			o("to selector and an undefined className", function() {
+				render(root, m(".foo1", {className: undefined}))
+				render(root, m(".foo2", {className: undefined}))
+
+				o(root.firstChild.className).equals("foo2")
+			})
+		})
+	})
+})


### PR DESCRIPTION
This makes the `attrs` take precedence over the selector (#2172), and improves class normalization (#1773).

The docs and change log will follow here.

## Description
See the respective issues for a detailed discussion.

`m("[a=b]", {a: "c"})` will now have `a` set to `"c"`, and `m("[a=b]", {a: null})` will have it set to `null` (likewise for `undefined`).

regarding classes: 

- `m(".foo", {}).attrs` will be `{className: "foo"}`
- `m(".foo", {className: "bar"}).attrs` will be `{className: "foo bar"}`
- `m(".foo", {class: "bar"}).attrs` will be `{class: "foo bar"}` (we re-use the `class` field if users chose it. Leo said it was slower, but I didn't see any difference in the benchmark)
- `m(".foo", {class: false})`,  `m(".foo", {class: null})` and `m(".foo", {class: undefined})` all behave as if there was no class in the attrs.


## How Has This Been Tested?

The test suite was adapted,

The benchmarks (improved a bit to cover class merging) were run in Chrome, Safari and Firefox (desktop). No difference was noticed (though the variance from run to run was high even though the standard error on the mean was always ~1% or 2%).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
