### PR TITLE
Custom element fix

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -28,6 +28,7 @@
 - hyperscript: when an attribute is defined on both the first and second argument (as a CSS selector and an `attrs` field, respectively), the latter takes precedence, except for `class` attributes that are still added together. [#2172](https://github.com/MithrilJS/mithril.js/issues/2172) ([#2174](https://github.com/MithrilJS/mithril.js/pull/2174))
 - stream: when a stream conditionally returns HALT, dependant stream will also end ([#2200](https://github.com/MithrilJS/mithril.js/pull/2200))
 - render: remove some redundancy within the component initialization code ([#2213](https://github.com/MithrilJS/mithril.js/pull/2213))
+- render: Align custom elements to work like normal elements, minus all the HTML-specific magic. ([#2221](https://github.com/MithrilJS/mithril.js/pull/2221))
 
 #### News
 

--- a/docs/hyperscript.md
+++ b/docs/hyperscript.md
@@ -178,6 +178,76 @@ m("input[readonly]")
 m("input[readOnly]")
 ```
 
+This even includes custom elements. For example, you can use [A-Frame](https://aframe.io/docs/0.8.0/introduction/) within Mithril, no problem!
+
+```javascript
+m("a-scene", [
+	m("a-box", {
+		position: "-1 0.5 -3",
+		rotation: "0 45 0",
+		color: "#4CC3D9",
+	}),
+
+	m("a-sphere", {
+		position: "0 1.25 -5",
+		radius: "1.25",
+		color: "#EF2D5E",
+	}),
+
+	m("a-cylinder", {
+		position: "1 0.75 -3",
+		radius: "0.5",
+		height: "1.5",
+		color: "#FFC65D",
+	}),
+
+	m("a-plane", {
+		position: "0 0 -4",
+		rotation: "-90 0 0",
+		width: "4",
+		height: "4",
+		color: "#7BC8A4",
+	}),
+
+	m("a-sky", {
+		color: "#ECECEC",
+	}),
+])
+```
+
+And yes, this translates to both attributes and properties, and it works just like they would in the DOM. Using [Brick's `brick-deck`](http://brick.mozilla.io/docs/brick-deck) as an example, they have a `selected-index` attribute with a corresponding `selectedIndex` getter/setter property.
+
+```javascript
+m("brick-deck[selected-index=0]", [/* ... */]) // lowercase
+m("brick-deck[selectedIndex=0]", [/* ... */]) // uppercase
+// I know these look odd, but `brick-deck`'s `selectedIndex` property is a
+// string, not a number.
+m("brick-deck", {"selected-index": "0"}, [/* ... */])
+m("brick-deck", {"selectedIndex": "0"}, [/* ... */])
+```
+
+For custom elements, it doesn't auto-stringify properties, in case they are objects, numbers, or some other non-string value. So assuming you had some custom element `my-special-element` that has an `elem.whitelist` array getter/setter property, you could do this, and it'd work as you'd expect:
+
+```javascript
+m("my-special-element", {
+	whitelist: [
+		"https://example.com",
+		"http://neverssl.com",
+		"https://google.com",
+	],
+})
+```
+
+If you have classes or IDs for those elements, the shorthands still work as you would expect. To pull another A-Frame example:
+
+```javascript
+// These two are equivalent
+m("a-entity#player")
+m("a-entity", {id: "player"})
+```
+
+Do note that all the properties with magic semantics, like lifecycle attributes, `onevent` handlers, `key`s, `class`, and `style`, those are still treated the same way they are for normal HTML elements.
+
 ---
 
 ### Style attribute
@@ -192,7 +262,7 @@ m("div[style=background:red]")
 
 Using a string as a `style` would overwrite all inline styles in the element if it is redrawn, and not only CSS rules whose values have changed.
 
-Mithril does not attempt to add units to number values.
+Mithril does not attempt to add units to number values. It simply stringifies them.
 
 ---
 

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -111,6 +111,7 @@ o.spec("call()", function() {
 
 		o(spy.callCount).equals(1)
 		o(spy.args[0]).equals(1)
+		o(spy.calls[0]).deepEquals([1])
 	})
 })
 ```

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -4,6 +4,7 @@
 ## Upcoming...
 _2018-xx-yy_
 <!-- Add new lines here. Version number will be decided later -->
+- Add `spy.calls` array property to get the `this` and `arguments` values for any arbitrary call.
 
 ## 3.0.1
 _2018-06-30_
@@ -70,10 +71,7 @@ _2017-12-01_
 
 
 
-## 1.3 and earlier 
+## 1.3 and earlier
 - Log using util.inspect to show object content instead of "[object Object]" ([#1661](https://github.com/MithrilJS/mithril.js/issues/1661), [@porsager](https://github.com/porsager))
 - Shell command: Ignore hidden directories and files ([#1855](https://github.com/MithrilJS/mithril.js/pull/1855) [@pdfernhout)](https://github.com/pdfernhout))
 - Library: Add the possibility to name new test suites ([#1529](https://github.com/MithrilJS/mithril.js/pull/1529))
-
-
-

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -49,6 +49,7 @@ else window.o = m()
 		var spy = function() {
 			spy.this = this
 			spy.args = [].slice.call(arguments)
+			spy.calls.push({this: this, args: spy.args})
 			spy.callCount++
 
 			if (fn) return fn.apply(this, arguments)
@@ -59,6 +60,7 @@ else window.o = m()
 				name: {value: fn.name}
 			})
 		spy.args = []
+		spy.calls = []
 		spy.callCount = 0
 		return spy
 	}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -206,6 +206,8 @@ o.spec("ospec", function() {
 			o(spy.callCount).equals(1)
 			o(spy.args.length).equals(1)
 			o(spy.args[0]).equals(1)
+			o(spy.calls.length).equals(1)
+			o(spy.calls[0]).deepEquals({this: undefined, args: [1]})
 		})
 		o("spy wrapping", function() {
 			var spy = o.spy(function view(vnode){
@@ -223,6 +225,8 @@ o.spec("ospec", function() {
 			o(spy.callCount).equals(1)
 			o(spy.args.length).equals(1)
 			o(spy.args[0]).deepEquals({children: children})
+			o(spy.calls.length).equals(1)
+			o(spy.calls[0]).deepEquals({this: state, args: [{children: children}]})
 			o(state).deepEquals({drawn: true})
 			o(output).deepEquals({tag: "div", children: children})
 		})
@@ -461,7 +465,7 @@ o.spec("ospec", function() {
 			oo.spec("nested 3", function () {
 				oo("", function() {
 					oo(true).equals(true)
-	
+
 					return {then: function() {}}
 				})
 			})
@@ -490,10 +494,10 @@ o.spec("ospec", function() {
 						o(diff >= 50).equals(true)
 						o(diff < 80).equals(true)
 					})
-		
+
 					oo("", function() {
 						oo(true).equals(true)
-		
+
 						return {then: function() {}}
 					})
 				})

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -302,6 +302,63 @@ o.spec("hyperscript", function() {
 			o(vnode.attrs.className).equals("a b")
 		})
 	})
+	o.spec("custom element attrs", function() {
+		o("handles string attr", function() {
+			var vnode = m("custom-element", {a: "b"})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals("b")
+		})
+		o("handles falsy string attr", function() {
+			var vnode = m("custom-element", {a: ""})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals("")
+		})
+		o("handles number attr", function() {
+			var vnode = m("custom-element", {a: 1})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals(1)
+		})
+		o("handles falsy number attr", function() {
+			var vnode = m("custom-element", {a: 0})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals(0)
+		})
+		o("handles boolean attr", function() {
+			var vnode = m("custom-element", {a: true})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals(true)
+		})
+		o("handles falsy boolean attr", function() {
+			var vnode = m("custom-element", {a: false})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals(false)
+		})
+		o("handles only key in attrs", function() {
+			var vnode = m("custom-element", {key:"a"})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs).equals(null)
+			o(vnode.key).equals("a")
+		})
+		o("handles many attrs", function() {
+			var vnode = m("custom-element", {a: "b", c: "d"})
+
+			o(vnode.tag).equals("custom-element")
+			o(vnode.attrs.a).equals("b")
+			o(vnode.attrs.c).equals("d")
+		})
+		o("handles className attrs property", function() {
+			var vnode = m("custom-element", {className: "a"})
+
+			o(vnode.attrs.className).equals("a")
+		})
+	})
 	o.spec("children", function() {
 		o("handles string single child", function() {
 			var vnode = m("div", {}, ["a"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Align custom elements to work just like normal elements, minus our HTML workarounds. Previously, our support has been undocumented and completely untested, but I plan to fix that in a follow-up commit (along with a changelog entry).

Drive-by: add a `spy.calls` property to ospec that helped me develop the patch. It's technically unnecessary, but it helped me clean up the tests some, and it made the tests a little more concise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2220 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the tests in ospec + Node. Performance changes are within the margin of error, although I made a few size-related optimizations that incidentally reclaimed 33 bytes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
