### PR TITLE
Clarify pathname docs, follow spec with fragments

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -43,6 +43,8 @@
 - request: set `Content-Type: application/json; charset=utf-8` for all XHR methods by default, provided they have a body that's `!= null` ([#2361](https://github.com/MithrilJS/mithril.js/pull/2361), [#2421](https://github.com/MithrilJS/mithril.js/pull/2421))
     - This can cause CORS issues when issuing `GET` with bodies, but you can address them through configuring CORS appropriately.
     - Previously, it was only set for all non-`GET` methods and only when `useBody: true` was passed (the default), and it was always set for them. Now it's automatically omitted when no body is present, so the hole is slightly broadened.
+- route: query parameters in hash strings are no longer supported
+    - It's technically invalid in hashes, so I'd rather push people to keep in line with spec.
 
 #### News
 
@@ -96,6 +98,7 @@
 - request: autoredraw support fixed for `async`/`await` in Chrome ([#2428](https://github.com/MithrilJS/mithril.js/pull/2428) [@isiahmeadows](https://github.com/isiahmeadows))
 - render: fix when attrs change with `onbeforeupdate` returning false, then remaining the same on next redraw ([#2447](https://github.com/MithrilJS/mithril.js/pull/2447) [@isiahmeadows](https://github.com/isiahmeadows))
 - render: fix internal error when `onbeforeupdate` returns false and then true with new child tree ([#2447](https://github.com/MithrilJS/mithril.js/pull/2447) [@isiahmeadows](https://github.com/isiahmeadows))
+- route: arbitrary prefixes are properly supported now, including odd prefixes like `?#` and invalid prefixes like `#foo#bar`
 
 ---
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -43,7 +43,7 @@
 - request: set `Content-Type: application/json; charset=utf-8` for all XHR methods by default, provided they have a body that's `!= null` ([#2361](https://github.com/MithrilJS/mithril.js/pull/2361), [#2421](https://github.com/MithrilJS/mithril.js/pull/2421))
     - This can cause CORS issues when issuing `GET` with bodies, but you can address them through configuring CORS appropriately.
     - Previously, it was only set for all non-`GET` methods and only when `useBody: true` was passed (the default), and it was always set for them. Now it's automatically omitted when no body is present, so the hole is slightly broadened.
-- route: query parameters in hash strings are no longer supported
+- route: query parameters in hash strings are no longer supported ([#2448](https://github.com/MithrilJS/mithril.js/pull/2448) [@isiahmeadows](https://github.com/isiahmeadows))
     - It's technically invalid in hashes, so I'd rather push people to keep in line with spec.
 
 #### News
@@ -98,7 +98,7 @@
 - request: autoredraw support fixed for `async`/`await` in Chrome ([#2428](https://github.com/MithrilJS/mithril.js/pull/2428) [@isiahmeadows](https://github.com/isiahmeadows))
 - render: fix when attrs change with `onbeforeupdate` returning false, then remaining the same on next redraw ([#2447](https://github.com/MithrilJS/mithril.js/pull/2447) [@isiahmeadows](https://github.com/isiahmeadows))
 - render: fix internal error when `onbeforeupdate` returns false and then true with new child tree ([#2447](https://github.com/MithrilJS/mithril.js/pull/2447) [@isiahmeadows](https://github.com/isiahmeadows))
-- route: arbitrary prefixes are properly supported now, including odd prefixes like `?#` and invalid prefixes like `#foo#bar`
+- route: arbitrary prefixes are properly supported now, including odd prefixes like `?#` and invalid prefixes like `#foo#bar` ([#2448](https://github.com/MithrilJS/mithril.js/pull/2448) [@isiahmeadows](https://github.com/isiahmeadows))
 
 ---
 

--- a/docs/parsePathname.md
+++ b/docs/parsePathname.md
@@ -32,11 +32,15 @@ Argument     | Type     | Required | Description
 
 ### How it works
 
-The `m.parsePathname` method creates an object from a path with a possible query string and hash string. It is useful for parsing a URL into more sensible paths, and it's what [`m.route`](route.md) uses internally to normalize paths to later match them. It uses [`m.parseQueryString`](parseQueryString.md) to parse the query parameters into an object.
+The `m.parsePathname` method creates an object from a path with a possible query string. It is useful for parsing a local path name into its parts, and it's what [`m.route`](route.md) uses internally to normalize paths to later match them. It uses [`m.parseQueryString`](parseQueryString.md) to parse the query parameters into an object.
 
 ```javascript
-var data = m.parsePathname("/path/user?a=hello&b=world#random=hash&some=value")
+var data = m.parsePathname("/path/user?a=hello&b=world")
 
 // data.path is "/path/user"
-// data.params is {a: "hello", b: "world", random: "hash", some: "value"}
+// data.params is {a: "hello", b: "world"}
 ```
+
+### General-purpose URL parsing
+
+The method is called `parsePathname` because it applies to pathnames. If you want a general-purpose URL parser, you should use [the global `URL` class](https://developer.mozilla.org/en-US/docs/Web/API/URL) instead.

--- a/docs/parseQueryString.md
+++ b/docs/parseQueryString.md
@@ -19,13 +19,12 @@ var object = m.parseQueryString("a=1&b=2")
 
 ### Signature
 
-`object = m.parseQueryString(string, object)`
+`object = m.parseQueryString(string)`
 
 Argument     | Type                                       | Required | Description
 ------------ | ------------------------------------------ | -------- | ---
 `string`     | `String`                                   | Yes      | A querystring
-`object`     | `Object`                                   | No       | An existing key-value map to merge values into, potentially from a previous `m.parseQueryString` call
-**returns**  | `Object`                                   |          | A key-value map, `object` if provided
+**returns**  | `Object`                                   |          | A key-value map
 
 [How to read signatures](signatures.md)
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -123,7 +123,7 @@ m.route(document.body, "/edit/1", {
 })
 ```
 
-Note that query parameters are implicit - you don't need to name them to accept them. You can match based on an existing value, like in `"/edit?type=image"`, but you don't need to use `"/edit?type=:type"` to accept the value. In fact, Mithril would treat that as you trying to literally match against `m.route.param("type") === ":type"`. Or in summary, use `m.route.param("key")` to extract parameters - it simplifies things.
+Query parameters are implicitly consumed - you don't need to name them to accept them. You can match based on an existing value, like in `"/edit?type=image"`, but you don't need to use `"/edit?type=:type"` to accept the value. In fact, Mithril would treat that as you trying to literally match against `m.route.param("type") === ":type"`, so you probably don't want to do that. In short, use `m.route.param("key")` or route component attributes to read query parameters.
 
 ### Path normalization
 

--- a/pathname/parse.js
+++ b/pathname/parse.js
@@ -9,16 +9,16 @@ module.exports = function(url) {
 	var queryEnd = hashIndex < 0 ? url.length : hashIndex
 	var pathEnd = queryIndex < 0 ? queryEnd : queryIndex
 	var path = url.slice(0, pathEnd).replace(/\/{2,}/g, "/")
-	var params = {}
 
 	if (!path) path = "/"
 	else {
 		if (path[0] !== "/") path = "/" + path
 		if (path.length > 1 && path[path.length - 1] === "/") path = path.slice(0, -1)
 	}
-	// Note: these are reversed because `parseQueryString` appends parameters
-	// only if they don't exist. Please don't flip them.
-	if (queryIndex >= 0) parseQueryString(url.slice(queryIndex + 1, queryEnd), params)
-	if (hashIndex >= 0) parseQueryString(url.slice(hashIndex + 1), params)
-	return {path: path, params: params}
+	return {
+		path: path,
+		params: queryIndex < 0
+			? {}
+			: parseQueryString(url.slice(queryIndex + 1, queryEnd)),
+	}
 }

--- a/pathname/tests/test-compileTemplate.js
+++ b/pathname/tests/test-compileTemplate.js
@@ -198,18 +198,6 @@ o.spec("compileTemplate", function() {
 		o(compileTemplate("/route/:id?bar=foo")(data)).equals(false)
 		o(data.params).deepEquals({foo: "bar"})
 	})
-	o("checks hash params match", function() {
-		var data = parsePathname("/route/1#foo=bar")
-		o(compileTemplate("/route/:id#foo=bar")(data)).equals(true)
-		o(data.params).deepEquals({id: "1", foo: "bar"})
-	})
-	o("checks hash params mismatch", function() {
-		var data = parsePathname("/route/1#foo=bar")
-		o(compileTemplate("/route/:id#foo=1")(data)).equals(false)
-		o(data.params).deepEquals({foo: "bar"})
-		o(compileTemplate("/route/:id#bar=foo")(data)).equals(false)
-		o(data.params).deepEquals({foo: "bar"})
-	})
 	o("checks dot before dot", function() {
 		var data = parsePathname("/file.test.png/edit")
 		o(compileTemplate("/:file.:ext/edit")(data)).equals(true)

--- a/pathname/tests/test-parsePathname.js
+++ b/pathname/tests/test-parsePathname.js
@@ -18,18 +18,18 @@ o.spec("parsePathname", function() {
 			params: {a: "b", c: "d"}
 		})
 	})
-	o("parses hash at start", function() {
+	o("ignores hash at start", function() {
 		var data = parsePathname("#a=b&c=d")
 		o(data).deepEquals({
 			path: "/",
-			params: {a: "b", c: "d"}
+			params: {}
 		})
 	})
-	o("parses query + hash at start", function() {
+	o("parses query, ignores hash at start", function() {
 		var data = parsePathname("?a=1&b=2#c=3&d=4")
 		o(data).deepEquals({
 			path: "/",
-			params: {a: "1", b: "2", c: "3", d: "4"}
+			params: {a: "1", b: "2"}
 		})
 	})
 	o("parses root", function() {
@@ -46,18 +46,18 @@ o.spec("parsePathname", function() {
 			params: {a: "b", c: "d"}
 		})
 	})
-	o("parses root + hash at start", function() {
+	o("parses root, ignores hash at start", function() {
 		var data = parsePathname("/#a=b&c=d")
 		o(data).deepEquals({
 			path: "/",
-			params: {a: "b", c: "d"}
+			params: {}
 		})
 	})
-	o("parses root + query + hash at start", function() {
+	o("parses root + query, ignores hash at start", function() {
 		var data = parsePathname("/?a=1&b=2#c=3&d=4")
 		o(data).deepEquals({
 			path: "/",
-			params: {a: "1", b: "2", c: "3", d: "4"}
+			params: {a: "1", b: "2"}
 		})
 	})
 	o("parses route", function() {
@@ -102,25 +102,25 @@ o.spec("parsePathname", function() {
 			params: {c: "3", d: "4"}
 		})
 	})
-	o("parses route + query + hash", function() {
+	o("parses route + query, ignores hash", function() {
 		var data = parsePathname("/route/foo?a=1&b=2#c=3&d=4")
 		o(data).deepEquals({
 			path: "/route/foo",
-			params: {a: "1", b: "2", c: "3", d: "4"}
+			params: {a: "1", b: "2"}
 		})
 	})
-	o("deduplicates same-named params in query + hash", function() {
-		var data = parsePathname("/route/foo?a=1&b=2#a=3&c=4")
-		o(data).deepEquals({
-			path: "/route/foo",
-			params: {a: "3", b: "2", c: "4"}
-		})
-	})
-	o("parses route + query + hash with lots of junk slashes", function() {
+	o("parses route + query, ignores hash with lots of junk slashes", function() {
 		var data = parsePathname("//route/////foo//?a=1&b=2#c=3&d=4")
 		o(data).deepEquals({
 			path: "/route/foo",
-			params: {a: "1", b: "2", c: "3", d: "4"}
+			params: {a: "1", b: "2"}
+		})
+	})
+	o("doesn't comprehend protocols", function() {
+		var data = parsePathname("https://example.com/foo/bar")
+		o(data).deepEquals({
+			path: "/https:/example.com/foo/bar",
+			params: {}
 		})
 	})
 })

--- a/querystring/parse.js
+++ b/querystring/parse.js
@@ -2,12 +2,11 @@
 
 // The extra `data` parameter is for if you want to append to an existing
 // parameters object.
-module.exports = function(string, data) {
-	if (data == null) data = {}
+module.exports = function(string) {
 	if (string === "" || string == null) return {}
 	if (string.charAt(0) === "?") string = string.slice(1)
 
-	var entries = string.split("&"), counters = {}
+	var entries = string.split("&"), counters = {}, data = {}
 	for (var i = 0; i < entries.length; i++) {
 		var entry = entries[i].split("=")
 		var key = decodeURIComponent(entry[0])

--- a/querystring/tests/test-parseQueryString.js
+++ b/querystring/tests/test-parseQueryString.js
@@ -97,16 +97,4 @@ o.spec("parseQueryString", function() {
 		var data = parseQueryString("a=1&b=2&a=3")
 		o(data).deepEquals({a: "3", b: "2"})
 	})
-	o("continues to append to arrays between calls", function() {
-		var data = {}
-		parseQueryString("a[]=1&a[]=2", data)
-		parseQueryString("a[]=3&a[]=4", data)
-		o(data).deepEquals({a: ["1", "2", "3", "4"]})
-	})
-	o("continues to append to objects between calls", function() {
-		var data = {}
-		parseQueryString("a[b]=1&a[c]=2", data)
-		parseQueryString("a[d]=3&a[e]=4", data)
-		o(data).deepEquals({a: {b: "1", c: "2", d: "3", e: "4"}})
-	})
 })

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -73,6 +73,17 @@ o.spec("request", function() {
 				o(data).deepEquals({a: 1})
 			}).then(done)
 		})
+		o("first argument keeps protocol", function(done) {
+			mock.$defineRoutes({
+				"POST /item": function(request) {
+					o(request.rawUrl).equals("https://example.com/item")
+					return {status: 200, responseText: JSON.stringify({a: 1})}
+				}
+			})
+			request("https://example.com/item", {method: "POST"}).then(function(data) {
+				o(data).deepEquals({a: 1})
+			}).then(done)
+		})
 		o("works w/ parameterized data via GET", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function(request) {

--- a/router/tests/test-defineRoutes.js
+++ b/router/tests/test-defineRoutes.js
@@ -7,7 +7,7 @@ var Router = require("../../router/router")
 
 o.spec("Router.defineRoutes", function() {
 	void [{protocol: "http:", hostname: "localhost"}, {protocol: "file:", hostname: "/"}].forEach(function(env) {
-		void ["#", "?", "", "#!", "?!", "/foo"].forEach(function(prefix) {
+		void ["#", "?", "", "#!", "?!", "/foo", "?#", "##"].forEach(function(prefix) {
 			o.spec("using prefix `" + prefix + "` starting on " + env.protocol + "//" + env.hostname, function() {
 				var $window, router, onRouteChange, onFail
 
@@ -44,12 +44,12 @@ o.spec("Router.defineRoutes", function() {
 				})
 
 				o("resolves to route w/ escaped unicode", function(done) {
-					$window.location.href = prefix + "/%C3%B6?%C3%B6=%C3%B6#%C3%B6=%C3%B6"
+					$window.location.href = prefix + "/%C3%B6?%C3%B6=%C3%B6"
 					router.defineRoutes({"/ö": {data: 2}}, onRouteChange, onFail)
 
 					callAsync(function() {
 						o(onRouteChange.callCount).equals(1)
-						o(onRouteChange.args).deepEquals([{data: 2}, {"ö": "ö"}, "/ö?ö=ö#ö=ö", "/ö"])
+						o(onRouteChange.args).deepEquals([{data: 2}, {"ö": "ö"}, "/ö?ö=ö", "/ö"])
 						o(onFail.callCount).equals(0)
 
 						done()
@@ -57,12 +57,12 @@ o.spec("Router.defineRoutes", function() {
 				})
 
 				o("resolves to route w/ unicode", function(done) {
-					$window.location.href = prefix + "/ö?ö=ö#ö=ö"
+					$window.location.href = prefix + "/ö?ö=ö"
 					router.defineRoutes({"/ö": {data: 2}}, onRouteChange, onFail)
 
 					callAsync(function() {
 						o(onRouteChange.callCount).equals(1)
-						o(onRouteChange.args).deepEquals([{data: 2}, {"ö": "ö"}, "/ö?ö=ö#ö=ö", "/ö"])
+						o(onRouteChange.args).deepEquals([{data: 2}, {"ö": "ö"}, "/ö?ö=ö", "/ö"])
 						o(onFail.callCount).equals(0)
 
 						done()
@@ -138,45 +138,6 @@ o.spec("Router.defineRoutes", function() {
 					})
 				})
 
-				o("handles route with hash", function(done) {
-					$window.location.href = prefix + "/test#a=b&c=d"
-					router.defineRoutes({"/test": {data: 1}}, onRouteChange, onFail)
-
-					callAsync(function() {
-						o(onRouteChange.callCount).equals(1)
-						o(onRouteChange.args).deepEquals([{data: 1}, {a: "b", c: "d"}, "/test#a=b&c=d", "/test"])
-						o(onFail.callCount).equals(0)
-
-						done()
-					})
-				})
-
-				o("handles route with search and hash", function(done) {
-					$window.location.href = prefix + "/test?a=b#c=d"
-					router.defineRoutes({"/test": {data: 1}}, onRouteChange, onFail)
-
-					callAsync(function() {
-						o(onRouteChange.callCount).equals(1)
-						o(onRouteChange.args).deepEquals([{data: 1}, {a: "b", c: "d"}, "/test?a=b#c=d", "/test"])
-						o(onFail.callCount).equals(0)
-
-						done()
-					})
-				})
-
-				o("handles route with search and hash + duplicate params", function(done) {
-					$window.location.href = prefix + "/test?a=b#a=d"
-					router.defineRoutes({"/test": {data: 1}}, onRouteChange, onFail)
-
-					callAsync(function() {
-						o(onRouteChange.callCount).equals(1)
-						o(onRouteChange.args).deepEquals([{data: 1}, {a: "d"}, "/test?a=b#a=d", "/test"])
-						o(onFail.callCount).equals(0)
-
-						done()
-					})
-				})
-
 				o("calls reject", function(done) {
 					$window.location.href = prefix + "/test"
 					router.defineRoutes({"/other": {data: 1}}, onRouteChange, onFail)
@@ -184,18 +145,6 @@ o.spec("Router.defineRoutes", function() {
 					callAsync(function() {
 						o(onFail.callCount).equals(1)
 						o(onFail.args).deepEquals(["/test", {}])
-
-						done()
-					})
-				})
-
-				o("calls reject w/ search and hash", function(done) {
-					$window.location.href = prefix + "/test?a=b#c=d"
-					router.defineRoutes({"/other": {data: 1}}, onRouteChange, onFail)
-
-					callAsync(function() {
-						o(onFail.callCount).equals(1)
-						o(onFail.args).deepEquals(["/test?a=b#c=d", {a: "b", c: "d"}])
 
 						done()
 					})

--- a/router/tests/test-getPath.js
+++ b/router/tests/test-getPath.js
@@ -6,7 +6,7 @@ var Router = require("../../router/router")
 
 o.spec("Router.getPath", function() {
 	void [{protocol: "http:", hostname: "localhost"}, {protocol: "file:", hostname: "/"}].forEach(function(env) {
-		void ["#", "?", "", "#!", "?!", "/foo"].forEach(function(prefix) {
+		void ["#", "?", "", "#!", "?!", "/foo", "?#", "##"].forEach(function(prefix) {
 			o.spec("using prefix `" + prefix + "` starting on " + env.protocol + "//" + env.hostname, function() {
 				var $window, router, onRouteChange, onFail
 

--- a/test-utils/tests/test-parseURL.js
+++ b/test-utils/tests/test-parseURL.js
@@ -7,9 +7,18 @@ o.spec("parseURL", function() {
 	var root = {protocol: "http:", hostname: "localhost", port: "", pathname: "/"}
 
 	o.spec("full URL", function() {
-		o("parses full URL", function() {
+		o("parses full http URL", function() {
 			var data = parseURL("http://www.google.com:80/test?a=b#c")
 			o(data.protocol).equals("http:")
+			o(data.hostname).equals("www.google.com")
+			o(data.port).equals("80")
+			o(data.pathname).equals("/test")
+			o(data.search).equals("?a=b")
+			o(data.hash).equals("#c")
+		})
+		o("parses full websocket URL", function() {
+			var data = parseURL("ws://www.google.com:80/test?a=b#c")
+			o(data.protocol).equals("ws:")
 			o(data.hostname).equals("www.google.com")
 			o(data.port).equals("80")
 			o(data.pathname).equals("/test")

--- a/test-utils/xhrMock.js
+++ b/test-utils/xhrMock.js
@@ -36,6 +36,7 @@ module.exports = function() {
 			}
 			this.open = function(method, url, async, user, password) {
 				var urlData = parseURL(url, {protocol: "http:", hostname: "localhost", port: "", pathname: "/"})
+				args.rawUrl = url
 				args.method = method
 				args.pathname = urlData.pathname
 				args.search = urlData.search
@@ -56,7 +57,7 @@ module.exports = function() {
 				var self = this
 				if(!aborted) {
 					var handler = routes[args.method + " " + args.pathname] || serverErrorHandler.bind(null, args.pathname)
-					var data = handler({url: args.pathname, query: args.search || {}, body: body || null})
+					var data = handler({rawUrl: args.rawUrl, url: args.pathname, query: args.search || {}, body: body || null})
 					self.status = data.status
 					// Match spec
 					if (self.responseType === "json") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is multi-part:

- A few parts of the docs were updated to clear up some confusion and bring some clarity.
- Valid URLs must not contain a `#` within its fragment per spec (see #2445). This removes the hash parameter parsing, to bring it in line with spec. (I suspect almost nobody actually uses this.)
	- I also removed the extra parameter to `m.parseQueryString`, which existed almost solely to support this.
- I added a bunch of new tests to ensure a few more various edge cases were properly covered, including the report in #2440.
- Prefix handling was corrected, so now, arbitrary URL paths can be used, complete with both path names, query strings, *and* hash strings. For instance, `?#` is now correctly handled as a prefix.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2440 by just updating the docs
Fixes #2445 
Also fixes a bug I found along the way. (That's where the prefix handling fix came in.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
