### PR TITLE
Add build/parsePathname to API TOC

### DIFF
--- a/docs/nav-methods.md
+++ b/docs/nav-methods.md
@@ -7,6 +7,8 @@
 	- [m.jsonp](jsonp.md)
 	- [m.parseQueryString](parseQueryString.md)
 	- [m.buildQueryString](buildQueryString.md)
+	- [m.buildPathname](buildPathname.md)
+	- [m.parsePathname](parsePathname.md)
 	- [m.trust](trust.md)
 	- [m.fragment](fragment.md)
 	- [m.redraw](redraw.md)


### PR DESCRIPTION
`buildPathname` and `parsePathname` already had doc pages written, however they weren't linked from the API table of contents so I don't think you could get to them. I've added these to the `nav-methods.md` which adds them to the left nav in the API section.

## How Has This Been Tested?
Rebuilt docs, tested on local server

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
