### PR TITLE
Add 'throws'/'notThrows' assertion to Ospec for error reporting

### DIFF
--- a/ospec/README.md
+++ b/ospec/README.md
@@ -469,9 +469,17 @@ Asserts that two values are not recursively equal
 
 Asserts that a function throws an instance of the provided constructo
 
+#### Function(String description) o(Function fn).throws(String message)
+
+Asserts that a function throws an Error with the provided message
+
 #### Function(String description) o(Function fn).notThrows(Object constructor)
 
 Asserts that a function does not throw an instance of the provided constructor
+
+#### Function(String description) o(Function fn).notThrows(String message)
+
+Asserts that a function does not throw an Error with the provided message
 
 ---
 

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -427,7 +427,7 @@ If an argument is defined for the `assertions` function, the test is deemed to b
 
 ### Assertion o(any value)
 
-Starts an assertion. There are four types of assertion: `equals`, `notEquals`, `deepEquals` and `notDeepEquals`.
+Starts an assertion. There are six types of assertion: `equals`, `notEquals`, `deepEquals`, `notDeepEquals`, `throws`, `notThrows`.
 
 Assertions have this form:
 
@@ -464,6 +464,14 @@ Asserts that two values are recursively equal
 #### Function(String description) o(any value).notDeepEquals(any value)
 
 Asserts that two values are not recursively equal
+
+#### Function(String description) o(Function fn).throws(Object constructor)
+
+Asserts that a function throws an Error of the provided constructor
+
+#### Function(String description) o(Function fn).notThrows(Object constructor)
+
+Asserts that a function does not throw an Error of the provided constructor
 
 ---
 

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -467,11 +467,11 @@ Asserts that two values are not recursively equal
 
 #### Function(String description) o(Function fn).throws(Object constructor)
 
-Asserts that a function throws an Error of the provided constructor
+Asserts that a function throws an instance of the provided constructo
 
 #### Function(String description) o(Function fn).notThrows(Object constructor)
 
-Asserts that a function does not throw an Error of the provided constructor
+Asserts that a function does not throw an instance of the provided constructor
 
 ---
 

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -5,7 +5,7 @@
 _2018-xx-yy_
 <!-- Add new lines here. Version number will be decided later -->
 - Add `spy.calls` array property to get the `this` and `arguments` values for any arbitrary call.
-- Added `.throws` and `.notThrows` assertions to ospec
+- Added `.throws` and `.notThrows` assertions to ospec. (#2255 @robertakarobin)
 
 ## 3.0.1
 _2018-06-30_

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -5,6 +5,7 @@
 _2018-xx-yy_
 <!-- Add new lines here. Version number will be decided later -->
 - Add `spy.calls` array property to get the `this` and `arguments` values for any arbitrary call.
+- Added `.throws` and `.notThrows` assertions to ospec
 
 ## 3.0.1
 _2018-06-30_

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -217,6 +217,8 @@ else window.o = m()
 	define("notEquals", "should not equal", function(a, b) {return a !== b})
 	define("deepEquals", "should deep equal", deepEqual)
 	define("notDeepEquals", "should not deep equal", function(a, b) {return !deepEqual(a, b)})
+	define("throws", "should throw a", throws)
+	define("notThrows", "should not throw a", function(a, b) {return !throws(a, b)})
 
 	function isArguments(a) {
 		if ("callee" in a) {
@@ -254,6 +256,14 @@ else window.o = m()
 				return true
 			}
 			if (a.valueOf() === b.valueOf()) return true
+		}
+		return false
+	}
+	function throws(a, b){
+		try{
+			a()
+		}catch(e){
+			return (e instanceof b)
 		}
 		return false
 	}

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -263,7 +263,11 @@ else window.o = m()
 		try{
 			a()
 		}catch(e){
-			return (e instanceof b)
+			if(typeof b === "string"){
+				return (e.message === b)
+			}else{
+				return (e instanceof b)
+			}
 		}
 		return false
 	}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -164,6 +164,14 @@ o.spec("ospec", function() {
 			o(a).notEquals(2)
 			o({a: [1, 2], b: 3}).deepEquals({a: [1, 2], b: 3})
 			o([{a: 1, b: 2}, {c: 3}]).deepEquals([{a: 1, b: 2}, {c: 3}])
+			o(function(){throw new Error()}).throws(Error)
+			o(function(){'ayy'.foo()}).throws(TypeError)
+			o(function(){Math.PI.toFixed(Math.pow(10,20))}).throws(RangeError)
+			o(function(){foo.bar()}).throws(ReferenceError)
+			o(function(){eval('foo bar')}).throws(SyntaxError)
+			o(function(){decodeURIComponent('%')}).throws(URIError)
+
+			o(function(){'ayy'.foo()}).notThrows(SyntaxError)
 
 			var undef1 = {undef: void 0}
 			var undef2 = {UNDEF: void 0}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -170,6 +170,8 @@ o.spec("ospec", function() {
 			o(function(){decodeURIComponent("%")}).throws(URIError)
 
 			o(function(){"ayy".foo()}).notThrows(SyntaxError)
+			o(function(){throw new Error("foo")}).throws("foo")
+			o(function(){throw new Error("foo")}).notThrows("bar")
 
 			var undef1 = {undef: void 0}
 			var undef2 = {UNDEF: void 0}

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -165,13 +165,11 @@ o.spec("ospec", function() {
 			o({a: [1, 2], b: 3}).deepEquals({a: [1, 2], b: 3})
 			o([{a: 1, b: 2}, {c: 3}]).deepEquals([{a: 1, b: 2}, {c: 3}])
 			o(function(){throw new Error()}).throws(Error)
-			o(function(){'ayy'.foo()}).throws(TypeError)
+			o(function(){"ayy".foo()}).throws(TypeError)
 			o(function(){Math.PI.toFixed(Math.pow(10,20))}).throws(RangeError)
-			o(function(){foo.bar()}).throws(ReferenceError)
-			o(function(){eval('foo bar')}).throws(SyntaxError)
-			o(function(){decodeURIComponent('%')}).throws(URIError)
+			o(function(){decodeURIComponent("%")}).throws(URIError)
 
-			o(function(){'ayy'.foo()}).notThrows(SyntaxError)
+			o(function(){"ayy".foo()}).notThrows(SyntaxError)
 
 			var undef1 = {undef: void 0}
 			var undef2 = {UNDEF: void 0}


### PR DESCRIPTION
## Description
This adds two assertions to Ospec:
- o(Function).throws(Object)
- o(Function).notThrows(Object)

These assertions test whether the provided Function throws the correct type of Error. For example:

```
o(function(){"ayy".foo()}).throws(TypeError)
```

## Motivation and Context
**Edit (isiahmeadows):** Fixes #2146

At present, the only way to use ospec to test whether something throws/doesn't throw an error is something like the following:

```
let error
try{
    /* bad code*/
}catch(e){
    error = e
}finally{
    o(error.constructor).equals(Error)
}
```

Robust applications often have custom error reporting. Ospec would benefit from eliminating the need for developers to include this try/catch boilerplate when testing error reporting.

## How Has This Been Tested?
Tested by running `npm test`, and running the Ospec tests specifically in the browser. This should affect no other areas of the code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
