### PR TITLE
Set non primitives as properties instead of attribute

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -687,6 +687,7 @@ module.exports = function($window) {
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
 		else if (key === "style") updateStyle(vnode.dom, old, value)
+		else if (typeof value === "object") vnode.dom[key] = value
 		else if (hasPropertyKey(vnode, key, ns)) {
 			if (key === "value") {
 				// Only do the coercion if we're actually going to check the value.
@@ -714,6 +715,7 @@ module.exports = function($window) {
 		if (key === "key" || key === "is" || old == null || isLifecycleMethod(key)) return
 		if (key[0] === "o" && key[1] === "n" && !isLifecycleMethod(key)) updateEvent(vnode, key, undefined)
 		else if (key === "style") updateStyle(vnode.dom, old, null)
+		else if (typeof old === "object") delete vnode.dom[key]
 		else if (
 			hasPropertyKey(vnode, key, ns)
 			&& key !== "className"

--- a/render/render.js
+++ b/render/render.js
@@ -687,7 +687,7 @@ module.exports = function($window) {
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
 		else if (key === "style") updateStyle(vnode.dom, old, value)
-		else if (typeof value === "object") vnode.dom[key] = value
+		else if (typeof value === "object" || typeof value === "function" || typeof value === "symbol") vnode.dom[key] = value
 		else if (hasPropertyKey(vnode, key, ns)) {
 			if (key === "value") {
 				// Only do the coercion if we're actually going to check the value.
@@ -715,7 +715,7 @@ module.exports = function($window) {
 		if (key === "key" || key === "is" || old == null || isLifecycleMethod(key)) return
 		if (key[0] === "o" && key[1] === "n" && !isLifecycleMethod(key)) updateEvent(vnode, key, undefined)
 		else if (key === "style") updateStyle(vnode.dom, old, null)
-		else if (typeof old === "object") delete vnode.dom[key]
+		else if (typeof old === "object" || typeof old === "function" || typeof old === "symbol") delete vnode.dom[key]
 		else if (
 			hasPropertyKey(vnode, key, ns)
 			&& key !== "className"

--- a/render/tests/test-properties.js
+++ b/render/tests/test-properties.js
@@ -1,0 +1,29 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+var domMock = require("../../test-utils/domMock")
+var vdom = require("../../render/render")
+
+o.spec("properties", function() {
+	var $window, root, render
+	o.beforeEach(function() {
+		$window = domMock()
+		root = $window.document.createElement("div")
+		render = vdom($window).render
+	})
+
+	o("adds non primitives as properties", function() {
+		var vnode = {tag: "div", attrs: {
+			array: [1, 2, 3],
+			object: {a: 1, b: 2, c: 3},
+			symbol: Symbol(42),
+			function: function() { }
+		}}
+		render(root, [vnode])
+
+		o(typeof vnode.dom.array).equals("object")
+		o(typeof vnode.dom.object).equals("object")
+		o(typeof vnode.dom.symbol).equals("symbol")
+		o(typeof vnode.dom.function).equals("function")
+	})
+})


### PR DESCRIPTION
To comply with custom-elements and most likely also user expectations any non primitive should be set as a property on the dom element instead of as attributes

## Description
I've added a check to set value as a property on the dom element if the type is not a primitive

## Motivation and Context
Fixes custom-elements compliance (https://github.com/MithrilJS/mithril.js/issues/2220) which should have been added in https://github.com/MithrilJS/mithril.js/pull/2221 , but I couldn't find where.

## How Has This Been Tested?
All existing tests passes, and new tests for non primitives to be set as properties have been added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`