### PR TITLE
Update request.js

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -28,14 +28,23 @@ module.exports = function($window, Promise) {
 			return promise
 		}
 	}
-	function normalize(args, extra) {
+	
+    	function normalize(args, extra) {
 		if (typeof args === "string") {
-			var url = args
-			args = extra ? Object.assign(extra, {}} : {}
-			if (args.url == null) args.url = url
+		    var url = args;
+
+		    args = extra || {};
+
+		    for(var key in extra) {
+			if (hasOwn.call(extra, key)) {
+			    args[key] = extra[key]
+			}
+		    }
+
+		    args.url = url;
 		}
 		return args
-	}
+    	}
 
 	function request(args, extra) {
 		var finalize = finalizer()

--- a/request/request.js
+++ b/request/request.js
@@ -31,7 +31,7 @@ module.exports = function($window, Promise) {
 	function normalize(args, extra) {
 		if (typeof args === "string") {
 			var url = args
-			args = extra || {}
+			args = extra ? Object.assign(extra, {}} : {}
 			if (args.url == null) args.url = url
 		}
 		return args


### PR DESCRIPTION
Shallow copy args when url is string.

This fix an issue when you have for exemple 4 requests.
The 4 urls are the same because it takes the wrong url, the first reference of the object that was passed on the first request.
Now it is not passed as reference but it is copied.
