### PR TITLE
Ospec: expose messages for passing tests, in addition to failing tests

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -41,6 +41,7 @@
 - API: add support for raw SVG in `m.trust()` string ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
 - render/core: remove the DOM nodes recycling pool ([#2122](https://github.com/MithrilJS/mithril.js/pull/2122))
 - render/core: revamp the core diff engine, and introduce a longest-increasing-subsequence-based logic to minimize DOM operations when re-ordering keyed nodes.
+- ospec: Test results now include `.message` and `.context` regardless of whether the test passed or failed
 
 #### Bug fixes
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -41,7 +41,6 @@
 - API: add support for raw SVG in `m.trust()` string ([#2097](https://github.com/MithrilJS/mithril.js/pull/2097))
 - render/core: remove the DOM nodes recycling pool ([#2122](https://github.com/MithrilJS/mithril.js/pull/2122))
 - render/core: revamp the core diff engine, and introduce a longest-increasing-subsequence-based logic to minimize DOM operations when re-ordering keyed nodes.
-- ospec: Test results now include `.message` and `.context` regardless of whether the test passed or failed
 
 #### Bug fixes
 

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -614,7 +614,7 @@ o.spec("message", function() {
 
 ### String result.context
 
-In case of failure, a `>`-separated string showing the structure of the test specification.
+A `>`-separated string showing the structure of the test specification.
 In the below example, `result.context` would be `testing > rocks`.
 
 ```javascript

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -3,6 +3,7 @@
 
 ## Upcoming...
 _2018-xx-yy_
+- ospec: Test results now include `.message` and `.context` regardless of whether the test passed or failed. (#2227 @robertakarobin)
 <!-- Add new lines here. Version number will be decided later -->
 
 ## 3.0.1

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -268,13 +268,14 @@ else window.o = m()
 	}
 	function define(name, verb, compare) {
 		Assert.prototype[name] = function assert(value) {
-			var message = serialize(this.value) + "\n  " + verb + "\n" + serialize(value)
-			if (compare(this.value, value)) succeed(this, message)
-			else fail(this, message)
 			var self = this
-			return function(message) {
-				if (!self.pass) self.message = message + "\n\n" + self.message
-			}
+			var message = serialize(self.value) + "\n  " + verb + "\n" + serialize(value)
+			if (compare(self.value, value)){
+				succeed(self, message)
+				return function(message) {
+					if (!self.pass) self.message = message + "\n\n" + self.message
+				}
+			}else fail(self, message)
 		}
 	}
 	function succeed(assertion, message) {

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -268,16 +268,19 @@ else window.o = m()
 	}
 	function define(name, verb, compare) {
 		Assert.prototype[name] = function assert(value) {
-			if (compare(this.value, value)) succeed(this)
-			else fail(this, serialize(this.value) + "\n  " + verb + "\n" + serialize(value))
+			var message = serialize(this.value) + "\n  " + verb + "\n" + serialize(value)
+			if (compare(this.value, value)) succeed(this, message)
+			else fail(this, message)
 			var self = this
 			return function(message) {
 				if (!self.pass) self.message = message + "\n\n" + self.message
 			}
 		}
 	}
-	function succeed(assertion) {
+	function succeed(assertion, message) {
 		results[assertion.i].pass = true
+		results[assertion.i].context = subjects.join(" > ")
+		results[assertion.i].message = message
 	}
 	function fail(assertion, message, error) {
 		results[assertion.i].pass = false

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -89,6 +89,8 @@ o.spec("reporting", function() {
 			o(results.length).equals(2)("Two results")
 
 			o("error" in results[0] && "pass" in results[0]).equals(true)("error and pass keys present in failing result")
+			o("message" in results[0] && "context" in results[0]).equals(true)("message and context keys present in failing result")
+			o("message" in results[1] && "context" in results[1]).equals(true)("message and context keys present in passing result")
 			o(results[0].pass).equals(false)("Test meant to fail has failed")
 			o(results[1].pass).equals(true)("Test meant to pass has passed")
 


### PR DESCRIPTION
Previously only failing test results had .message and .context.

## Description
This adds .message and .context to passing test results as well, so a complete summary of all test results can be printed if desired.

## Motivation and Context
When reviewing releases, etc, especially with non-developers, it is helpful to be able to explicitly show all test results, including for tests that have passed.

## How Has This Been Tested?
Added 2 tests to Ospec to ensure .message and .context are in both passing and failing test results. Ran Ospec. All tests passed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
