### PR TITLE
standardize cdn links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Mithril supports IE11, Firefox ESR, and the last two versions of Firefox, Edge, 
 ### CDN
 
 ```html
-<script src="https://unpkg.com/mithril"></script>
+<script src="https://unpkg.com/mithril@next/mithril.js"></script>
 <!-- or -->
-<script src="https://cdn.jsdelivr.net/npm/mithril/mithril.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mithril@next/mithril.js"></script>
 ```
 
 ### npm

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Let's create an HTML file to follow along:
 
 ```markup
 <body>
-	<script src="https://unpkg.com/mithril/mithril.js"></script>
+	<script src="https://unpkg.com/mithril@next/mithril.js"></script>
 	<script>
 	var root = document.body
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@
 If you're new to JavaScript or just want a very simple setup to get your feet wet, you can get Mithril from a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network):
 
 ```markup
-<script src="https://unpkg.com/mithril/mithril.js"></script>
+<script src="https://unpkg.com/mithril@next/mithril.js"></script>
 ```
 
 ---
@@ -247,7 +247,7 @@ If you don't have the ability to run a bundler script due to company security po
     <title>Hello world</title>
   </head>
   <body>
-    <script src="https://cdn.rawgit.com/MithrilJS/mithril.js/master/mithril.js"></script>
+    <script src="https://unpkg.com/mithril@next/mithril.js"></script>
     <script src="index.js"></script>
   </body>
 </html>

--- a/docs/stream.md
+++ b/docs/stream.md
@@ -46,7 +46,7 @@ var Stream = require("mithril/stream")
 You can also download the module directly if your environment does not support a bundling toolchain:
 
 ```markup
-<script src="https://unpkg.com/mithril@next/stream"></script>
+<script src="https://unpkg.com/mithril@next/stream/stream.js"></script>
 ```
 
 When loaded directly with a `<script>` tag (rather than required), the stream library will be exposed as `window.m.stream`. If `window.m` is already defined (e.g. because you also use the main Mithril script), it will attach itself to the existing object. Otherwise it creates a new `window.m`. If you want to use streams in conjunction with Mithril as raw script tags, you should include Mithril in your page before `mithril/stream`, because `mithril` will otherwise overwrite the `window.m` object defined by `mithril/stream`. This is not a concern when the libraries are consumed as CommonJS modules (using `require(...)`).


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- consistently use `@next` and explicit path in unpkg links
- replaced old rawgit link with unpkg link
- updated jsdelivr link on readme to use `@next`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix broken unpkg link in stream docs, and standardize the rest.
[Motivated by this gitter discussion](https://gitter.im/mithriljs/mithril.js?at=5cebd81aef853135c830235a).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
hand tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
