### PR TITLE
Update onbeforeremove animation example to use animationend event

### DIFF
--- a/docs/animation.md
+++ b/docs/animation.md
@@ -75,7 +75,7 @@ var FancyComponent = {
 	onbeforeremove: function(vnode) {
 		vnode.dom.classList.add("exit")
 		return new Promise(function(resolve) {
-			setTimeout(resolve, 500)
+			vnode.dom.addEventListener("animationend", resolve)
 		})
 	},
 	view: function() {
@@ -86,7 +86,7 @@ var FancyComponent = {
 
 `vnode.dom` points to the root DOM element of the component (`<div class="fancy">`). We use the classList API here to add an `exit` class to `<div class="fancy">`.
 
-Then we return a [Promise](promise.md) that resolves after half a second. When we return a promise from `onbeforeremove`, Mithril waits until the promise is resolved and only then it removes the element. In this case, it waits half a second, giving the exit animation the exact time it needs to complete.
+Then we return a [Promise](promise.md) that resolves when the `animationend` event fires. When we return a promise from `onbeforeremove`, Mithril waits until the promise is resolved and only then it removes the element. In this case, it waits for the exit animation to finish.
 
 We can verify that both the enter and exit animations work by mounting the `Toggler` component:
 


### PR DESCRIPTION
Update `onbeforeremove` animation example to use `animationend` event

## Description
The example uses `setTimeout()` to time resolve the `onbeforeremove` life cycle method. This PR updates the example, resolving the returned promise when the animationend event is fired.

## Motivation and Context
This change is not required, but provides a better solution. The current example requires matching the CSS animation duration with the timeout. The updated example removes that requirement by using `animationend` event.

## How Has This Been Tested?
Here's a working example using code copied unaltered from animation.md
https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J4AbhgBOAAnrSAvNOKSArjAA6aTRJkAVWgHMDsGYuCb1xMRBgB3RNLAq01YhHoAKAJTTzW4paSMMQqkmjSyBYB0Vge6iAARirExPTxFL701FAQ1ADWDk4ubp4+wHKKAIT0rOzS8fpGsPFeFFGWlnIA-NKxAGIYLgCeAMK0WAAO9CI+DmgqUFBt-pYAulGsmptaaDrSA8Njk9MMCr5R9AkwYLRBQVi0YjCFzq7uaB5iaLQAJjBl7Ss3z++B+43w2QwcDgABkIHBiPgMD8fnEQDAAB4QAIgLyAoIhMLSNB2aQABUk43hMA8RTeniCcFoUCeAJW0S+vxgoPByJ+AFEngw4QimDBJGjBhAsBgSiS0D90tJGczWYDWHj-OwotY7C9iu9vOd2QTQuFYvF8GBBtQhkr4gAJGCLWjSWy3KCK3EbLYWHZYfAPZzEDxg6gqHAMfAJX5DDKNYziryUEBwZ0weloBA8ABMABZEABmACMbA4IEwODwEOhKaEjGYPCtNqGvilMrliGtfwAtBBwgAGfAAVjgAG5tgABPIwIZgSRcOCOZEwPvhPyWefjTITDDUbFDRADidRVI7vcHxDFk9obaafCY7FttDS2XvLsrnu0ZLSIejm-TrO86LsuvbfsQxqbpSWDnvuxCHted4pK65S7nBh7HtsrBsKsVA5GgeTZqgFZcHgWDYoQkjQCmoTkDwJDEBMcCIAA9CxzgTHkBgQuMLHkcQlHQJOxb4CJABsfEUVRUD4PwKbwRM3CptQVETKIrCrKwQA

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`