### PR TITLE
Edit types installation docs to be clearer and easier to find

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -21,6 +21,20 @@ If you're new to JavaScript or just want a very simple setup to get your feet we
 $ npm install mithril@next --save
 ```
 
+TypeScript type definitions are available from DefinitelyTyped. They can be installed with:
+
+```bash
+$ npm install @types/mithril --save-dev
+```
+
+For example usage, to file issues or to discuss TypeScript related topics visit: https://github.com/MithrilJS/mithril.d.ts
+
+Type definitions for pre-release versions of Mithril (on the `next` branch) align with the `next` branch of the [types development repo](https://github.com/MithrilJS/mithril.d.ts/tree/next). You can install these types with:
+
+```bash
+$ npm install -D MithrilJS/mithril.d.ts#next
+```
+
 ---
 
 ### Quick start with Webpack
@@ -259,15 +273,3 @@ If you don't have the ability to run a bundler script due to company security po
 // if a CommonJS environment is not detected, Mithril will be created in the global scope
 m.render(document.body, "hello world")
 ```
-
----
-
-### TypeScript
-
-TypeScript type definitions are available from DefinitelyTyped. They can be installed with:
-
-```bash
-$ npm install @types/mithril --save-dev
-```
-
-For example usage, to file issues or to discuss TypeScript related topics visit: https://github.com/MithrilJS/mithril.d.ts


### PR DESCRIPTION
I've seen a few recent questions around installing types for v2.rc so I wanted to add a note about installing the `next` branch that I've created on the types dev repo. Going forward this should always align with mithril@next.

I also went ahead and re-arranged the doc a bit. npm installation notes and types installation were at opposite ends of the page. I moved the types ahead of the opus about webpack setup.

## Types of changes
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
