### PR TITLE
Fixed scan with skip

### DIFF
--- a/stream/stream.js
+++ b/stream/stream.js
@@ -114,7 +114,7 @@ function merge(streams) {
 function scan(fn, acc, origin) {
 	var stream = origin.map(function(v) {
 		var next = fn(acc, v)
-		acc = next === Stream.SKIP ? acc : next
+		if (next !== Stream.SKIP) acc = next
 		return next
 	})
 	stream(acc)

--- a/stream/stream.js
+++ b/stream/stream.js
@@ -113,8 +113,9 @@ function merge(streams) {
 
 function scan(fn, acc, origin) {
 	var stream = origin.map(function(v) {
-		acc = fn(acc, v)
-		return acc
+		var next = fn(acc, v)
+		acc = next === Stream.SKIP ? acc : next
+		return next
 	})
 	stream(acc)
 	return stream

--- a/stream/tests/test-scan.js
+++ b/stream/tests/test-scan.js
@@ -51,15 +51,17 @@ o.spec("scan", function() {
 		action(7)
 		action("11")
 		action(undefined)
-		action({a: 1})
+	        action({a: 1})
+		action(8) // assures we didn't break the accumulator
 
 		result = child()
 
 		// check we got the expect result
 		o(result[0]).equals(7)
+		o(result[1]).equals(8)
 
 		// check child received minimum # of updates
-		o(count).equals(2)
+		o(count).equals(3)
 	})
 
 })


### PR DESCRIPTION
## Description
Fixes an issue with scan that arose from #2207. The reducer no longer accepted SKIP value as a way of limiting child updates, instead the accumulator value became "SKIP".

For more context see my original change: https://github.com/MithrilJS/mithril.js/pull/1957. The test I added wasn't sufficient to catch breaking change, that is also fixed in this PR! :)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
