### PR TITLE
Fix #1714 conditionally halting stream

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -26,6 +26,7 @@
 - API: `m.request` will no longer reject the Promise on server errors (eg. status >= 400) if the caller supplies an `extract` callback. This gives applications more control over handling server responses.
 - hyperscript: when attributes have a `null` or `undefined` value, they are treated as if they were absent. [#1773](https://github.com/MithrilJS/mithril.js/issues/1773) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
 - hyperscript: when an attribute is defined on both the first and second argument (as a CSS selector and an `attrs` field, respectively), the latter takes precedence, except for `class` attributes that are still added together. [#2172](https://github.com/MithrilJS/mithril.js/issues/2172) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
+- stream: when a stream conditionally returns HALT, dependant stream will also end
 
 #### News
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -26,7 +26,7 @@
 - API: `m.request` will no longer reject the Promise on server errors (eg. status >= 400) if the caller supplies an `extract` callback. This gives applications more control over handling server responses.
 - hyperscript: when attributes have a `null` or `undefined` value, they are treated as if they were absent. [#1773](https://github.com/MithrilJS/mithril.js/issues/1773) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
 - hyperscript: when an attribute is defined on both the first and second argument (as a CSS selector and an `attrs` field, respectively), the latter takes precedence, except for `class` attributes that are still added together. [#2172](https://github.com/MithrilJS/mithril.js/issues/2172) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
-- stream: when a stream conditionally returns HALT, dependant stream will also end
+- stream: when a stream conditionally returns HALT, dependant stream will also end ([#2200])(https://github.com/MithrilJS/mithril.js/pull/2200)
 
 #### News
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -26,7 +26,7 @@
 - API: `m.request` will no longer reject the Promise on server errors (eg. status >= 400) if the caller supplies an `extract` callback. This gives applications more control over handling server responses.
 - hyperscript: when attributes have a `null` or `undefined` value, they are treated as if they were absent. [#1773](https://github.com/MithrilJS/mithril.js/issues/1773) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
 - hyperscript: when an attribute is defined on both the first and second argument (as a CSS selector and an `attrs` field, respectively), the latter takes precedence, except for `class` attributes that are still added together. [#2172](https://github.com/MithrilJS/mithril.js/issues/2172) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
-- stream: when a stream conditionally returns HALT, dependant stream will also end ([#2200])(https://github.com/MithrilJS/mithril.js/pull/2200)
+- stream: when a stream conditionally returns HALT, dependant stream will also end ([#2200](https://github.com/MithrilJS/mithril.js/pull/2200))
 
 #### News
 

--- a/stream/stream.js
+++ b/stream/stream.js
@@ -53,7 +53,7 @@ function updateDependency(stream, mustSync) {
 	var state = stream._state, parents = state.parents
 	if (parents.length > 0 && parents.every(active) && (mustSync || parents.some(changed))) {
 		var value = stream._state.derive()
-		if (value === HALT) return false
+		if (value === HALT) return unregisterStream(stream)
 		updateState(stream, value)
 	}
 }

--- a/stream/tests/test-stream.js
+++ b/stream/tests/test-stream.js
@@ -164,6 +164,27 @@ o.spec("stream", function() {
 			o(b()).equals(undefined)
 			o(count).equals(0)
 		})
+		o("combine can conditionaly halt", function() {
+			var count = 0
+			var halt = false
+			var a = Stream(1)
+			var b = Stream.combine(function(a) {
+				if (halt) {
+					return Stream.HALT
+				}
+				return a()
+			}, [a])["fantasy-land/map"](function(a) {
+				count++
+				return a
+			})
+			o(b()).equals(1)
+			o(count).equals(1)
+			halt = true
+			count = 0
+			a(2)
+			o(b()).equals(1)
+			o(count).equals(0)
+		})
 		o("combine will throw with a helpful error if given non-stream values", function () {
 			var spy = o.spy()
 			var a = Stream(1)


### PR DESCRIPTION
## Description
When a stream returns halt it is unregistrered to avoid calling dependent streams

## Motivation and Context
https://github.com/MithrilJS/mithril.js/issues/1714

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`