### PR TITLE
Replace confusing example in docs/component.ts

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -574,23 +574,26 @@ For that reason you should avoid recreating components. Instead, consume compone
 ```javascript
 // AVOID
 var ComponentFactory = function(greeting) {
-	// creates a new component on every call
 	return {
 		view: function() {
 			return m("div", greeting)
 		}
 	}
 }
+
 m.render(document.body, m(ComponentFactory("hello")))
 // calling a second time recreates div from scratch rather than doing nothing
 m.render(document.body, m(ComponentFactory("hello")))
 
 // PREFER
-var Component = {
-	view: function(vnode) {
-		return m("div", vnode.attrs.greeting)
+var Component = function(vnode) {
+	return {
+		view: function() {
+			return m("div", vnode.attrs.greeting)
+		}
 	}
 }
+
 m.render(document.body, m(Component, {greeting: "hello"}))
 // calling a second time does not modify DOM
 m.render(document.body, m(Component, {greeting: "hello"}))


### PR DESCRIPTION
Switch example to use closure component.

## Description
In the example here: https://github.com/MithrilJS/mithril.js/blob/next/docs/components.md#define-components-statically-call-them-dynamically

It says (paraphrased): 
Avoid: using a factory function like `m(ComponentFactory("hello"))`
Prefer:  use POJO like `m(Component, { greeting: "hello" })`

## Motivation and Context
I believe the current example causes confusion as it seems at quick glance to disallow closure components. Updating the "prefer" example itself to use a closure component will call out the distinction in usage.

## How Has This Been Tested?
This is a doc change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [n/a] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
