### PR TITLE
Kill ESM exports for now, since they break Webpack users

### DIFF
--- a/ospec/package.json
+++ b/ospec/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.1",
   "description": "Noiseless testing framework",
   "main": "ospec.js",
-  "module": "ospec.mjs",
   "directories": {
     "test": "tests"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Leo Horie",
   "license": "MIT",
   "main": "mithril.js",
-  "module": "mithril.mjs",
   "repository": "MithrilJS/mithril.js",
   "scripts": {
     "dev": "node bundler/cli browser.js -output mithril.js -watch",

--- a/stream/package.json
+++ b/stream/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.0",
   "description": "Streaming data, mithril-style",
   "main": "stream.js",
-  "module": "stream.mjs",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- See: https://github.com/MithrilJS/mithril.js/issues/2336
- See: https://github.com/webpack/webpack/issues/8491
- Note: revert this once the above issue is resolved

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It unbreaks the experience for Webpack users. This is a stopgap solution until the Webpack issue linked above is fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A. It's all package-related.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
