### PR TITLE
Fix #1771 and probably others

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -62,6 +62,7 @@
 - docs: tweaks: ([#2104](https://github.com/MithrilJS/mithril.js/pull/2104) [@mikeyb](https://github.com/mikeyb), [#2205](https://github.com/MithrilJS/mithril.js/pull/2205), [@cavemansspa](https://github.com/cavemansspa), [#2265](https://github.com/MithrilJS/mithril.js/pull/2265), [@isiahmeadows](https://github.com/isiahmeadows))
 - render/core: avoid touching `Object.prototype.__proto__` setter with `key: "__proto__"` in certain situations ([#2251](https://github.com/MithrilJS/mithril.js/pull/2251))
 - render/core: Vnodes stored in the dom node supplied to `m.render()` are now normalized [#2266](https://github.com/MithrilJS/mithril.js/pull/2266)
+- render/core: `blur` handlers are now removed before removing the DOM vnodes, but after firing hooks ([#2286](https://github.com/MithrilJS/mithril.js/pull/2286))
 
 ---
 

--- a/render/render.js
+++ b/render/render.js
@@ -673,6 +673,13 @@ module.exports = function($window) {
 					if (child != null) onremove(child)
 				}
 			}
+			// Chrome emits a `blur` event on children when they are removed,
+			// but *before* they dereference their parent...
+			// https://stackoverflow.com/questions/21926083/failed-to-execute-removechild-on-node#22934552
+			// https://github.com/MithrilJS/mithril.js/issues/1771
+			if (vnode.events != null && vnode.events.onblur != null) {
+				vnode.dom.removeEventListener("blur", vnode.events, false)
+			}
 		}
 	}
 

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -324,4 +324,16 @@ o.spec("event", function() {
 		o(onevent.args[0].type).equals("transitionend")
 		o(onevent.args[0].target).equals(div.dom)
 	})
+
+	o("doesn't fire blur on removed nodes", function() {
+		var spy = o.spy()
+		var div = {tag: "div", attrs: {onblur: spy}}
+
+		render(root, [div])
+		div.dom.focus()
+		render(root, [])
+
+		o(spy.callCount).equals(0)
+		o(onevent.callCount).equals(0)
+	})
 })

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -87,6 +87,13 @@ module.exports = function(options) {
 		var index = this.childNodes.indexOf(child)
 		if (index > -1) {
 			this.childNodes.splice(index, 1)
+			// Yes, *this* is the behavior Chrome has and what FF is considering in
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=559561
+			if (activeElement === child) {
+				var blur = $window.document.createEvent()
+				blur.initEvent("blur")
+				child.dispatchEvent(blur)
+			}
 			child.parentNode = null
 		}
 		else throw new TypeError("Failed to execute 'removeChild'")

--- a/test-utils/tests/test-domMock.js
+++ b/test-utils/tests/test-domMock.js
@@ -208,6 +208,19 @@ o.spec("domMock", function() {
 			try {parent.removeChild(child)}
 			catch (e) {done()}
 		})
+		o("invokes blur on child if focused", function() {
+			var parent = $document.createElement("div")
+			var child = $document.createElement("a")
+			var spy = o.spy()
+			parent.appendChild(child)
+			child.addEventListener("blur", spy, false)
+			child.focus()
+			parent.removeChild(child)
+
+			o(spy.callCount).equals(1)
+			o(spy.args[0].type).equals("blur")
+			o(spy.args[0].target).equals(child)
+		})
 	})
 
 	o.spec("insertBefore", function() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This is *super* subtle, and IMHO Chrome did exactly the wrong thing here. I have *no* clue why Chrome decided it was a good idea to dispatch the event *after* removal but *before* dereferencing the child from the parent. Couldn't they just remove the child and fire a new event type that contains both the child *and* parent? 😖 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1771.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added some new DOM mocks to align with Chrome and some relevant tests for both this and the new mock behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
