### PR TITLE
Use parcel instead of webpack for quickstart.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,17 +23,17 @@ $ npm install mithril --save
 
 ---
 
-### Quick start with Webpack
+### Quick start with [Parcel](https://parceljs.org/)
 
 1. Initialize the directory as an npm package
 ```bash
 $ npm init --yes
 ```
 
-2. install required tools
+2. Install the required tools.
 ```bash
 $ npm install mithril --save
-$ npm install webpack webpack-cli --save-dev
+$ npm install parcel-bundler --save-dev
 ```
 
 3. Add a "start" entry to the scripts section in `package.json`.
@@ -41,7 +41,7 @@ $ npm install webpack webpack-cli --save-dev
 {
 	// ...
 	"scripts": {
-		"start": "webpack src/index.js --output bin/app.js -d --watch"
+		"start": "parcel src/index.html"
 	}
 }
 ```
@@ -52,20 +52,20 @@ import m from "mithril";
 m.render(document.body, "hello world");
 ```
 
-5. create `index.html`
+5. Create `index.html`.
 ```html
 <!DOCTYPE html>
 <body>
-    <script src="bin/app.js"></script>
+    <script src="./index.js"></script>
 </body>
 ```
 
-6. run bundler
+6. Run the bundler.
 ```bash
 $ npm start
 ```
 
-7. open `index.html` in a browser
+7. Click the shown link to open it in the browser.
 
 #### Step by step
 


### PR DESCRIPTION
Replace webpack example with one that uses parcel. It's much simpler.

## Motivation and Context
There was an issue of a user in the gitter where (s)he wasn't able to get the webpack thing started. I recommend using parcel and it went smoothly.

## How Has This Been Tested?
yep, just followed the instructions and it worked like a charm.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
