### PR TITLE
Fix `m.version` to not depend on `package.json`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@
 .travis.yml
 CONTRIBUTING.md
 yarn.lock
+scripts

--- a/bundler/bundle.js
+++ b/bundler/bundle.js
@@ -24,10 +24,6 @@ module.exports = function (input) {
 	var include = /(?:((?:var|let|const|,|)[\t ]*)([\w_$\.\[\]"'`]+)(\s*=\s*))?require\(([^\)]+)\)(\s*[`\.\(\[])?/gm
 	var uuid = 0
 	var process = function(filepath, data) {
-		// HACK: inline Mithril's `package.json` keys without reading the whole file.
-		data = data.replace(/require\((['"])\.\/package\.json\1\)\.(\w+)/, function (match, quote, key) {
-			return JSON.stringify(pkg[key])
-		})
 		data.replace(declaration, function(match, binding) {bindings[binding] = 0})
 
 		return data.replace(include, function(match, def, variable, eq, dep, rest) {

--- a/bundler/tests/test-bundler.js
+++ b/bundler/tests/test-bundler.js
@@ -320,11 +320,4 @@ o.spec("bundler", function() {
 		remove("a.js")
 		remove("b.js")
 	})
-	o("reads package.json keys", function() {
-		write("a.js", 'var b = require("./package.json").version')
-
-		o(bundle(ns + "a.js")).equals(";(function() {\nvar b = " + JSON.stringify(pkg.version) + "\n}());")
-
-		remove("a.js")
-	})
 })

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -86,8 +86,6 @@
     - Previously, this was possible to do in `m.route.set`, `m.request`, and `m.jsonp`, but it was wholly untested for and also undocumented.
 - API: `m.buildPathname` and `m.parsePathname` added. ([#2361](https://github.com/MithrilJS/mithril.js/pull/2361))
 - route: Use `m.mount(root, null)` to unsubscribe and clean up after a `m.route(root, ...)` call. ([#2453](https://github.com/MithrilJS/mithril.js/pull/2453))
-- version: `m.version` returns the previous version string for what's in `next`. ([#2453](https://github.com/MithrilJS/mithril.js/pull/2453))
-    - If you're using `next`, you should hopefully know what you're doing. If you need stability, don't use `next`. (This is also why I'm not labelling it as a breaking change.)
 - render: new `redraw` parameter exposed any time a child event handler is used ([#2458](https://github.com/MithrilJS/mithril.js/pull/2458) [@isiahmeadows](https://github.com/isiahmeadows))
 
 #### Bug fixes

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ m.parseQueryString = require("./querystring/parse")
 m.buildQueryString = require("./querystring/build")
 m.parsePathname = require("./pathname/parse")
 m.buildPathname = require("./pathname/build")
-m.version = "next"
+m.version = "2.0.0-rc.7"
 m.vnode = require("./render/vnode")
 m.PromisePolyfill = require("./promise/polyfill")
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ m.parseQueryString = require("./querystring/parse")
 m.buildQueryString = require("./querystring/build")
 m.parsePathname = require("./pathname/parse")
 m.buildPathname = require("./pathname/build")
-m.version = require("./package.json").version
+m.version = "next"
 m.vnode = require("./render/vnode")
 m.PromisePolyfill = require("./promise/polyfill")
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cover": "istanbul cover --print both ospec/bin/ospec",
     "release": "npm version -m 'v%s'",
     "preversion": "npm run test",
-    "version": "npm run build && git add mithril.js mithril.min.js",
+    "version": "node scripts/update-version && npm run build && git add index.js mithril.js mithril.min.js",
     "postversion": "git push --follow-tags"
   },
   "devDependencies": {

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,10 @@
+"use strict"
+
+const fs = require("fs")
+const version = require("../package.json").version
+const index = require.resolve("../index")
+
+fs.writeFile(index,
+	fs.readFile(index, "utf-8")
+		.replace(/(version\s*=\s*)(['"])next\2/, `$1$2${version}$2`)
+)

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -6,5 +6,5 @@ const index = require.resolve("../index")
 
 fs.writeFile(index,
 	fs.readFile(index, "utf-8")
-		.replace(/(version\s*=\s*)(['"])next\2/, `$1$2${version}$2`)
+		.replace(/(version\s*=\s*)(['"]).*?\2/, `$1$2${version}$2`)
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Created an accidental breaking change in #2453, so I'm 90% reverting it. Note that I still want it to be different in the repo, but it'll be `"next"` rather than pulling the actual version from `package.json`. (This will be in a follow-up PR.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2463 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
