### PR TITLE
Fix #2197 end all in chain when calling end(true)

### DIFF
--- a/stream/stream.js
+++ b/stream/stream.js
@@ -86,10 +86,13 @@ function registerDependency(stream, parents) {
 	}
 }
 function unregisterStream(stream) {
-	for (var i = 0; i < stream._state.parents.length; i++) {
+	var i = stream._state.parents.length
+	while (i--) {
 		var parent = stream._state.parents[i]
 		delete parent._state.deps[stream._state.id]
+		stream._state.parents.splice(i, 1)
 	}
+
 	for (var id in stream._state.deps) {
 		var dependent = stream._state.deps[id]
 		var index = dependent._state.parents.indexOf(stream)

--- a/stream/tests/test-stream.js
+++ b/stream/tests/test-stream.js
@@ -255,6 +255,17 @@ o.spec("stream", function() {
 
 			o(doubled()).equals(undefined)
 		})
+		o("end stops all dependant streams", function() {
+			var stream = Stream()
+			var stream2 = stream.map(function(v) { return v })
+			var stream3 = stream2.map(function(v) { return v })
+
+			stream3.end(true)
+
+			stream(3)
+
+			o(stream3()).equals(undefined)
+		})
 		o("end stream works with default value", function() {
 			var stream = Stream(2)
 			var doubled = Stream.combine(function(stream) {return stream() * 2}, [stream])


### PR DESCRIPTION
## Description
When a stream ends it clears all dependent streams in the chain too

## Motivation and Context
https://github.com/MithrilJS/mithril.js/issues/2197

## How Has This Been Tested?
Wrote test for this case

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`