### PR TITLE
Fix Stream.end()

### DIFF
--- a/stream/tests/test-scan.js
+++ b/stream/tests/test-scan.js
@@ -51,7 +51,7 @@ o.spec("scan", function() {
 		action(7)
 		action("11")
 		action(undefined)
-	        action({a: 1})
+		action({a: 1})
 		action(8) // assures we didn't break the accumulator
 
 		result = child()

--- a/stream/tests/test-stream.js
+++ b/stream/tests/test-stream.js
@@ -266,6 +266,15 @@ o.spec("stream", function() {
 			o(thrown.constructor === TypeError).equals(false)
 			o(spy.callCount).equals(0)
 		})
+		o("combine callback not called when child stream was ended", function () {
+			var spy = o.spy()
+			var a = Stream(1)
+			var b = Stream(2)
+			var mapped = Stream.combine(spy, [a, b])
+			mapped.end(true)
+			a(11)
+			o(spy.callCount).equals(1)
+		})
 	})
 	o.spec("lift", function() {
 		o("transforms value", function() {
@@ -484,6 +493,12 @@ o.spec("stream", function() {
 
 			o(spy.callCount).equals(1)
 		})
+		o("ended stream works like a container", function() {
+			var stream = Stream(1)
+			stream.end(true)
+			stream(2)
+			o(stream()).equals(2)
+		})
 	})
 	o.spec("toJSON", function() {
 		o("works", function() {
@@ -548,6 +563,14 @@ o.spec("stream", function() {
 			var stream = Stream(undefined)
 
 			o(stream["fantasy-land/map"]).equals(stream.map)
+		})
+		o("mapping function is not invoked after ending", function () {
+			var stream = Stream(undefined)
+			var fn = o.spy()
+			var mapped = stream.map(fn)
+			mapped.end(true)
+			stream(undefined)
+			o(fn.callCount).equals(1)
 		})
 	})
 	o.spec("ap", function() {


### PR DESCRIPTION
As discussed in https://github.com/MithrilJS/mithril.js/issues/2365
Stops calling dependent function and reduces memory leaks.
Also fixes container semants for ended streams.

## Description
Removing dependent function and stream when the child ends. This restores old (correct) behavior. Before, ending child stream would keep it and it's function in a parent and that function would be called.
Also fixed container semantics for ended streams: they will still change their value now.

## Motivation and Context
Maintaining correctness of parent-child relationship and preventing memory leaks for keeping children and their functions.

## How Has This Been Tested?
I've added two new tests (for `map` & `combine`). For other functions semantics shouldn't change, but memory impact may improve (`merge` would be GC'd e.g.). 
I've also added test for stream working as a container in the ended state.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md` (no need to)

I'm not sure that I understood the proposed fix for container semantics but I think mine works too.

There's one open question regarding the end stream (the open obtained by `stream.end`, not "ended stream"). Who ends the end stream? Each stream has a co-dependent `end` stream, event the `end` stream itself. An attempt to close it will continue infinitely. I'm not sure it's needed, I don't think it's mentioned in docs but I wanted to raise this question anyway, as it seems to be related.