### PR TITLE
support falsy arguments in Object.assign polyfill

### DIFF
--- a/pathname/assign.js
+++ b/pathname/assign.js
@@ -1,5 +1,5 @@
 "use strict"
 
 module.exports = Object.assign || function(target, source) {
-	Object.keys(source || {}).forEach(function(key) { target[key] = source[key] })
+	if(source) Object.keys(source).forEach(function(key) { target[key] = source[key] })
 }

--- a/pathname/assign.js
+++ b/pathname/assign.js
@@ -1,5 +1,5 @@
 "use strict"
 
 module.exports = Object.assign || function(target, source) {
-	Object.keys(source).forEach(function(key) { target[key] = source[key] })
+	Object.keys(source || {}).forEach(function(key) { target[key] = source[key] })
 }

--- a/pathname/tests/index.html
+++ b/pathname/tests/index.html
@@ -13,6 +13,7 @@
 		<script src="test-buildPathname.js"></script>
 		<script src="test-parsePathname.js"></script>
 		<script src="test-parseTemplate.js"></script>
+		<script src="test-assign.js"></script>
 
 		<script>require("../../ospec/ospec").run()</script>
 	</body>

--- a/pathname/tests/test-assign.js
+++ b/pathname/tests/test-assign.js
@@ -1,0 +1,26 @@
+"use strict"
+
+var o = require("../../ospec/ospec")
+
+// force usage of polyfill
+var save = Object.assign
+Object.assign = null
+delete require.cache[require.resolve("../assign")]
+var assign = require("../assign")
+Object.assign = save
+
+o.spec("assign polyfill", function() {
+	o("works", function() {
+		var target = {hello: "world", foo: "bar"}
+		var source = {foo: "foo", extra: true}
+
+		assign(target, source)
+
+		o(target).deepEquals({hello: "world", foo: "foo", extra: true})
+
+		var falsySources = [null, 0, "", false, void 0]
+		falsySources.forEach(function(falsy) { assign(target, falsy) })
+
+		o(target).deepEquals({hello: "world", foo: "foo", extra: true})
+	})
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Don't call `Object.keys` on falsy argument in `assign` polyfill, to more closely match native `Object.assign` behavior. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue with `m.route` in IE 11, [caused by this line](https://github.com/MithrilJS/mithril.js/blob/next/router/router.js#L63). `history.state` can be null and the `Object.assign` polyfill does not handle it. 

Also see these gitter discussions:
https://gitter.im/mithriljs/mithril.js?at=5d035c64e527d95addcf33d3
https://gitter.im/mithriljs/mithril.js?at=5d03aa40d100e447fc12f6ca

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Hand tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
