### PR TITLE
[request] Clearer error message for JSON deserialization failure

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -32,6 +32,7 @@
 - API: Introduction of `m.redraw.sync()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Event handlers may also be objects with `handleEvent` methods ([#1939](https://github.com/MithrilJS/mithril.js/issues/1939)).
 - API: `m.route.link` accepts an optional `options` object ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
+- API: `m.request` better error message on JSON parse error - ([#2195](https://github.com/MithrilJS/mithril.js/pull/2195), [@codeclown](https://github.com/codeclown))
 - API: `m.request` supports `timeout` as attr - ([#1966](https://github.com/MithrilJS/mithril.js/pull/1966))
 - Mocks: add limited support for the DOMParser API ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
 - API: add support for raw SVG in `m.trust()` string ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))

--- a/request/request.js
+++ b/request/request.js
@@ -162,7 +162,7 @@ module.exports = function($window, Promise) {
 
 	function deserialize(data) {
 		try {return data !== "" ? JSON.parse(data) : null}
-		catch (e) {throw new Error(`Error when parsing JSON: ${data}`)}
+		catch (e) {throw new Error("Error trying to parse JSON: " + data)}
 	}
 
 	function extract(xhr) {return xhr.responseText}

--- a/request/request.js
+++ b/request/request.js
@@ -162,7 +162,7 @@ module.exports = function($window, Promise) {
 
 	function deserialize(data) {
 		try {return data !== "" ? JSON.parse(data) : null}
-		catch (e) {throw new Error(data)}
+		catch (e) {throw new Error(`Error when parsing JSON: ${data}`)}
 	}
 
 	function extract(xhr) {return xhr.responseText}

--- a/request/request.js
+++ b/request/request.js
@@ -162,7 +162,7 @@ module.exports = function($window, Promise) {
 
 	function deserialize(data) {
 		try {return data !== "" ? JSON.parse(data) : null}
-		catch (e) {throw new Error("Error trying to parse JSON: " + data)}
+		catch (e) {throw new Error("Invalid JSON: " + data)}
 	}
 
 	function extract(xhr) {return xhr.responseText}

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -494,7 +494,7 @@ o.spec("xhr", function() {
 				}
 			})
 			xhr({method: "GET", url: "/item"}).catch(function(e) {
-				o(e.message).equals("error")
+				o(e.message).equals("Error when parsing JSON: error")
 			}).then(done)
 		})
 		o("triggers all branched catches upon rejection", function(done) {

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -494,7 +494,7 @@ o.spec("xhr", function() {
 				}
 			})
 			xhr({method: "GET", url: "/item"}).catch(function(e) {
-				o(e.message).equals("Error trying to parse JSON: error")
+				o(e.message).equals("Invalid JSON: error")
 			}).then(done)
 		})
 		o("triggers all branched catches upon rejection", function(done) {

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -494,7 +494,7 @@ o.spec("xhr", function() {
 				}
 			})
 			xhr({method: "GET", url: "/item"}).catch(function(e) {
-				o(e.message).equals("Error when parsing JSON: error")
+				o(e.message).equals("Error trying to parse JSON: error")
 			}).then(done)
 		})
 		o("triggers all branched catches upon rejection", function(done) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, when response JSON is not parsed successfully and an error is raised, the error message only contains the response body.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is unnecessarily cryptic. As someone using the new request implementation for the first time, I was confused as to why just an error "foo" was raised when I was testing a new endpoint.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Relevant test updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
