### PR TITLE
Component docs update: an effective compromise re: state & syntactic variance

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -101,7 +101,7 @@ var Example = {
 }
 ```
 
-NOTE: Lifecycle methods can also be provided via the `attrs` object, so you should avoid using the lifecycle method names for your own callbacks as they would also be invoked by Mithril. Use lifecycle methods in `attrs` only when you specifically wish to create lifecycle hooks.
+NOTE: Lifecycle methods can also be defined in the `attrs` object, so you should avoid using their names for your own callbacks as they would also be invoked by Mithril itself. Use them in `attrs` only when you specifically wish to use them as lifecycle methods.
 
 ---
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -29,7 +29,7 @@ m(Example)
 
 ### Lifecycle methods
 
-Components can have the same [lifecycle methods](lifecycle-methods.md) as virtual DOM nodes:
+Components can have the same [lifecycle methods](lifecycle-methods.md) as virtual DOM nodes. Note that `vnode` is passed as an argument to each lifecycle method, as well as to `view` (with the _previous_ vnode passed additionally to `onbeforeupdate`):
 
 ```javascript
 var ComponentWithHooks = {

--- a/docs/components.md
+++ b/docs/components.md
@@ -43,7 +43,7 @@ var ComponentWithHooks = {
 	oncreate: function(vnode) {
 		console.log("DOM created")
 	},
-	onbeforeupdate: function(new_vnode, old_vnode) {
+	onbeforeupdate: function(newVnode, oldVnode) {
 		return true
 	},
 	onupdate: function(vnode) {

--- a/docs/components.md
+++ b/docs/components.md
@@ -185,7 +185,7 @@ A big advantage of closure components is that we don't need to worry about bindi
 
 #### POJO Component State
 
-It is generally accepted that a component with state that must be managed is best expressed as a closure. If, however, you have reason to manage state in a POJO, the state of a component can be accessed in three ways: as a blueprint at initialization, via `vnode.state` and via the `this` keyword in component methods.
+It is generally recommended that you use closures for managing component state. If, however, you have reason to manage state in a POJO, the state of a component can be accessed in three ways: as a blueprint at initialization, via `vnode.state` and via the `this` keyword in component methods.
 
 #### At initialization
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -17,12 +17,14 @@ Components are a mechanism to encapsulate parts of a view to make code easier to
 Any Javascript object that has a `view` method is a Mithril component. Components can be consumed via the [`m()`](hyperscript.md) utility:
 
 ```javascript
+// define your component
 var Example = {
 	view: function(vnode) {
 		return m("div", "Hello")
 	}
 }
 
+// consume your component
 m(Example)
 
 // equivalent HTML

--- a/docs/components.md
+++ b/docs/components.md
@@ -251,7 +251,7 @@ Be aware that when using ES5 functions, the value of `this` in nested anonymous 
 
 ### ES6 classes
 
-If it suits your needs (f.e. in object-oriented projects), components can also be written using ES6 class syntax:
+If it suits your needs (like in object-oriented projects), components can also be written using ES6 class syntax:
 
 ```javascript
 class ES6ClassComponent {

--- a/docs/components.md
+++ b/docs/components.md
@@ -4,10 +4,10 @@
 - [Lifecycle methods](#lifecycle-methods)
 - [Passing data to components](#passing-data-to-components)
 - [State](#state)
-	- [Closure state](#closure-component-state)
-	- [POJO state](#pojo-component-state)
+	- [Closure component state](#closure-component-state)
+	- [POJO component state](#pojo-component-state)
 - [ES6 Classes](#es6-classes)
-	- [Class state](#class-component-state)
+	- [Class component state](#class-component-state)
 - [Avoid anti-patterns](#avoid-anti-patterns)
 
 ### Structure


### PR DESCRIPTION
## Description
Fixes #2293, for v2 scope. Mostly just re-arranged the document flow, and special-cased ES6 classes.

## Motivation and Context
Clarity on this doc has been severely lacking. I think this is simpler to understand, without omitting anything.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
