### PR TITLE
remove redundant changelogs for 1.1.4-6

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -74,29 +74,6 @@
 
 ### v1.1.6
 
-- core: render() function can no longer prevent from changing `document.activeElement` in lifecycle hooks ([#1988](https://github.com/MithrilJS/mithril.js/pull/1988), [@purplecode](https://github.com/purplecode))
-- core: don't call `onremove` on the children of components that return null from the view [#1921](https://github.com/MithrilJS/mithril.js/issues/1921) [@octavore](https://github.com/octavore) ([#1922](https://github.com/MithrilJS/mithril.js/pull/1922))
-- hypertext: correct handling of shared attributes object passed to `m()`. Will copy attributes when it's necessary [#1941](https://github.com/MithrilJS/mithril.js/issues/1941) [@s-ilya](https://github.com/s-ilya) ([#1942](https://github.com/MithrilJS/mithril.js/pull/1942))
-
-
----
-
-### v1.1.5
-
-- API: If a user sets the Content-Type header within a request's options, that value will be the entire header value rather than being appended to the default value ([#1924](https://github.com/MithrilJS/mithril.js/pull/1924))
-
----
-
-### v1.1.4
-
-#### Bug fixes:
-
-- Fix IE bug where active element is null causing render function to throw error ([#1943](https://github.com/MithrilJS/mithril.js/pull/1943), [@JacksonJN](https://github.com/JacksonJN))
-
----
-
-### v1.1.6
-
 #### Bug fixes
 
 - core: render() function can no longer prevent from changing `document.activeElement` in lifecycle hooks ([#1988](https://github.com/MithrilJS/mithril.js/pull/1988), [@purplecode](https://github.com/purplecode))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changelogs for 1.1.4, 1.1.5 and 1.1.6 were there twice. This fixes that.

## Motivation and Context
They should only be there once.

## How Has This Been Tested?
I read it the way it was, and then I read it the new-and-improved way. I like the new way better.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
