### PR TITLE
Add implicit + explicit censorship of lifecycle methods

### DIFF
--- a/docs/censor.md
+++ b/docs/censor.md
@@ -1,0 +1,62 @@
+# censor(keys)
+
+- [Description](#description)
+- [Signature](#signature)
+- [How it works](#how-it-works)
+
+---
+
+### Description
+
+Takes an attributes object, removes all the special attribute keys like `key` and `oninit` from it, and then removes any extra properties specified in an optional list.
+
+```javascript
+var Component = {
+	view: function(vnode) {
+		return m("button", m.censor(vnode.attrs), [
+			"Click to ", vnode.children
+		])
+	}
+}
+```
+
+---
+
+### Signature
+
+`m.censor(attrs, extras?)`
+
+Argument    | Type                 | Required | Description
+----------- | -------------------- | -------- | ---
+`attrs`     | `Object`             | Yes      | The attributes to censor properties from
+`extras`    | `Array<String>`      | No       | Any extra attributes to censor
+**returns** | `Event -> undefined` |          | A censored attributes object, or the original attributes if thre was nothing to censor
+
+[How to read signatures](signatures.md)
+
+---
+
+### How it works
+
+The `m.censor` method exists to strip lifecycle methods and other special keys, defined internally and/or used by your component, from an attributes object you intend to proxy through a component. It's useful for [avoiding restrictive interfaces](components.md#avoid-restrictive-interfaces) when defining components, to get around the common gotcha of [double-called lifecycle methods](https://github.com/MithrilJS/mithril.js/issues/1775) when you do it naïvely.
+
+```javascript
+// This does not do what you want, especially if you choose to add lifecycle
+// attributes to it when you use it.
+var BadComponent = {
+	view: function(vnode) {
+		return m("button", vnode.attrs, [
+			"Click to ", vnode.children
+		])
+	}
+}
+
+// This is 100% safe, and you've handled everything correctly. Do this instead.
+var GoodComponent = {
+	view: function(vnode) {
+		return m("button", m.censor(vnode.attrs), [
+			"Click to ", vnode.children
+		])
+	}
+}
+```

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -30,6 +30,7 @@
 - render: remove some redundancy within the component initialization code ([#2213](https://github.com/MithrilJS/mithril.js/pull/2213))
 - render: Align custom elements to work like normal elements, minus all the HTML-specific magic. ([#2221](https://github.com/MithrilJS/mithril.js/pull/2221))
 - render: simplify component removal ([#2214](https://github.com/MithrilJS/mithril.js/pull/2214))
+- API: Introduction of `m.censor()` ([#2219](https://github.com/MithrilJS/mithril.js/pull/2219))
 
 #### News
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -31,6 +31,7 @@
 - render: Align custom elements to work like normal elements, minus all the HTML-specific magic. ([#2221](https://github.com/MithrilJS/mithril.js/pull/2221))
 - render: simplify component removal ([#2214](https://github.com/MithrilJS/mithril.js/pull/2214))
 - API: Introduction of `m.censor()` ([#2219](https://github.com/MithrilJS/mithril.js/pull/2219))
+- API: When you use a component's `vnode.attrs` directly as a child vnode's attrs in the children returned from the component's `view` method, `key` and lifecycle methods within its attrs are not applied to those instances. This does not carry into child components' own trees, which could come up in cases like `m(SomeComponent, {view() { ... }})` ([#2219](https://github.com/MithrilJS/mithril.js/pull/2219))
 
 #### News
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -380,15 +380,34 @@ var RestrictiveComponent = {
 }
 ```
 
-If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node, using [`m.censor`](censor.md) to strip out the lifecycle methods.
+If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node, using the same `vnode.attrs` you received.
 
 ```javascript
 // PREFER
 var FlexibleComponent = {
 	view: function(vnode) {
-		return m("button", m.censor(vnode.attrs), [
+		return m("button", vnode.attrs, [
 			"Click to ", vnode.children
 		])
+	}
+}
+```
+
+Do note that when you proxy vnode attributes like this, keys and all lifecycle hooks on it are ignored when Mithril renders the component's view template, to not interfere with the expected layout. This is unlike normal behavior, but it's so you don't have to censor them yourself to avoid weird things like duplicate calls.
+
+If you're passing them via an attribute callback that's not within the immediate template (like a `view` attribute), you'll instead need to use [`m.censor`](censor.md) to strip out the lifecycle methods, since Mithril doesn't know to follow that through.
+
+```javascript
+// PREFER
+var FlexibleComponent = {
+	view: function(vnode) {
+		return m(SomeComponent, {
+			view: function () {
+				return m("button", m.censor(vnode.attrs), [
+					"Click to ", vnode.children
+				])
+			}
+		})
 	}
 }
 ```

--- a/docs/components.md
+++ b/docs/components.md
@@ -380,13 +380,13 @@ var RestrictiveComponent = {
 }
 ```
 
-If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node.
+If the required attributes are equivalent to generic DOM attributes, it's preferable to allow passing through parameters to a component's root node, using [`m.censor`](censor.md) to strip out the lifecycle methods.
 
 ```javascript
 // PREFER
 var FlexibleComponent = {
 	view: function(vnode) {
-		return m("button", vnode.attrs, [
+		return m("button", m.censor(vnode.attrs), [
 			"Click to ", vnode.children
 		])
 	}

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ requestService.setCompletionCallback(redrawService.redraw)
 m.mount = require("./mount")
 m.route = require("./route")
 m.withAttr = require("./util/withAttr")
+m.censor = require("./util/censor")
 m.render = require("./render").render
 m.redraw = redrawService.redraw
 m.request = requestService.request

--- a/render/tests/test-component.js
+++ b/render/tests/test-component.js
@@ -157,6 +157,61 @@ o.spec("component", function() {
 
 					o(root.firstChild.firstChild.namespaceURI).equals("http://www.w3.org/2000/svg")
 				})
+				o("ignores keys in proxied element attrs", function() {
+					var toggle = true
+					var remove = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return [
+								toggle ?
+									{tag: "div", key: 1, attrs: {onremove: remove}, text: "b"} :
+									{tag: "div", key: 1, attrs: vnode.attrs, text: "b"}
+							]
+						}
+					})
+
+					render(root, [{tag: component, key: 1, attrs: {}}])
+					toggle = false
+					render(root, [{tag: component, key: 1, attrs: {}}])
+					o(remove.callCount).equals(1)
+				})
+				o("ignores keys in proxied fragment attrs", function() {
+					var toggle = true
+					var remove = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return [
+								toggle ?
+									{tag: "[", key: 1, attrs: {onremove: remove}, children: []} :
+									{tag: "[", key: 1, attrs: vnode.attrs, children: []}
+							]
+						}
+					})
+
+					render(root, [{tag: component, key: 1, attrs: {}}])
+					toggle = false
+					render(root, [{tag: component, key: 1, attrs: {}}])
+					o(remove.callCount).equals(1)
+				})
+				o("ignores keys in proxied component attrs", function() {
+					var toggle = true
+					var remove = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return [
+								toggle ?
+									{tag: child, key: 1, attrs: {onremove: remove}, children: []} :
+									{tag: child, key: 1, attrs: vnode.attrs, children: []}
+							]
+						}
+					})
+
+					render(root, [{tag: component, key: 1, attrs: {}}])
+					toggle = false
+					render(root, [{tag: component, key: 1, attrs: {}}])
+					o(remove.callCount).equals(1)
+				})
 			})
 			o.spec("return value", function() {
 				o("can return fragments", function() {
@@ -403,6 +458,43 @@ o.spec("component", function() {
 					o(root.firstChild.attributes["id"].value).equals("a")
 					o(root.firstChild.firstChild.nodeValue).equals("b")
 				})
+				o("does not call oninit in proxied element attrs", function() {
+					var init = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: "b"}
+						}
+					})
+					var node = {tag: component, attrs: {oninit: init}}
+
+					render(root, [node])
+					o(init.callCount).equals(1)
+				})
+				o("does not call oninit in proxied fragment attrs", function() {
+					var init = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "[", attrs: vnode.attrs, children: []}
+						}
+					})
+					var node = {tag: component, attrs: {oninit: init}}
+
+					render(root, [node])
+					o(init.callCount).equals(1)
+				})
+				o("does not call oninit in proxied component attrs", function() {
+					var init = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: child, attrs: vnode.attrs, children: []}
+						}
+					})
+					var node = {tag: component, attrs: {oninit: init}}
+
+					render(root, [node])
+					o(init.callCount).equals(1)
+				})
 				o("calls oninit when returning fragment", function() {
 					var called = 0
 					var component = createComponent({
@@ -482,6 +574,43 @@ o.spec("component", function() {
 					o(root.firstChild.attributes["id"].value).equals("a")
 					o(root.firstChild.firstChild.nodeValue).equals("b")
 				})
+				o("does not call oncreate in proxied element attrs", function() {
+					var create = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: "b"}
+						}
+					})
+					var node = {tag: component, attrs: {oncreate: create}}
+
+					render(root, [node])
+					o(create.callCount).equals(1)
+				})
+				o("does not call oncreate in proxied fragment attrs", function() {
+					var create = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "[", attrs: vnode.attrs, children: []}
+						}
+					})
+					var node = {tag: component, attrs: {oncreate: create}}
+
+					render(root, [node])
+					o(create.callCount).equals(1)
+				})
+				o("does not call oncreate in proxied component attrs", function() {
+					var create = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: child, attrs: vnode.attrs, children: []}
+						}
+					})
+					var node = {tag: component, attrs: {oncreate: create}}
+
+					render(root, [node])
+					o(create.callCount).equals(1)
+				})
 				o("does not calls oncreate on redraw", function() {
 					var create = o.spy()
 					var component = createComponent({
@@ -549,6 +678,46 @@ o.spec("component", function() {
 					o(root.firstChild.attributes["id"].value).equals("a")
 					o(root.firstChild.firstChild.nodeValue).equals("b")
 				})
+				o("does not call onupdate in proxied element attrs", function() {
+					var update = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: "b"}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onupdate: update}}])
+					o(update.callCount).equals(0)
+					render(root, [{tag: component, attrs: {onupdate: update}}])
+					o(update.callCount).equals(1)
+				})
+				o("does not call onupdate in proxied fragment attrs", function() {
+					var update = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "[", attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onupdate: update}}])
+					o(update.callCount).equals(0)
+					render(root, [{tag: component, attrs: {onupdate: update}}])
+					o(update.callCount).equals(1)
+				})
+				o("does not call onupdate in proxied component attrs", function() {
+					var update = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: child, attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onupdate: update}}])
+					o(update.callCount).equals(0)
+					render(root, [{tag: component, attrs: {onupdate: update}}])
+					o(update.callCount).equals(1)
+				})
 				o("calls onupdate when returning fragment", function() {
 					var called = 0
 					var component = createComponent({
@@ -599,6 +768,46 @@ o.spec("component", function() {
 					o(called).equals(1)
 					o(root.childNodes.length).equals(0)
 				})
+				o("does not call onremove in proxied element attrs", function() {
+					var remove = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: "b"}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onremove: remove}}])
+					o(remove.callCount).equals(0)
+					render(root, [])
+					o(remove.callCount).equals(1)
+				})
+				o("does not call onremove in proxied fragment attrs", function() {
+					var remove = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "[", attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onremove: remove}}])
+					o(remove.callCount).equals(0)
+					render(root, [])
+					o(remove.callCount).equals(1)
+				})
+				o("does not call onremove in proxied component attrs", function() {
+					var remove = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: child, attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onremove: remove}}])
+					o(remove.callCount).equals(0)
+					render(root, [])
+					o(remove.callCount).equals(1)
+				})
 				o("calls onremove when returning fragment", function() {
 					var called = 0
 					var component = createComponent({
@@ -647,6 +856,46 @@ o.spec("component", function() {
 					o(called).equals(1)
 					o(root.childNodes.length).equals(0)
 				})
+				o("does not call onbeforeremove in proxied element attrs", function() {
+					var beforeremove = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: "b"}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onbeforeremove: beforeremove}}])
+					o(beforeremove.callCount).equals(0)
+					render(root, [])
+					o(beforeremove.callCount).equals(1)
+				})
+				o("does not call onbeforeremove in proxied fragment attrs", function() {
+					var beforeremove = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "[", attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onbeforeremove: beforeremove}}])
+					o(beforeremove.callCount).equals(0)
+					render(root, [])
+					o(beforeremove.callCount).equals(1)
+				})
+				o("does not call onbeforeremove in proxied component attrs", function() {
+					var beforeremove = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: child, attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onbeforeremove: beforeremove}}])
+					o(beforeremove.callCount).equals(0)
+					render(root, [])
+					o(beforeremove.callCount).equals(1)
+				})
 				o("calls onbeforeremove when returning fragment", function() {
 					var called = 0
 					var component = createComponent({
@@ -686,6 +935,46 @@ o.spec("component", function() {
 					render(root, [updated])
 
 					o(vnode.dom).notEquals(updated.dom)
+				})
+				o("does not call onbeforeupdate in proxied element attrs", function() {
+					var beforeupdate = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "div", attrs: vnode.attrs, text: "b"}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onbeforeupdate: beforeupdate}}])
+					o(beforeupdate.callCount).equals(0)
+					render(root, [{tag: component, attrs: {onbeforeupdate: beforeupdate}}])
+					o(beforeupdate.callCount).equals(1)
+				})
+				o("does not call onbeforeupdate in proxied fragment attrs", function() {
+					var beforeupdate = o.spy()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: "[", attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onbeforeupdate: beforeupdate}}])
+					o(beforeupdate.callCount).equals(0)
+					render(root, [{tag: component, attrs: {onbeforeupdate: beforeupdate}}])
+					o(beforeupdate.callCount).equals(1)
+				})
+				o("does not call onbeforeupdate in proxied component attrs", function() {
+					var beforeupdate = o.spy()
+					var child = createComponent()
+					var component = createComponent({
+						view: function(vnode) {
+							return {tag: child, attrs: vnode.attrs, children: []}
+						}
+					})
+
+					render(root, [{tag: component, attrs: {onbeforeupdate: beforeupdate}}])
+					o(beforeupdate.callCount).equals(0)
+					render(root, [{tag: component, attrs: {onbeforeupdate: beforeupdate}}])
+					o(beforeupdate.callCount).equals(1)
 				})
 				o("lifecycle timing megatest (for a single component)", function() {
 					var methods = {

--- a/util/censor.js
+++ b/util/censor.js
@@ -1,0 +1,55 @@
+"use strict"
+
+// Note: this avoids as much allocation and overhead as possible.
+var hasOwn = {}.hasOwnProperty
+var magic = [
+	"key", "oninit", "oncreate", "onbeforeupdate", "onupdate",
+	"onbeforeremove", "onremove",
+]
+
+function includesOwn(attrs, keys) {
+	if (Array.isArray(keys)) {
+		for (var i = 0; i < keys.length; i++) {
+			if (hasOwn.call(attrs, keys[i])) return true
+		}
+	}
+	return false
+}
+
+function filterOne(attrs, list) {
+	var result = {}
+
+	for (var key in attrs) {
+		if (hasOwn.call(attrs, key) && list.indexOf(key) < 0) {
+			result[key] = attrs[key]
+		}
+	}
+
+	return result
+}
+
+function filterTwo(attrs, extras) {
+	var result = {}
+
+	for (var key in attrs) {
+		if (hasOwn.call(attrs, key) &&
+				magic.indexOf(key) < 0 &&
+				extras.indexOf(key) < 0) {
+			result[key] = attrs[key]
+		}
+	}
+
+	return result
+}
+
+module.exports = function(attrs, extras) {
+	if (includesOwn(attrs, magic)) {
+		return includesOwn(attrs, extras) ?
+			filterTwo(attrs, extras) :
+			filterOne(attrs, magic)
+	} else {
+		return includesOwn(attrs, extras) ?
+			filterOne(attrs, extras) :
+			attrs
+	}
+}

--- a/util/tests/test-censor.js
+++ b/util/tests/test-censor.js
@@ -1,0 +1,74 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var censor = require("../../util/censor")
+
+o.spec("censor", function() {
+	o("returns empty objects unmodified", function() {
+		var attrs = {}
+
+		o(censor(attrs)).equals(attrs)
+	})
+
+	o("returns non-empty objects without lifecycle methods unmodified", function() {
+		var attrs = {foo: 1, bar: 2, onevent: function () {}}
+
+		o(censor(attrs)).equals(attrs)
+	})
+
+	o("strips methods from objects with key", function() {
+		var attrs = {foo: 1, bar: 2, key: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+
+	o("strips methods from objects with oninit", function() {
+		var attrs = {foo: 1, bar: 2, oninit: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+
+	o("strips methods from objects with oncreate", function() {
+		var attrs = {foo: 1, bar: 2, oncreate: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+
+	o("strips methods from objects with onbeforeupdate", function() {
+		var attrs = {foo: 1, bar: 2, onbeforeupdate: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+
+	o("strips methods from objects with onupdate", function() {
+		var attrs = {foo: 1, bar: 2, onupdate: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+
+	o("strips methods from objects with onbeforeremove", function() {
+		var attrs = {foo: 1, bar: 2, onbeforeremove: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+
+	o("strips methods from objects with onremove", function() {
+		var attrs = {foo: 1, bar: 2, onremove: "foo"}
+		var censored = censor(attrs)
+
+		o(censored).notEquals(attrs)
+		o(censored).deepEquals({foo: 1, bar: 2})
+	})
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I added two things:

- I basically brought [this](https://github.com/isiahmeadows/mithril-helpers/blob/master/docs/censor.md) into core, semantics and all. It was almost a bit-for-bit copy.
- I added, for convenience and intuitiveness, the ability to forward attributes directly without worrying about duplicate lifecycle calls as much.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is to make it harder for users to screw themselves over doing the most obvious thing, and when things could go wrong, it gives them a way out. Providing the default for the common path of simple attribute proxying is also something we can optimize for internally without much issue. If forwarding through attrs ignores lifecycle methods, users don't have to allocate *yet another object* within their trees, and it cuts down on the amount of branching within views. (`m.censor` is non-trivial and a bit heavy for a mildly perf-sensitive method, FWIW.)

Fixes #1775 
Fixes #1986 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've run perf tests, the existing tests, and I added some new unit tests. I ran them all in ospec, but I don't expect much to change when translated to the browser. They all pass, which is awesome.

Note that the existing benchmarks don't cover keys - I didn't actually get around to writing some that tested that, but it's easier said than done.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

I listed it as non-breaking, because the changed functionality was broken to the point of unusability to begin with. (I have little reason to believe anyone is actually *depending* on hooks getting called multiple times when they're proxied through.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
