### PR TITLE
Add example for m.route.set with params

### DIFF
--- a/docs/route.md
+++ b/docs/route.md
@@ -78,6 +78,19 @@ Argument          | Type      | Required | Description
 `options.title`   | `String`  | No       | The `title` string to pass to the underlying `history.pushState` / `history.replaceState` call.
 **returns**       |           |          | Returns `undefined`
 
+Remember that when using `.set` with params you also need to define the route:
+```javascript
+var Article = {
+	view: function(vnode) {
+		return "This is article " + vnode.attrs.articleid
+	}
+}
+
+m.route(document.body, {
+	'/article/:articleid': Article
+})
+m.route.set('/article/:articleid', {articleid: 1})
+```
 ##### m.route.get
 
 Returns the last fully resolved routing path, without the prefix. It may differ from the path displayed in the location bar while an asynchronous route is [pending resolution](#code-splitting).


### PR DESCRIPTION
Add example on how to use m.route.set with params

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I had to try a few things before I learned that I needed to define the route, makes sense but couldn't find an example for it

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
