### PR TITLE
Ospec: make throws/notThrows more explicit

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -37,6 +37,7 @@
 - cast className using toString ([#2309](https://github.com/MithrilJS/mithril.js/pull/2309))
 - render: call attrs' hooks first, with express exception of `onbeforeupdate` to allow attrs to block components from even diffing ([#2297](https://github.com/MithrilJS/mithril.js/pull/2297))
 - API: `m.withAttr` removed. ([#2317](https://github.com/MithrilJS/mithril.js/pull/2317))
+- Ospec: `.throws` now explicitly compares constructors, instead of comparing with `instanceof`.
 
 #### News
 

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -269,7 +269,7 @@ else window.o = m()
 			if(typeof b === "string"){
 				return (e.message === b)
 			}else{
-				return (e instanceof b)
+				return (e.constructor === b)
 			}
 		}
 		return false

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -167,8 +167,11 @@ o.spec("ospec", function() {
 			o([{a: 1, b: 2}, {c: 3}]).deepEquals([{a: 1, b: 2}, {c: 3}])
 			o(function(){throw new Error()}).throws(Error)
 			o(function(){"ayy".foo()}).throws(TypeError)
+			o(function(){"ayy".foo()}).notThrows(Error)
 			o(function(){Math.PI.toFixed(Math.pow(10,20))}).throws(RangeError)
+			o(function(){Math.PI.toFixed(Math.pow(10,20))}).notThrows(Error)
 			o(function(){decodeURIComponent("%")}).throws(URIError)
+			o(function(){decodeURIComponent("%")}).notThrows(Error)
 
 			o(function(){"ayy".foo()}).notThrows(SyntaxError)
 			o(function(){throw new Error("foo")}).throws("foo")


### PR DESCRIPTION
## Description
`.throws` now explicitly compares constructors, instead of using `instanceof`.

## Motivation and Context
`.throws` was using `instanceof`, which meant `o().throws(Error)` would evaluate the same as `o().throws(TypeError)`.

## How Has This Been Tested?
Updated Ospec tests.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
