### PR TITLE
Fix typo in examples/editor

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -28,7 +28,7 @@ var Editor = {
 	view: function() {
 		return [
 			m("textarea.input", {
-				oninput: function (e) { state.update(e.traget.value) },
+				oninput: function (e) { state.update(e.target.value) },
 				value: state.text
 			}),
 			m(".preview", m.trust(marked(state.text))),


### PR DESCRIPTION
## Description
Fix a typo which prevented Markdown Editor example from working

## Motivation and Context
The Markdown Editor example linked here https://mithril.js.org/examples.html wasn’t working.

## How Has This Been Tested?
Manually opened mithril.js/examples/editor/index.html in recent Firefox and Chrome browsers. It wasn’t working on either before, but it’s working now, after the fix.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
