### PR TITLE
Suppress counter-intuitive behavior when providing extract function.

### DIFF
--- a/docs/request.md
+++ b/docs/request.md
@@ -84,7 +84,7 @@ A call to `m.request` returns a [promise](promise.md) and triggers a redraw upon
 
 By default, `m.request` assumes the response is in JSON format and parses it into a Javascript object (or array).
 
-If the HTTP response status code indicates an error, the returned Promise will be rejected. Supplying an extract callback will prevent the promise rejection.
+If the HTTP response status code indicates an error, the returned Promise will be rejected.
 
 ---
 

--- a/request/request.js
+++ b/request/request.js
@@ -118,7 +118,6 @@ module.exports = function($window, Promise) {
 						var response = xhr.responseText
 						if (typeof args.extract === "function") {
 							response = args.extract(xhr, args)
-							success = true
 						} else if (typeof args.deserialize === "function") {
 							response = args.deserialize(response)
 						} else {


### PR DESCRIPTION
Providing a custom extract function was preventing the promise rejection, which is counter-intuitive. Propose changing that.