### PR TITLE
Fix for #2423. request.data => body, params is used for querystrings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -79,7 +79,7 @@ m("a[href='/Home']", {oncreate: m.route.link}, "Go to home page")
 m.request({
 	method: "PUT",
 	url: "/api/v1/users/:id",
-	data: {id: 1, name: "test"}
+	params: {id: 1, name: "test"}
 })
 .then(function(result) {
 	console.log(result)
@@ -93,7 +93,7 @@ m.request({
 ```javascript
 m.jsonp({
 	url: "/api/v1/users/:id",
-	data: {id: 1},
+	params: {id: 1},
 	callbackKey: "callback",
 })
 .then(function(result) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -255,7 +255,7 @@ Basically, XHR is just a way to talk to a server.
 
 Let's change our click counter to make it save data on a server. For the server, we'll use [REM](http://rem-rest-api.herokuapp.com), a mock REST API designed for toy apps like this tutorial.
 
-First we create a function that calls `m.request`. The `url` specifies an endpoint that represents a resource, the `method` specifies the type of action we're taking (typically the `PUT` method [upserts](https://en.wiktionary.org/wiki/upsert)), `data` is the payload that we're sending to the endpoint and `withCredentials` means to enable cookies (a requirement for the REM API to work)
+First we create a function that calls `m.request`. The `url` specifies an endpoint that represents a resource, the `method` specifies the type of action we're taking (typically the `PUT` method [upserts](https://en.wiktionary.org/wiki/upsert)), `body` is the payload that we're sending to the endpoint and `withCredentials` means to enable cookies (a requirement for the REM API to work)
 
 ```javascript
 var count = 0
@@ -263,7 +263,7 @@ var increment = function() {
 	m.request({
 		method: "PUT",
 		url: "//rem-rest-api.herokuapp.com/api/tutorial/1",
-		data: {count: count + 1},
+		body: {count: count + 1},
 		withCredentials: true,
 	})
 	.then(function(data) {

--- a/docs/jsonp.md
+++ b/docs/jsonp.md
@@ -14,7 +14,7 @@ Makes JSON-P requests. Typically, it's useful to interact with servers that allo
 ```javascript
 m.jsonp({
 	url: "/api/v1/users/:id",
-	data: {id: 1},
+	params: {id: 1},
 	callbackKey: "callback",
 })
 .then(function(result) {
@@ -31,8 +31,8 @@ m.jsonp({
 Argument               | Type                              | Required | Description
 ---------------------- | --------------------------------- | -------- | ---
 `options`              | `Object`                          | Yes      | The request options to pass.
-`options.url`          | `String`                          | Yes      | The [path name](paths.md) to send the request to, optionally interpolated with values from `options.data`.
-`options.data`         | `any`                             | No       | The data to be interpolated into the URL and serialized into the querystring.
+`options.url`          | `String`                          | Yes      | The [path name](paths.md) to send the request to, optionally interpolated with values from `options.params`.
+`options.params`       | `Object`                          | No       | The data to be interpolated into the URL and serialized into the querystring.
 `options.type`         | `any = Function(any)`             | No       | A constructor to be applied to each object in the response. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).
 `options.callbackName` | `String`                          | No       | The name of the function that will be called as the callback. Defaults to a randomized string (e.g. `_mithril_6888197422121285_0({a: 1})`
 `options.callbackKey`  | `String`                          | No       | The name of the querystring parameter name that specifies the callback name. Defaults to `callback` (e.g. `/someapi?callback=_mithril_6888197422121285_0`)

--- a/docs/promise.md
+++ b/docs/promise.md
@@ -204,7 +204,7 @@ In the refactored version, it's trivial to test whether `getFirstTen` has any of
 Promises absorb other promises. Basically, this means you can never receive a Promise as an argument to `onFulfilled` or `onRejected` callbacks for `then` and `catch` methods. This feature allows us to flatten nested promises to make code more manageable.
 
 ```javascript
-function searchUsers(q) {return m.request("/api/v1/users/search", {data: {q: q}})}
+function searchUsers(q) {return m.request("/api/v1/users/search", {params: {q: q}})}
 function getUserProjects(id) {return m.request("/api/v1/users/" + id + "/projects")}
 
 // AVOID: pyramid of doom

--- a/docs/request.md
+++ b/docs/request.md
@@ -25,12 +25,12 @@ Makes XHR (aka AJAX) requests, and returns a [promise](promise.md)
 
 ```javascript
 m.request({
-  method: "PUT",
-  url: "/api/v1/users/:id",
-  params: {id: 1, name: "test"}
+	method: "PUT",
+	url: "/api/v1/users/:id",
+	params: {id: 1, name: "test"}
 })
 .then(function(result) {
-  console.log(result)
+	console.log(result)
 })
 ```
 
@@ -82,11 +82,11 @@ The `m.request` utility is a thin wrapper around [`XMLHttpRequest`](https://deve
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/api/v1/users",
+	method: "GET",
+	url: "/api/v1/users",
 })
 .then(function(users) {
-  console.log(users)
+	console.log(users)
 })
 ```
 
@@ -104,31 +104,31 @@ Here's an illustrative example of a component that uses `m.request` to retrieve 
 
 ```javascript
 var Data = {
-  todos: {
-    list: [],
-    fetch: function() {
-      m.request({
-        method: "GET",
-        url: "/api/v1/todos",
-      })
-      .then(function(items) {
-        Data.todos.list = items
-      })
-    }
-  }
+	todos: {
+		list: [],
+		fetch: function() {
+			m.request({
+				method: "GET",
+				url: "/api/v1/todos",
+			})
+			.then(function(items) {
+				Data.todos.list = items
+			})
+		}
+	}
 }
 
 var Todos = {
-  oninit: Data.todos.fetch,
-  view: function(vnode) {
-    return Data.todos.list.map(function(item) {
-      return m("div", item.title)
-    })
-  }
+	oninit: Data.todos.fetch,
+	view: function(vnode) {
+		return Data.todos.list.map(function(item) {
+			return m("div", item.title)
+		})
+	}
 }
 
 m.route(document.body, "/", {
-  "/": Todos
+	"/": Todos
 })
 ```
 
@@ -156,39 +156,39 @@ Here's an expanded version of the example above that implements a loading indica
 
 ```javascript
 var Data = {
-  todos: {
-    list: null,
-    error: "",
-    fetch: function() {
-      m.request({
-        method: "GET",
-        url: "/api/v1/todos",
-      })
-      .then(function(items) {
-        Data.todos.list = items
-      })
-      .catch(function(e) {
-        Data.todos.error = e.message
-      })
-    }
-  }
+	todos: {
+		list: null,
+		error: "",
+		fetch: function() {
+			m.request({
+				method: "GET",
+				url: "/api/v1/todos",
+			})
+			.then(function(items) {
+				Data.todos.list = items
+			})
+			.catch(function(e) {
+				Data.todos.error = e.message
+			})
+		}
+	}
 }
 
 var Todos = {
-  oninit: Data.todos.fetch,
-  view: function(vnode) {
-    return Data.todos.error ? [
-      m(".error", Data.todos.error)
-    ] : Data.todos.list ? [
-      Data.todos.list.map(function(item) {
-        return m("div", item.title)
-      })
-    ] : m(".loading-icon")
-  }
+	oninit: Data.todos.fetch,
+	view: function(vnode) {
+		return Data.todos.error ? [
+			m(".error", Data.todos.error)
+		] : Data.todos.list ? [
+			Data.todos.list.map(function(item) {
+				return m("div", item.title)
+			})
+		] : m(".loading-icon")
+	}
 }
 
 m.route(document.body, "/", {
-  "/": Todos
+	"/": Todos
 })
 ```
 
@@ -202,11 +202,11 @@ Request URLs may contain interpolations:
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/api/v1/users/:id",
-  params: {id: 123},
+	method: "GET",
+	url: "/api/v1/users/:id",
+	params: {id: 123},
 }).then(function(user) {
-  console.log(user.id) // logs 123
+	console.log(user.id) // logs 123
 })
 ```
 
@@ -216,9 +216,9 @@ Interpolations are ignored if no matching data exists in the `params` property.
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/api/v1/users/foo:bar",
-  params: {id: 123},
+	method: "GET",
+	url: "/api/v1/users/foo:bar",
+	params: {id: 123},
 })
 ```
 
@@ -235,18 +235,18 @@ Sometimes, it is desirable to abort a request. For example, in an autocompleter/
 ```javascript
 var searchXHR = null
 function search() {
-  abortPreviousSearch()
+	abortPreviousSearch()
 
-  m.request({
-    method: "GET",
-    url: "/api/v1/users",
-    params: {search: query},
-    config: function(xhr) {searchXHR = xhr}
-  })
+	m.request({
+		method: "GET",
+		url: "/api/v1/users",
+		params: {search: query},
+		config: function(xhr) {searchXHR = xhr}
+	})
 }
 function abortPreviousSearch() {
-  if (searchXHR !== null) searchXHR.abort()
-  searchXHR = null
+	if (searchXHR !== null) searchXHR.abort()
+	searchXHR = null
 }
 ```
 
@@ -258,11 +258,11 @@ To upload files, first you need to get a reference to a [`File`](https://develop
 
 ```javascript
 m.render(document.body, [
-  m("input[type=file]", {onchange: upload})
+	m("input[type=file]", {onchange: upload})
 ])
 
 function upload(e) {
-  var file = e.target.files[0]
+	var file = e.target.files[0]
 }
 ```
 
@@ -272,10 +272,10 @@ Next, you need to create a [`FormData`](https://developer.mozilla.org/en/docs/We
 
 ```javascript
 function upload(e) {
-  var file = e.target.files[0]
+	var file = e.target.files[0]
 
-  var body = new FormData()
-  body.append("myfile", file)
+	var body = new FormData()
+	body.append("myfile", file)
 }
 ```
 
@@ -283,16 +283,16 @@ Next, you need to call `m.request` and set `options.method` to an HTTP method th
 
 ```javascript
 function upload(e) {
-  var file = e.target.files[0]
+	var file = e.target.files[0]
 
-  var body = new FormData()
-  body.append("myfile", file)
+	var body = new FormData()
+	body.append("myfile", file)
 
-  m.request({
-    method: "POST",
-    url: "/api/v1/upload",
-    body: body,
-  })
+	m.request({
+		method: "POST",
+		url: "/api/v1/upload",
+		body: body,
+	})
 }
 ```
 
@@ -306,22 +306,22 @@ To upload multiple files, simply append them all to the `FormData` object. When 
 
 ```javascript
 m.render(document.body, [
-  m("input[type=file][multiple]", {onchange: upload})
+	m("input[type=file][multiple]", {onchange: upload})
 ])
 
 function upload(e) {
-  var files = e.target.files
+	var files = e.target.files
 
-  var body = new FormData()
-  for (var i = 0; i < files.length; i++) {
-    body.append("file" + i, files[i])
-  }
+	var body = new FormData()
+	for (var i = 0; i < files.length; i++) {
+		body.append("file" + i, files[i])
+	}
 
-  m.request({
-    method: "POST",
-    url: "/api/v1/upload",
-    body: body,
-  })
+	m.request({
+		method: "POST",
+		url: "/api/v1/upload",
+		body: body,
+	})
 }
 ```
 
@@ -337,32 +337,32 @@ Sometimes, if a request is inherently slow (e.g. a large file upload), it's desi
 var progress = 0
 
 m.mount(document.body, {
-  view: function() {
-    return [
-      m("input[type=file]", {onchange: upload}),
-      progress + "% completed"
-    ]
-  }
+	view: function() {
+		return [
+			m("input[type=file]", {onchange: upload}),
+			progress + "% completed"
+		]
+	}
 })
 
 function upload(e) {
-  var file = e.target.files[0]
+	var file = e.target.files[0]
 
-  var body = new FormData()
-  body.append("myfile", file)
+	var body = new FormData()
+	body.append("myfile", file)
 
-  m.request({
-    method: "POST",
-    url: "/api/v1/upload",
-    body: body,
-    config: function(xhr) {
-      xhr.upload.addEventListener("progress", function(e) {
-        progress = e.loaded / e.total
+	m.request({
+		method: "POST",
+		url: "/api/v1/upload",
+		body: body,
+		config: function(xhr) {
+			xhr.upload.addEventListener("progress", function(e) {
+				progress = e.loaded / e.total
 
-        m.redraw() // tell Mithril that data changed and a re-render is needed
-      })
-    }
-  })
+				m.redraw() // tell Mithril that data changed and a re-render is needed
+			})
+		}
+	})
 }
 ```
 
@@ -378,16 +378,16 @@ You can pass a constructor as the `options.type` parameter and Mithril will inst
 
 ```javascript
 function User(data) {
-  this.name = data.firstName + " " + data.lastName
+	this.name = data.firstName + " " + data.lastName
 }
 
 m.request({
-  method: "GET",
-  url: "/api/v1/users",
-  type: User
+	method: "GET",
+	url: "/api/v1/users",
+	type: User
 })
 .then(function(users) {
-  console.log(users[0].name) // logs a name
+	console.log(users[0].name) // logs a name
 })
 ```
 
@@ -401,12 +401,12 @@ Sometimes a server endpoint does not return a JSON response: for example, you ma
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/files/icon.svg",
-  deserialize: function(value) {return value}
+	method: "GET",
+	url: "/files/icon.svg",
+	deserialize: function(value) {return value}
 })
 .then(function(svg) {
-  m.render(document.body, m.trust(svg))
+	m.render(document.body, m.trust(svg))
 })
 ```
 
@@ -416,19 +416,19 @@ Of course, a `deserialize` function may be more elaborate:
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/files/data.csv",
-  deserialize: parseCSV
+	method: "GET",
+	url: "/files/data.csv",
+	deserialize: parseCSV
 })
 .then(function(data) {
-  console.log(data)
+	console.log(data)
 })
 
 function parseCSV(data) {
-  // naive implementation for the sake of keeping example simple
-  return data.split("\n").map(function(row) {
-    return row.split(",")
-  })
+	// naive implementation for the sake of keeping example simple
+	return data.split("\n").map(function(row) {
+		return row.split(",")
+	})
 }
 ```
 
@@ -438,13 +438,13 @@ Custom headers may also be helpful in this regard. For example, if you're reques
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/files/image.svg",
-  headers: {
-    "Content-Type": "image/svg+xml; charset=utf-8",
-    "Accept": "image/svg, text/*"
-  },
-  deserialize: function(value) {return value}
+	method: "GET",
+	url: "/files/image.svg",
+	headers: {
+		"Content-Type": "image/svg+xml; charset=utf-8",
+		"Accept": "image/svg, text/*"
+	},
+	deserialize: function(value) {return value}
 })
 ```
 
@@ -457,12 +457,12 @@ By default Mithril attempts to parse `xhr.responseText` as JSON and returns the 
 
 ```javascript
 m.request({
-  method: "GET",
-  url: "/api/v1/users",
-  extract: function(xhr) {return {status: xhr.status, body: xhr.responseText}}
+	method: "GET",
+	url: "/api/v1/users",
+	extract: function(xhr) {return {status: xhr.status, body: xhr.responseText}}
 })
 .then(function(response) {
-  console.log(response.status, response.body)
+	console.log(response.status, response.body)
 })
 ```
 
@@ -524,6 +524,6 @@ console.log("list of users:", users)
 
 // PREFER
 m.request("/api/v1/users").then(function(users) {
-  console.log("list of users:", users)
+	console.log("list of users:", users)
 })
 ```

--- a/docs/request.md
+++ b/docs/request.md
@@ -497,7 +497,7 @@ Mithril's `m.request` uses `XMLHttpRequest` instead of `fetch()` for a number of
 
 Currently, due to lack of browser support, `fetch()` typically requires a [polyfill](https://github.com/github/fetch), which is over 11kb uncompressed - nearly three times larger than Mithril's XHR module.
 
-Despite being much smaller, Mithril's XHR module supports many important and not-so-trivial-to-implement features like [URL interpolation](#dynamic-urls), querystring serialization and [JSON-P requests](jsonp.md), in addition to its ability to integrate seamlessly to Mithril's auto-redrawing subsystem. The `fetch` polyfill does not support any of those, and requires extra libraries and boilerplates to achieve the same level of functionality.
+Despite being much smaller, Mithril's XHR module supports many important and not-so-trivial-to-implement features like [URL interpolation](#dynamic-urls), querystring serialization and [JSON-P requests](jsonp.md), in addition to its ability to integrate seamlessly to Mithril's autoredrawing subsystem. The `fetch` polyfill does not support any of those, and requires extra libraries and boilerplates to achieve the same level of functionality.
 
 In addition, Mithril's XHR module is optimized for JSON-based endpoints and makes that most common case appropriately terse - i.e. `m.request(url)` - whereas `fetch` requires an additional explicit step to parse the response data as JSON: `fetch(url).then(function(response) {return response.json()})`
 

--- a/docs/request.md
+++ b/docs/request.md
@@ -27,7 +27,7 @@ Makes XHR (aka AJAX) requests, and returns a [promise](promise.md)
 m.request({
   method: "PUT",
   url: "/api/v1/users/:id",
-  body: {id: 1, name: "test"}
+  params: {id: 1, name: "test"}
 })
 .then(function(result) {
   console.log(result)
@@ -45,8 +45,8 @@ Argument                  | Type                              | Required | Descr
 `options`                 | `Object`                          | Yes      | The request options to pass.
 `options.method`          | `String`                          | No       | The HTTP method to use. This value should be one of the following: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD` or `OPTIONS`. Defaults to `GET`.
 `options.url`             | `String`                          | Yes      | The [path name](paths.md) to send the request to, optionally interpolated with values from `options.params`.
-`options.params`            | `any`                           | No       | The data to be interpolated into the URL and serialized into the querystring (for GET requests).
-`options.body`            | `any`                             | No       | The data to be serialized into the body (for other types of requests).
+`options.params`            | `Object`                        | No       | The data to be interpolated into the URL and/or serialized into the query string.
+`options.body`            | `Object`                          | No       | The data to be serialized into the body (for other types of requests).
 `options.async`           | `Boolean`                         | No       | Whether the request should be asynchronous. Defaults to `true`.
 `options.user`            | `String`                          | No       | A username for HTTP authorization. Defaults to `undefined`.
 `options.password`        | `String`                          | No       | A password for HTTP authorization. Defaults to `undefined`. This option is provided for `XMLHttpRequest` compatibility, but you should avoid using it because it sends the password in plain text over the network.
@@ -59,7 +59,6 @@ Argument                  | Type                              | Required | Descr
 `options.serialize`       | `string = Function(any)`          | No       | A serialization method to be applied to `body`. Defaults to `JSON.stringify`, or if `options.body` is an instance of [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData), defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function) (i.e. `function(value) {return value}`).
 `options.deserialize`     | `any = Function(any)`          | No       | A deserialization method to be applied to the `xhr.response` or normalized `xhr.responseText`. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function). If `extract` is defined, `deserialize` will be skipped.
 `options.extract`         | `any = Function(xhr, options)`    | No       | A hook to specify how the XMLHttpRequest response should be read. Useful for processing response data, reading headers and cookies. By default this is a function that returns `options.deserialize(parsedResponse)`, throwing an exception when the server response status code indicates an error or when the response is syntactically invalid. If a custom `extract` callback is provided, the `xhr` parameter is the XMLHttpRequest instance used for the request, and `options` is the object that was passed to the `m.request` call. Additionally, `deserialize` will be skipped and the value returned from the extract callback will be left as-is when the promise resolves.
-`options.useBody`         | `Boolean`                         | No       | Force the use of the HTTP body section for `body` in `GET` requests when set to `true`, or the use of querystring for other HTTP methods when set to `false`. Defaults to `false` for `GET` requests and `true` for other methods.
 `options.background`      | `Boolean`                         | No       | If `false`, redraws mounted components upon completion of the request. If `true`, it does not. Defaults to `false`.
 **returns**               | `Promise`                         |          | A promise that resolves to the response data, after it has been piped through the `extract`, `deserialize` and `type` methods
 
@@ -211,7 +210,7 @@ m.request({
 })
 ```
 
-In the code above, `:id` is populated with the data from the `{id: 123}` object, and the request becomes `GET /api/v1/users/123`.
+In the code above, `:id` is populated with the data from the `params` object, and the request becomes `GET /api/v1/users/123`.
 
 Interpolations are ignored if no matching data exists in the `params` property.
 
@@ -223,7 +222,7 @@ m.request({
 })
 ```
 
-In the code above, the request becomes `GET /api/v1/users/foo:bar`
+In the code above, the request becomes `GET /api/v1/users/foo:bar?id=123`
 
 ---
 
@@ -275,8 +274,8 @@ Next, you need to create a [`FormData`](https://developer.mozilla.org/en/docs/We
 function upload(e) {
   var file = e.target.files[0]
 
-  var data = new FormData()
-  data.append("myfile", file)
+  var body = new FormData()
+  body.append("myfile", file)
 }
 ```
 
@@ -286,13 +285,13 @@ Next, you need to call `m.request` and set `options.method` to an HTTP method th
 function upload(e) {
   var file = e.target.files[0]
 
-  var data = new FormData()
-  data.append("myfile", file)
+  var body = new FormData()
+  body.append("myfile", file)
 
   m.request({
     method: "POST",
     url: "/api/v1/upload",
-    body: data,
+    body: body,
   })
 }
 ```
@@ -313,15 +312,15 @@ m.render(document.body, [
 function upload(e) {
   var files = e.target.files
 
-  var data = new FormData()
+  var body = new FormData()
   for (var i = 0; i < files.length; i++) {
-    data.append("file" + i, files[i])
+    body.append("file" + i, files[i])
   }
 
   m.request({
     method: "POST",
     url: "/api/v1/upload",
-    body: data,
+    body: body,
   })
 }
 ```
@@ -349,13 +348,13 @@ m.mount(document.body, {
 function upload(e) {
   var file = e.target.files[0]
 
-  var data = new FormData()
-  data.append("myfile", file)
+  var body = new FormData()
+  body.append("myfile", file)
 
   m.request({
     method: "POST",
     url: "/api/v1/upload",
-    body: data,
+    body: body,
     config: function(xhr) {
       xhr.upload.addEventListener("progress", function(e) {
         progress = e.loaded / e.total

--- a/docs/request.md
+++ b/docs/request.md
@@ -25,12 +25,12 @@ Makes XHR (aka AJAX) requests, and returns a [promise](promise.md)
 
 ```javascript
 m.request({
-	method: "PUT",
-	url: "/api/v1/users/:id",
-	data: {id: 1, name: "test"}
+  method: "PUT",
+  url: "/api/v1/users/:id",
+  body: {id: 1, name: "test"}
 })
 .then(function(result) {
-	console.log(result)
+  console.log(result)
 })
 ```
 
@@ -44,8 +44,9 @@ Argument                  | Type                              | Required | Descr
 ------------------------- | --------------------------------- | -------- | ---
 `options`                 | `Object`                          | Yes      | The request options to pass.
 `options.method`          | `String`                          | No       | The HTTP method to use. This value should be one of the following: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD` or `OPTIONS`. Defaults to `GET`.
-`options.url`             | `String`                          | Yes      | The [path name](paths.md) to send the request to, optionally interpolated with values from `options.data`.
-`options.data`            | `any`                             | No       | The data to be interpolated into the URL and serialized into the querystring (for GET requests) or body (for other types of requests).
+`options.url`             | `String`                          | Yes      | The [path name](paths.md) to send the request to, optionally interpolated with values from `options.params`.
+`options.params`            | `any`                           | No       | The data to be interpolated into the URL and serialized into the querystring (for GET requests).
+`options.body`            | `any`                             | No       | The data to be serialized into the body (for other types of requests).
 `options.async`           | `Boolean`                         | No       | Whether the request should be asynchronous. Defaults to `true`.
 `options.user`            | `String`                          | No       | A username for HTTP authorization. Defaults to `undefined`.
 `options.password`        | `String`                          | No       | A password for HTTP authorization. Defaults to `undefined`. This option is provided for `XMLHttpRequest` compatibility, but you should avoid using it because it sends the password in plain text over the network.
@@ -55,10 +56,10 @@ Argument                  | Type                              | Required | Descr
 `options.config`          | `xhr = Function(xhr)`             | No       | Exposes the underlying XMLHttpRequest object for low-level configuration. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).
 `options.headers`         | `Object`                          | No       | Headers to append to the request before sending it (applied right before `options.config`).
 `options.type`            | `any = Function(any)`             | No       | A constructor to be applied to each object in the response. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function).
-`options.serialize`       | `string = Function(any)`          | No       | A serialization method to be applied to `data`. Defaults to `JSON.stringify`, or if `options.data` is an instance of [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData), defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function) (i.e. `function(value) {return value}`).
+`options.serialize`       | `string = Function(any)`          | No       | A serialization method to be applied to `body`. Defaults to `JSON.stringify`, or if `options.body` is an instance of [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData), defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function) (i.e. `function(value) {return value}`).
 `options.deserialize`     | `any = Function(any)`          | No       | A deserialization method to be applied to the `xhr.response` or normalized `xhr.responseText`. Defaults to the [identity function](https://en.wikipedia.org/wiki/Identity_function). If `extract` is defined, `deserialize` will be skipped.
 `options.extract`         | `any = Function(xhr, options)`    | No       | A hook to specify how the XMLHttpRequest response should be read. Useful for processing response data, reading headers and cookies. By default this is a function that returns `options.deserialize(parsedResponse)`, throwing an exception when the server response status code indicates an error or when the response is syntactically invalid. If a custom `extract` callback is provided, the `xhr` parameter is the XMLHttpRequest instance used for the request, and `options` is the object that was passed to the `m.request` call. Additionally, `deserialize` will be skipped and the value returned from the extract callback will be left as-is when the promise resolves.
-`options.useBody`         | `Boolean`                         | No       | Force the use of the HTTP body section for `data` in `GET` requests when set to `true`, or the use of querystring for other HTTP methods when set to `false`. Defaults to `false` for `GET` requests and `true` for other methods.
+`options.useBody`         | `Boolean`                         | No       | Force the use of the HTTP body section for `body` in `GET` requests when set to `true`, or the use of querystring for other HTTP methods when set to `false`. Defaults to `false` for `GET` requests and `true` for other methods.
 `options.background`      | `Boolean`                         | No       | If `false`, redraws mounted components upon completion of the request. If `true`, it does not. Defaults to `false`.
 **returns**               | `Promise`                         |          | A promise that resolves to the response data, after it has been piped through the `extract`, `deserialize` and `type` methods
 
@@ -82,11 +83,11 @@ The `m.request` utility is a thin wrapper around [`XMLHttpRequest`](https://deve
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/api/v1/users",
+  method: "GET",
+  url: "/api/v1/users",
 })
 .then(function(users) {
-	console.log(users)
+  console.log(users)
 })
 ```
 
@@ -104,37 +105,37 @@ Here's an illustrative example of a component that uses `m.request` to retrieve 
 
 ```javascript
 var Data = {
-	todos: {
-		list: [],
-		fetch: function() {
-			m.request({
-				method: "GET",
-				url: "/api/v1/todos",
-			})
-			.then(function(items) {
-				Data.todos.list = items
-			})
-		}
-	}
+  todos: {
+    list: [],
+    fetch: function() {
+      m.request({
+        method: "GET",
+        url: "/api/v1/todos",
+      })
+      .then(function(items) {
+        Data.todos.list = items
+      })
+    }
+  }
 }
 
 var Todos = {
-	oninit: Data.todos.fetch,
-	view: function(vnode) {
-		return Data.todos.list.map(function(item) {
-			return m("div", item.title)
-		})
-	}
+  oninit: Data.todos.fetch,
+  view: function(vnode) {
+    return Data.todos.list.map(function(item) {
+      return m("div", item.title)
+    })
+  }
 }
 
 m.route(document.body, "/", {
-	"/": Todos
+  "/": Todos
 })
 ```
 
 Let's assume making a request to the server URL `/api/items` returns an array of objects in JSON format.
 
-When `m.route` is called at the bottom, the `Todos` component is initialized. `oninit` is called, which calls `m.request`. This retrieves an array of objects from the server asynchronously. "Asynchronously" means that JavaScript continues running other code while it waits for the response from server. In this case, it means `fetch` returns, and the component is rendered using the original empty array as `Data.todos.list`. Once the request to the server completes, the array of objects `items` is assigned to `Data.todos.list` and the component is rendered again, yielding a list of `<div>`s containing the titles of each todo.
+When `m.route` is called at the bottom, the `Todos` component is initialized. `oninit` is called, which calls `m.request`. This retrieves an array of objects from the server asynchronously. "Asynchronously" means that JavaScript continues running other code while it waits for the response from server. In this case, it means `fetch` returns, and the component is rendered using the original empty array as `Data.todos.list`. Once the request to the server completes, the array of objects `items` is assigned to `Data.todos.list` and the component is rendered again, yielding a list of `<div>`s containing the titles of each `todo`.
 
 ---
 
@@ -156,39 +157,39 @@ Here's an expanded version of the example above that implements a loading indica
 
 ```javascript
 var Data = {
-	todos: {
-		list: null,
-		error: "",
-		fetch: function() {
-			m.request({
-				method: "GET",
-				url: "/api/v1/todos",
-			})
-			.then(function(items) {
-				Data.todos.list = items
-			})
-			.catch(function(e) {
-				Data.todos.error = e.message
-			})
-		}
-	}
+  todos: {
+    list: null,
+    error: "",
+    fetch: function() {
+      m.request({
+        method: "GET",
+        url: "/api/v1/todos",
+      })
+      .then(function(items) {
+        Data.todos.list = items
+      })
+      .catch(function(e) {
+        Data.todos.error = e.message
+      })
+    }
+  }
 }
 
 var Todos = {
-	oninit: Data.todos.fetch,
-	view: function(vnode) {
-		return Data.todos.error ? [
-			m(".error", Data.todos.error)
-		] : Data.todos.list ? [
-			Data.todos.list.map(function(item) {
-				return m("div", item.title)
-			})
-		] : m(".loading-icon")
-	}
+  oninit: Data.todos.fetch,
+  view: function(vnode) {
+    return Data.todos.error ? [
+      m(".error", Data.todos.error)
+    ] : Data.todos.list ? [
+      Data.todos.list.map(function(item) {
+        return m("div", item.title)
+      })
+    ] : m(".loading-icon")
+  }
 }
 
 m.route(document.body, "/", {
-	"/": Todos
+  "/": Todos
 })
 ```
 
@@ -202,23 +203,23 @@ Request URLs may contain interpolations:
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/api/v1/users/:id",
-	data: {id: 123},
+  method: "GET",
+  url: "/api/v1/users/:id",
+  params: {id: 123},
 }).then(function(user) {
-	console.log(user.id) // logs 123
+  console.log(user.id) // logs 123
 })
 ```
 
 In the code above, `:id` is populated with the data from the `{id: 123}` object, and the request becomes `GET /api/v1/users/123`.
 
-Interpolations are ignored if no matching data exists in the `data` property.
+Interpolations are ignored if no matching data exists in the `params` property.
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/api/v1/users/foo:bar",
-	data: {id: 123},
+  method: "GET",
+  url: "/api/v1/users/foo:bar",
+  params: {id: 123},
 })
 ```
 
@@ -228,25 +229,25 @@ In the code above, the request becomes `GET /api/v1/users/foo:bar`
 
 ### Aborting requests
 
-Sometimes, it is desirable to abort a request. For example, in an autocompleter/typeahead widget, you want to ensure that only the last request completes, because typically autocompleters fire several requests as the user types  and HTTP requests may complete out of order due to the unpredictable nature of networks. If another request finishes after the last fired request, the widget would display less relevant (or potentially wrong) data than if the last fired request finished last.
+Sometimes, it is desirable to abort a request. For example, in an autocompleter/typeahead widget, you want to ensure that only the last request completes, because typically autocompleters fire several requests as the user types and HTTP requests may complete out of order due to the unpredictable nature of networks. If another request finishes after the last fired request, the widget would display less relevant (or potentially wrong) data than if the last fired request finished last.
 
 `m.request()` exposes its underlying `XMLHttpRequest` object via the `options.config` parameter, which allows you to save a reference to that object and call its `abort` method when required:
 
 ```javascript
 var searchXHR = null
 function search() {
-	abortPreviousSearch()
+  abortPreviousSearch()
 
-	m.request({
-		method: "GET",
-		url: "/api/v1/users",
-		data: {search: query},
-		config: function(xhr) {searchXHR = xhr}
-	})
+  m.request({
+    method: "GET",
+    url: "/api/v1/users",
+    params: {search: query},
+    config: function(xhr) {searchXHR = xhr}
+  })
 }
 function abortPreviousSearch() {
-	if (searchXHR !== null) searchXHR.abort()
-	searchXHR = null
+  if (searchXHR !== null) searchXHR.abort()
+  searchXHR = null
 }
 ```
 
@@ -258,11 +259,11 @@ To upload files, first you need to get a reference to a [`File`](https://develop
 
 ```javascript
 m.render(document.body, [
-	m("input[type=file]", {onchange: upload})
+  m("input[type=file]", {onchange: upload})
 ])
 
 function upload(e) {
-	var file = e.target.files[0]
+  var file = e.target.files[0]
 }
 ```
 
@@ -272,27 +273,27 @@ Next, you need to create a [`FormData`](https://developer.mozilla.org/en/docs/We
 
 ```javascript
 function upload(e) {
-	var file = e.target.files[0]
+  var file = e.target.files[0]
 
-	var data = new FormData()
-	data.append("myfile", file)
+  var data = new FormData()
+  data.append("myfile", file)
 }
 ```
 
-Next, you need to call `m.request` and set `options.method` to an HTTP method that uses body (e.g. `POST`, `PUT`, `PATCH`) and use the `FormData` object as `options.data`.
+Next, you need to call `m.request` and set `options.method` to an HTTP method that uses body (e.g. `POST`, `PUT`, `PATCH`) and use the `FormData` object as `options.body`.
 
 ```javascript
 function upload(e) {
-	var file = e.target.files[0]
+  var file = e.target.files[0]
 
-	var data = new FormData()
-	data.append("myfile", file)
+  var data = new FormData()
+  data.append("myfile", file)
 
-	m.request({
-		method: "POST",
-		url: "/api/v1/upload",
-		data: data,
-	})
+  m.request({
+    method: "POST",
+    url: "/api/v1/upload",
+    body: data,
+  })
 }
 ```
 
@@ -306,22 +307,22 @@ To upload multiple files, simply append them all to the `FormData` object. When 
 
 ```javascript
 m.render(document.body, [
-	m("input[type=file][multiple]", {onchange: upload})
+  m("input[type=file][multiple]", {onchange: upload})
 ])
 
 function upload(e) {
-	var files = e.target.files
+  var files = e.target.files
 
-	var data = new FormData()
-	for (var i = 0; i < files.length; i++) {
-		data.append("file" + i, files[i])
-	}
+  var data = new FormData()
+  for (var i = 0; i < files.length; i++) {
+    data.append("file" + i, files[i])
+  }
 
-	m.request({
-		method: "POST",
-		url: "/api/v1/upload",
-		data: data,
-	})
+  m.request({
+    method: "POST",
+    url: "/api/v1/upload",
+    body: data,
+  })
 }
 ```
 
@@ -337,32 +338,32 @@ Sometimes, if a request is inherently slow (e.g. a large file upload), it's desi
 var progress = 0
 
 m.mount(document.body, {
-	view: function() {
-		return [
-			m("input[type=file]", {onchange: upload}),
-			progress + "% completed"
-		]
-	}
+  view: function() {
+    return [
+      m("input[type=file]", {onchange: upload}),
+      progress + "% completed"
+    ]
+  }
 })
 
 function upload(e) {
-	var file = e.target.files[0]
+  var file = e.target.files[0]
 
-	var data = new FormData()
-	data.append("myfile", file)
+  var data = new FormData()
+  data.append("myfile", file)
 
-	m.request({
-		method: "POST",
-		url: "/api/v1/upload",
-		data: data,
-		config: function(xhr) {
-			xhr.upload.addEventListener("progress", function(e) {
-				progress = e.loaded / e.total
+  m.request({
+    method: "POST",
+    url: "/api/v1/upload",
+    body: data,
+    config: function(xhr) {
+      xhr.upload.addEventListener("progress", function(e) {
+        progress = e.loaded / e.total
 
-				m.redraw() // tell Mithril that data changed and a re-render is needed
-			})
-		}
-	})
+        m.redraw() // tell Mithril that data changed and a re-render is needed
+      })
+    }
+  })
 }
 ```
 
@@ -378,20 +379,20 @@ You can pass a constructor as the `options.type` parameter and Mithril will inst
 
 ```javascript
 function User(data) {
-	this.name = data.firstName + " " + data.lastName
+  this.name = data.firstName + " " + data.lastName
 }
 
 m.request({
-	method: "GET",
-	url: "/api/v1/users",
-	type: User
+  method: "GET",
+  url: "/api/v1/users",
+  type: User
 })
 .then(function(users) {
-	console.log(users[0].name) // logs a name
+  console.log(users[0].name) // logs a name
 })
 ```
 
-In the example above, assuming `/api/v1/users` returns an array of objects, the `User` constructor will be instantiated (i.e. called as `new User(data)`) for each object in the array. If the response returned a single object, that object would be used as the `data` argument.
+In the example above, assuming `/api/v1/users` returns an array of objects, the `User` constructor will be instantiated (i.e. called as `new User(data)`) for each object in the array. If the response returned a single object, that object would be used as the `body` argument.
 
 ---
 
@@ -401,12 +402,12 @@ Sometimes a server endpoint does not return a JSON response: for example, you ma
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/files/icon.svg",
-	deserialize: function(value) {return value}
+  method: "GET",
+  url: "/files/icon.svg",
+  deserialize: function(value) {return value}
 })
 .then(function(svg) {
-	m.render(document.body, m.trust(svg))
+  m.render(document.body, m.trust(svg))
 })
 ```
 
@@ -416,19 +417,19 @@ Of course, a `deserialize` function may be more elaborate:
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/files/data.csv",
-	deserialize: parseCSV
+  method: "GET",
+  url: "/files/data.csv",
+  deserialize: parseCSV
 })
 .then(function(data) {
-	console.log(data)
+  console.log(data)
 })
 
 function parseCSV(data) {
-	// naive implementation for the sake of keeping example simple
-	return data.split("\n").map(function(row) {
-		return row.split(",")
-	})
+  // naive implementation for the sake of keeping example simple
+  return data.split("\n").map(function(row) {
+    return row.split(",")
+  })
 }
 ```
 
@@ -438,13 +439,13 @@ Custom headers may also be helpful in this regard. For example, if you're reques
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/files/image.svg",
-	headers: {
-		"Content-Type": "image/svg+xml; charset=utf-8",
-		"Accept": "image/svg, text/*"
-	},
-	deserialize: function(value) {return value}
+  method: "GET",
+  url: "/files/image.svg",
+  headers: {
+    "Content-Type": "image/svg+xml; charset=utf-8",
+    "Accept": "image/svg, text/*"
+  },
+  deserialize: function(value) {return value}
 })
 ```
 
@@ -457,12 +458,12 @@ By default Mithril attempts to parse `xhr.responseText` as JSON and returns the 
 
 ```javascript
 m.request({
-	method: "GET",
-	url: "/api/v1/users",
-	extract: function(xhr) {return {status: xhr.status, body: xhr.responseText}}
+  method: "GET",
+  url: "/api/v1/users",
+  extract: function(xhr) {return {status: xhr.status, body: xhr.responseText}}
 })
 .then(function(response) {
-	console.log(response.status, response.body)
+  console.log(response.status, response.body)
 })
 ```
 
@@ -497,7 +498,7 @@ Mithril's `m.request` uses `XMLHttpRequest` instead of `fetch()` for a number of
 
 Currently, due to lack of browser support, `fetch()` typically requires a [polyfill](https://github.com/github/fetch), which is over 11kb uncompressed - nearly three times larger than Mithril's XHR module.
 
-Despite being much smaller, Mithril's XHR module supports many important and not-so-trivial-to-implement features like [URL interpolation](#dynamic-urls), querystring serialization and [JSON-P requests](jsonp.md), in addition to its ability to integrate seamlessly to Mithril's autoredrawing subsystem. The `fetch` polyfill does not support any of those, and requires extra libraries and boilerplates to achieve the same level of functionality.
+Despite being much smaller, Mithril's XHR module supports many important and not-so-trivial-to-implement features like [URL interpolation](#dynamic-urls), querystring serialization and [JSON-P requests](jsonp.md), in addition to its ability to integrate seamlessly to Mithril's auto-redrawing subsystem. The `fetch` polyfill does not support any of those, and requires extra libraries and boilerplates to achieve the same level of functionality.
 
 In addition, Mithril's XHR module is optimized for JSON-based endpoints and makes that most common case appropriately terse - i.e. `m.request(url)` - whereas `fetch` requires an additional explicit step to parse the response data as JSON: `fetch(url).then(function(response) {return response.json()})`
 
@@ -524,6 +525,6 @@ console.log("list of users:", users)
 
 // PREFER
 m.request("/api/v1/users").then(function(users) {
-	console.log("list of users:", users)
+  console.log("list of users:", users)
 })
 ```

--- a/docs/route.md
+++ b/docs/route.md
@@ -67,18 +67,18 @@ Argument               | Type                                     | Required | D
 
 Redirects to a matching route, or to the default route if no matching routes can be found. Triggers an asynchronous redraw off all mount points.
 
-`m.route.set(path, data, options)`
+`m.route.set(path, params, options)`
 
 Argument          | Type      | Required | Description
 ----------------- | --------- | -------- | ---
-`path`            | `String`  | Yes      | The [path name](paths.md) to route to, without a prefix. The path may include parameters, interpolated with values from `data`.
-`data`            | `Object`  | No       | Routing parameters. If `path` has routing parameter slots, the properties of this object are interpolated into the path string
+`path`            | `String`  | Yes      | The [path name](paths.md) to route to, without a prefix. The path may include parameters, interpolated with values from `params`.
+`params`          | `Object`  | No       | Routing parameters. If `path` has routing parameter slots, the properties of this object are interpolated into the path string
 `options.replace` | `Boolean` | No       | Whether to create a new history entry or to replace the current one. Defaults to false
 `options.state`   | `Object`  | No       | The `state` object to pass to the underlying `history.pushState` / `history.replaceState` call. This state object becomes available in the `history.state` property, and is merged into the [routing parameters](#routing-parameters) object. Note that this option only works when using the pushState API, but is ignored if the router falls back to hashchange mode (i.e. if the pushState API is not available)
 `options.title`   | `String`  | No       | The `title` string to pass to the underlying `history.pushState` / `history.replaceState` call.
 **returns**       |           |          | Returns `undefined`
 
-Remember that when using `.set` with params you also need to define the route:
+Remember that when using `.set` with `params` you also need to define the route:
 ```javascript
 var Article = {
 	view: function(vnode) {
@@ -582,7 +582,7 @@ var Auth = {
 	login: function() {
 		m.request({
 			url: "/api/v1/auth",
-			data: {username: Auth.username, password: Auth.password}
+			params: {username: Auth.username, password: Auth.password}
 		}).then(function(data) {
 			localStorage.setItem("auth-token", data.token)
 			m.route.set("/secret")

--- a/docs/simple-application.md
+++ b/docs/simple-application.md
@@ -522,7 +522,7 @@ var User = {
 		return m.request({
 			method: "PUT",
 			url: "https://rem-rest-api.herokuapp.com/api/users/" + User.current.id,
-			data: User.current,
+			body: User.current,
 			withCredentials: true,
 		})
 	}


### PR DESCRIPTION
## Description

- Replaced request.data with request.body.
- Added request.params to the signature table.
- Where request.data was used for querystring interpolation, I've used request.params.
- serialize uses body too
- replaced hard tabs with double spaces, so the markdown linter is happy.

## Motivation and Context

This is suppose to fix #2423, m.request documentation.
 
## How Has This Been Tested?

Not

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
