### PR TITLE
Fix glob inclusion on npm install

### DIFF
--- a/ospec/package.json
+++ b/ospec/package.json
@@ -13,7 +13,7 @@
     "ospec": "./bin/ospec"
   },
   "repository": "MithrilJS/mithril.js",
-  "devDependencies": {
+  "dependencies": {
     "glob": "^7.1.2"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The glob dependency was moved from `devDependencies` to `dependencies`

## Motivation and Context
To allow installation of ospec properly using npm. Before this change, either `glob` had to be installed manually, or npm would throw the error `Cannot find module 'glob'`

## How Has This Been Tested?
Haven't tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`