### PR TITLE
Avoid triggering `Object.prototype.__proto__` with keys

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -59,6 +59,8 @@
 - render/events: Event handlers, when set to literally `undefined` (or any non-function), are now correctly removed.
 - render/hooks: fixed an ommission that caused `oninit` to be called unnecessarily in some cases [#1992](https://github.com/MithrilJS/mithril.js/issues/1992)
 - docs: tweaks: ([#2104](https://github.com/MithrilJS/mithril.js/pull/2104) [@mikeyb](https://github.com/mikeyb), [#2205](https://github.com/MithrilJS/mithril.js/pull/2205), [@cavemansspa](https://github.com/cavemansspa))
+- render/core: avoid touching `Object.prototype.__proto__` setter with `key: "__proto__"` in certain situations ([#2251](https://github.com/MithrilJS/mithril.js/pull/2251))
+
 ---
 
 ### v1.1.7

--- a/render/render.js
+++ b/render/render.js
@@ -521,7 +521,7 @@ module.exports = function($window) {
 		}
 	}
 	function getKeyMap(vnodes, start, end) {
-		var map = {}
+		var map = Object.create(null)
 		for (; start < end; start++) {
 			var vnode = vnodes[start]
 			if (vnode != null) {

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -264,6 +264,21 @@ o.spec("updateNodes", function() {
 		o(updated[2].dom.nodeName).equals("S")
 		o(updated[2].dom).equals(root.childNodes[2])
 	})
+	o("creates, deletes, reverses els at same time with '__proto__' key", function() {
+		var vnodes = [{tag: "a", key: "__proto__"}, {tag: "i", key: 3}, {tag: "b", key: 2}]
+		var updated = [{tag: "b", key: 2}, {tag: "a", key: "__proto__"}, {tag: "s", key: 4}]
+
+		render(root, vnodes)
+		render(root, updated)
+
+		o(root.childNodes.length).equals(3)
+		o(updated[0].dom.nodeName).equals("B")
+		o(updated[0].dom).equals(root.childNodes[0])
+		o(updated[1].dom.nodeName).equals("A")
+		o(updated[1].dom).equals(root.childNodes[1])
+		o(updated[2].dom.nodeName).equals("S")
+		o(updated[2].dom).equals(root.childNodes[2])
+	})
 	o("adds to empty array followed by el", function() {
 		var vnodes = [{tag: "[", key: 1, children: []}, {tag: "b", key: 2}]
 		var updated = [{tag: "[", key: 1, children: [{tag: "a"}]}, {tag: "b", key: 2}]
@@ -1242,7 +1257,7 @@ o.spec("updateNodes", function() {
 		o(root.appendChild.callCount + root.insertBefore.callCount).equals(5)
 		o(tagNames).deepEquals(expectedTagNames)
 	})
-	
+
 	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This way, the diff algorithm works with untrusted keys.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a new unit test for this subtle key bug.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
