### PR TITLE
Fix #2210

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -232,7 +232,7 @@ If you want to try it and give feedback, you can open `package.json` and change 
 {
 	"name": "my-project",
 	"scripts": {
-		"build": "bundle index.js --output app.js --watch"
+		"build": "bundle src/index.js --output bin/app.js --watch"
 	}
 }
 ```


### PR DESCRIPTION
## Description
Changed the example command for Mithril Bundler to be more consistent with Webpack quick start.

## Motivation and Context
This PR fixes #2210 

## How Has This Been Tested?
I started a new Mithril project using the installation guide and replaced the old command with the new one. Since I was following the guide, `src/index.js` was picked up by the bundler and `bin/app.js` was picked up by `index.html` successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
