### PR TITLE
this addresses bug - shouldnot #2067

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -885,6 +885,7 @@ module.exports = function($window) {
 		vnode.dom = old.dom
 		vnode.domSize = old.domSize
 		vnode.instance = old.instance
+		vnode.state = old.state
 		return true
 	}
 


### PR DESCRIPTION
## Description
shouldNotUpdate throws an uncaught exception: vnode._state is undefined (vnode.state in v2)

## Motivation and Context
When shouldNotUpdate is true, we should also copy the rest of the state of the old vnode (children, instance, dom) on the new one. Otherwise on the next cycle, the old vnode is unbaked, and thus unfit for diff.(https://github.com/MithrilJS/mithril.js/issues/2067#issuecomment-449162547)

https://github.com/MithrilJS/mithril.js/issues/2067

## How Has This Been Tested?
Not Yet

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
