### PR TITLE
Store normalized vnodes in the dom element. Add render tests.

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -60,6 +60,7 @@
 - render/hooks: fixed an ommission that caused `oninit` to be called unnecessarily in some cases [#1992](https://github.com/MithrilJS/mithril.js/issues/1992)
 - docs: tweaks: ([#2104](https://github.com/MithrilJS/mithril.js/pull/2104) [@mikeyb](https://github.com/mikeyb), [#2205](https://github.com/MithrilJS/mithril.js/pull/2205), [@cavemansspa](https://github.com/cavemansspa))
 - render/core: avoid touching `Object.prototype.__proto__` setter with `key: "__proto__"` in certain situations ([#2251](https://github.com/MithrilJS/mithril.js/pull/2251))
+- render/core: Vnodes stored in the dom node supplied to `m.render()` are now normalized [#2266](https://github.com/MithrilJS/mithril.js/pull/2266)
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -865,8 +865,8 @@ module.exports = function($window) {
 		// First time rendering into a node clears it out
 		if (dom.vnodes == null) dom.textContent = ""
 
-		if (!Array.isArray(vnodes)) vnodes = [vnodes]
-		updateNodes(dom, dom.vnodes, Vnode.normalizeChildren(vnodes), hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
+		vnodes = Vnode.normalizeChildren(Array.isArray(vnodes) ? vnodes : [vnodes])
+		updateNodes(dom, dom.vnodes, vnodes, hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
 		dom.vnodes = vnodes
 		// document.activeElement can return null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/activeElement
 		if (active != null && $doc.activeElement !== active && typeof active.focus === "function") active.focus()

--- a/render/tests/test-render.js
+++ b/render/tests/test-render.js
@@ -12,6 +12,32 @@ o.spec("render", function() {
 		render = vdom($window).render
 	})
 
+	o("renders plain text", function() {
+		render(root, "a")
+		o(root.childNodes.length).equals(1)
+		o(root.childNodes[0].nodeValue).equals("a")
+	})
+
+	o("updates plain text", function() {
+		render(root, "a")
+		render(root, "b")
+		o(root.childNodes.length).equals(1)
+		o(root.childNodes[0].nodeValue).equals("b")
+	})
+
+	o("renders a number", function() {
+		render(root, 1)
+		o(root.childNodes.length).equals(1)
+		o(root.childNodes[0].nodeValue).equals("1")
+	})
+
+	o("updates a number", function() {
+		render(root, 1)
+		render(root, 2)
+		o(root.childNodes.length).equals(1)
+		o(root.childNodes[0].nodeValue).equals("2")
+	})
+
 	o("overwrites existing content", function() {
 		var vnodes = []
 


### PR DESCRIPTION
## Description
Ensures that vnodes are normalized before being stored in the dom element (in `m.render()`).

## Motivation and Context
Fixes #2264

## How Has This Been Tested?
Existing tests pass, added tests to cover this case.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
