### PR TITLE
Normalise fragments

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -74,6 +74,7 @@
 - render/core: Vnodes stored in the dom node supplied to `m.render()` are now normalized [#2266](https://github.com/MithrilJS/mithril.js/pull/2266)
 - render/core: CSS vars can now be specified in `{style}` attributes ([#2192](https://github.com/MithrilJS/mithril.js/pull/2192) [@barneycarroll](https://github.com/barneycarroll)), ([#2311](https://github.com/MithrilJS/mithril.js/pull/2311) [@porsager](https://github.com/porsager)), ([#2312](https://github.com/MithrilJS/mithril.js/pull/2312) [@isiahmeadows](https://github.com/isiahmeadows))
 - request: don't modify params, call `extract`/`serialize`/`deserialize` with correct `this` value ([#2288](https://github.com/MithrilJS/mithril.js/pull/2288))
+- fragments: allow same overloading logic as hyperscript ([#2327](https://github.com/MithrilJS/mithril.js/pull/2327))
 
 ---
 

--- a/docs/fragment.md
+++ b/docs/fragment.md
@@ -37,9 +37,9 @@ Generates a fragment [vnode](vnodes.md)
 
 Argument    | Type                                                | Required | Description
 ----------- | --------------------------------------------------- | -------- | ---
-`attrs`     | `Object`                                            | Yes      | A map of attributes
-`children`  | `Array<Vnode|String|Number|Boolean|null|undefined>` | Yes      | A list of vnodes
-**returns** | `Vnode`                                             |          | A fragment [vnode](vnodes.md)
+`attrs`     | `Object`                                            | No       | HTML attributes or element properties
+`children`  | `Array<Vnode>|String|Number|Boolean`                | No       | Child [vnodes](vnodes.md#structure). Can be written as [splat arguments](signatures.md#splats)
+**returns** | `Vnode`                                             |          | A fragment [vnode](vnodes.md#structure)
 
 [How to read signatures](signatures.md)
 
@@ -49,14 +49,14 @@ Argument    | Type                                                | Required | D
 
 `m.fragment()` creates a [fragment vnode](vnodes.md) with attributes. It is meant for advanced use cases involving [keys](keys.md) or [lifecyle methods](lifecycle-methods.md).
 
-A fragment vnode represents a list of DOM elements. If you want a regular element vnode that represents only one DOM element, you should use [`m()`](hyperscript.md) instead.
+A fragment vnode represents a list of DOM elements. If you want a regular element vnode that represents only one DOM element and don't require keyed logic, you should use [`m()`](hyperscript.md) instead.
 
-Normally you can use simple arrays instead to denote a list of nodes:
+Normally you can use simple arrays or splats instead to denote a list of nodes:
 
 ```javascript
 var groupVisible = true
 
-m("ul", [
+m("ul",
 	m("li", "child 1"),
 	m("li", "child 2"),
 	groupVisible ? [
@@ -64,7 +64,7 @@ m("ul", [
 		m("li", "child 3"),
 		m("li", "child 4"),
 	] : null
-])
+)
 ```
 
 However, Javascript arrays cannot be keyed or hold lifecycle methods. One option would be to create a wrapper element to host the key or lifecycle method, but sometimes it is not desirable to have an extra element (for example in complex table structures). In those cases, a fragment vnode can be used instead.

--- a/docs/hyperscript.md
+++ b/docs/hyperscript.md
@@ -40,12 +40,12 @@ You can also [use HTML syntax](https://babeljs.io/repl/#?code=%2F**%20%40jsx%20m
 
 ### Signature
 
-`vnode = m(selector, attributes, children)`
+`vnode = m(selector, attrs, children)`
 
 Argument     | Type                                       | Required | Description
 ------------ | ------------------------------------------ | -------- | ---
 `selector`   | `String|Object`                            | Yes      | A CSS selector or a [component](components.md)
-`attributes` | `Object`                                   | No       | HTML attributes or element properties
+`attrs`      | `Object`                                   | No       | HTML attributes or element properties
 `children`   | `Array<Vnode>|String|Number|Boolean`       | No       | Child [vnodes](vnodes.md#structure). Can be written as [splat arguments](signatures.md#splats)
 **returns**  | `Vnode`                                    |          | A [vnode](vnodes.md#structure)
 
@@ -55,7 +55,7 @@ Argument     | Type                                       | Required | Descripti
 
 ### How it works
 
-Mithril provides a hyperscript function `m()`, which allows expressing any HTML structure using javascript syntax. It accepts a `selector` string (required), an `attributes` object (optional) and a `children` array (optional).
+Mithril provides a hyperscript function `m()`, which allows expressing any HTML structure using javascript syntax. It accepts a `selector` string (required), an `attrs` object (optional) and a `children` array (optional).
 
 ```javascript
 m("div", {id: "box"}, "hello")

--- a/render/fragment.js
+++ b/render/fragment.js
@@ -2,6 +2,23 @@
 
 var Vnode = require("../render/vnode")
 
-module.exports = function(attrs, children) {
+module.exports = function() {
+	var attrs = arguments[0], start = 1, children
+
+	if (attrs == null) {
+		attrs = {}
+	} else if (typeof attrs !== "object" || attrs.tag != null || Array.isArray(attrs)) {
+		attrs = {}
+		start = 1
+	}
+
+	if (arguments.length === start + 1) {
+		children = arguments[start]
+		if (!Array.isArray(children)) children = [children]
+	} else {
+		children = []
+		while (start < arguments.length) children.push(arguments[start++])
+	}
+
 	return Vnode("[", attrs.key, attrs, Vnode.normalizeChildren(children), undefined, undefined)
 }

--- a/render/fragment.js
+++ b/render/fragment.js
@@ -9,7 +9,7 @@ module.exports = function() {
 		attrs = {}
 	} else if (typeof attrs !== "object" || attrs.tag != null || Array.isArray(attrs)) {
 		attrs = {}
-		start = 1
+		start = 0
 	}
 
 	if (arguments.length === start + 1) {

--- a/render/tests/test-fragment.js
+++ b/render/tests/test-fragment.js
@@ -32,4 +32,27 @@ o.spec("fragment", function() {
 
 		o(frag.key).equals(7)
 	})
+	o("attributes are optional", function() {
+		var frag = fragment([])
+		o(frag.tag).equals("[")
+
+		o(Array.isArray(frag.children)).equals(true)
+		o(frag.children.length).equals(0)
+
+		o(frag.attrs).deepEquals({})
+	})
+	o("children are optional", function() {
+		var frag = fragment()
+		o(frag.tag).equals("[")
+
+		o(Array.isArray(frag.children)).equals(true)
+		o(frag.children.length).equals(0)
+	})
+	o("accepts splats", function() {
+		var frag = fragment("A", "B")
+		o(frag.tag).equals("[")
+
+		o(Array.isArray(frag.children)).equals(true)
+		o(frag.children.length).equals(2)
+	})
 })

--- a/render/tests/test-fragment.js
+++ b/render/tests/test-fragment.js
@@ -54,5 +54,7 @@ o.spec("fragment", function() {
 
 		o(Array.isArray(frag.children)).equals(true)
 		o(frag.children.length).equals(2)
+		o(frag.children[0].children).equals("A")
+		o(frag.children[1].children).equals("B")
 	})
 })


### PR DESCRIPTION
`m.fragment`'s signature now replicates the overloading logic of `m` (minus the leading selector).

**Edit(isiahmeadows):** Fixes #2275

**Edit(isiahmeadows):** Closes #2328

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
