### PR TITLE
Cast className using toString

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -30,6 +30,7 @@
 - render: remove some redundancy within the component initialization code ([#2213](https://github.com/MithrilJS/mithril.js/pull/2213))
 - render: Align custom elements to work like normal elements, minus all the HTML-specific magic. ([#2221](https://github.com/MithrilJS/mithril.js/pull/2221))
 - render: simplify component removal ([#2214](https://github.com/MithrilJS/mithril.js/pull/2214))
+- cast className using toString ([#2309](https://github.com/MithrilJS/mithril.js/pull/2309))
 
 #### News
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -54,7 +54,7 @@ function execSelector(state, attrs, children) {
 	if (className != null || state.attrs.className != null) attrs.className =
 		className != null
 			? state.attrs.className != null
-				? state.attrs.className + " " + className
+				? String(state.attrs.className) + " " + String(className)
 				: className
 			: state.attrs.className != null
 				? state.attrs.className

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -358,6 +358,15 @@ o.spec("hyperscript", function() {
 
 			o(vnode.attrs.className).equals("a")
 		})
+		o("casts className using toString like browsers", function() {
+			const className = {
+				valueOf: () => ".valueOf",
+				toString: () => "toString"
+			}
+			var vnode = m("custom-element" + className, {className: className})
+
+			o(vnode.attrs.className).equals("valueOf toString")
+		})
 	})
 	o.spec("children", function() {
 		o("handles string single child", function() {


### PR DESCRIPTION
## Description
When mithril normalizes classNames it now ensures toString is called before concatenating strings. This ensures mithril works like the browser does when setting `dom.className =`. The browser always calls toString for either `dom.classList.add()` or `dom.className =`
## Motivation and Context
This makes mithril behave more like the dom, and allows bss (and maybe others) to support casting to a className using a period when doing 
```
m('div' + b('background blue')) => m('div.bssClass')
```
and not adding a period when doing
```
m('div', { class: b('background blue') }) => m('div', { class: 'bssClass' })
```

[flems with fixed mithril](https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J4s+AE5MAJjAkAKabWoBXHA3wAjWtICeFADpoABMazyA5IQCMF4wGpjmgAZHTpzdWNTpb484pjYD9TaigMODhEJ1cTd1MwOGNrAAYUkPdPY2JaLAwcjNjTdgyLAAkIbMI5GAs-AEojesoaXIAHaDk8TQxNGHIqOH6YamIIegQea2tEazYOEEwcPHxqSJahRmYeNgBdKigINABrSdRFrjEIYkIJaBaVCXIeEmI2qIB6D5U0NuOAc1WuQ+WGut2gAAFrPhoQA2EFgu5QfD8FrEXRtbggODUO5tURUNr5ajVM7IZApQYAOS4xgAvMYQPtkNYqABlYh3ND-eRMigUwbEfIwfD5PnWWEUABMAGZpTLYZLZYrmQKQOFIjTlszWSBmszKSAHMYDEbTQ5xZLrAB2eUATgALPaHarDY5zebHHyWezOUced7DWEInAtZb5dKHSknVKoy7+WrufJg5rLjqqPr+YajAZiLnWDniAW0LmwLQJHzY9KAKyRiV12G7fbY4ajcZoSYgWEOxAy+acZY8TTrKiPZ4gV7vRBfH5-QF0LAfYdwKH4av4FJLyIogQgdGYvA4vEEluwNsTPAyqOzat7VhAA)

[flems without fix](https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J4s+AE5MAJjAkAKabWoBXHA3wAjWtICeFADpoABMazyA5IQCMF4wGpjmgAZHTpzdWNTpb484pjYD9TaigMODhEJ1cTd1MwOGNrAAYUkPdPY2JaLAwcjNjTdgyLAAkIbMI5GAs-AEojesoaXIAHaDk8TQxNGHIqOH6YamIIegQeACZEVLYOEEwcPHxqSJahRmYeNgBdKigINABrSdRFrjEIYkIJaBaVCXIeEmI2qIB6D5U0NuOAc1WuQ+WGut2gAAFrPhoQA2EFgu5QfD8FrEXRtbggODUO5tUSDYajcZoSYgWEAZkQsJS804yx4mnWVEezxAr3eiC+Pz+gLoWA+TLgUPwAFZ8ClBZEUQIQOjMXgcXiCdiiWMJngKQAWFKzUV7VhAA)
## How Has This Been Tested?
Added a test to check if `toString` is called when using `className` attr.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`