### PR TITLE
Partially recast the router API to be a lot more intuitive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mithril.js [![NPM Version](https://img.shields.io/npm/v/mithril.svg)](https://ww
 
 ## What is Mithril?
 
-A modern client-side Javascript framework for building Single Page Applications. It's small (<!-- size -->9.31 KB<!-- /size --> gzipped), fast and provides routing and XHR utilities out of the box.
+A modern client-side Javascript framework for building Single Page Applications. It's small (<!-- size -->9.50 KB<!-- /size --> gzipped), fast and provides routing and XHR utilities out of the box.
 
 Mithril is used by companies like Vimeo and Nike, and open source platforms like Lichess 👍.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mithril.js [![NPM Version](https://img.shields.io/npm/v/mithril.svg)](https://ww
 
 ## What is Mithril?
 
-A modern client-side Javascript framework for building Single Page Applications. It's small (<!-- size -->9.50 KB<!-- /size --> gzipped), fast and provides routing and XHR utilities out of the box.
+A modern client-side Javascript framework for building Single Page Applications. It's small (<!-- size -->9.53 KB<!-- /size --> gzipped), fast and provides routing and XHR utilities out of the box.
 
 Mithril is used by companies like Vimeo and Nike, and open source platforms like Lichess 👍.
 

--- a/api/router.js
+++ b/api/router.js
@@ -1,6 +1,7 @@
 "use strict"
 
 var Vnode = require("../render/vnode")
+var m = require("../render/hyperscript")
 var Promise = require("../promise/promise")
 
 var buildPathname = require("../pathname/build")
@@ -11,9 +12,6 @@ var assign = require("../pathname/assign")
 var sentinel = {}
 
 module.exports = function($window, mountRedraw) {
-	var callAsync = typeof setImmediate === "function" ? setImmediate : setTimeout
-	var supportsPushState = typeof $window.history.pushState === "function"
-	var routePrefix = "#!"
 	var fireAsync
 
 	function setPath(path, data, options) {
@@ -22,16 +20,16 @@ module.exports = function($window, mountRedraw) {
 			fireAsync()
 			var state = options ? options.state : null
 			var title = options ? options.title : null
-			if (options && options.replace) $window.history.replaceState(state, title, routePrefix + path)
-			else $window.history.pushState(state, title, routePrefix + path)
+			if (options && options.replace) $window.history.replaceState(state, title, route.prefix + path)
+			else $window.history.pushState(state, title, route.prefix + path)
 		}
 		else {
-			$window.location.href = routePrefix + path
+			$window.location.href = route.prefix + path
 		}
 	}
 
 	var currentResolver = sentinel, component, attrs, currentPath, lastUpdate
-	var route = function(root, defaultRoute, routes) {
+	function route(root, defaultRoute, routes) {
 		if (root == null) throw new Error("Ensure the DOM element that was passed to `m.route` is not undefined")
 		// 0 = start
 		// 1 = init
@@ -49,7 +47,9 @@ module.exports = function($window, mountRedraw) {
 				check: compileTemplate(route),
 			}
 		})
-		var onremove, asyncId
+		var callAsync = typeof setImmediate === "function" ? setImmediate : setTimeout
+		var scheduled = false
+		var onremove
 
 		fireAsync = null
 
@@ -62,12 +62,13 @@ module.exports = function($window, mountRedraw) {
 		}
 
 		function resolveRoute() {
+			scheduled = false
 			// Consider the pathname holistically. The prefix might even be invalid,
 			// but that's not our problem.
 			var prefix = $window.location.hash
-			if (routePrefix[0] !== "#") {
+			if (route.prefix[0] !== "#") {
 				prefix = $window.location.search + prefix
-				if (routePrefix[0] !== "?") {
+				if (route.prefix[0] !== "?") {
 					prefix = $window.location.pathname + prefix
 					if (prefix[0] !== "/") prefix = "/" + prefix
 				}
@@ -77,7 +78,7 @@ module.exports = function($window, mountRedraw) {
 			// optimized cons string.
 			var path = prefix.concat()
 				.replace(/(?:%[a-f89][a-f0-9])+/gim, decodeURIComponent)
-				.slice(routePrefix.length)
+				.slice(route.prefix.length)
 			var data = parsePathname(path)
 
 			assign(data.params, $window.history.state)
@@ -85,7 +86,7 @@ module.exports = function($window, mountRedraw) {
 			for (var i = 0; i < compiled.length; i++) {
 				if (compiled[i].check(data)) {
 					var payload = compiled[i].component
-					var route = compiled[i].route
+					var matchedRoute = compiled[i].route
 					var update = lastUpdate = function(routeResolver, comp) {
 						if (update !== lastUpdate) return
 						component = comp != null && (typeof comp.view === "function" || typeof comp === "function")? comp : "div"
@@ -100,7 +101,7 @@ module.exports = function($window, mountRedraw) {
 					if (payload.view || typeof payload === "function") update({}, payload)
 					else {
 						if (payload.onmatch) {
-							Promise.resolve(payload.onmatch(data.params, path, route)).then(function(resolved) {
+							Promise.resolve(payload.onmatch(data.params, path, matchedRoute)).then(function(resolved) {
 								update(payload, resolved)
 							}, function () {
 								if (path === defaultRoute) throw new Error("Could not resolve default route " + defaultRoute)
@@ -117,18 +118,17 @@ module.exports = function($window, mountRedraw) {
 			setPath(defaultRoute, null, {replace: true})
 		}
 
-		if (supportsPushState) {
+		if (typeof $window.history.pushState === "function") {
 			onremove = function() {
 				$window.removeEventListener("popstate", fireAsync, false)
 			}
 			$window.addEventListener("popstate", fireAsync = function() {
-				if (asyncId) return
-				asyncId = callAsync(function() {
-					asyncId = null
-					resolveRoute()
-				})
+				if (!scheduled) {
+					scheduled = true
+					callAsync(resolveRoute)
+				}
 			}, false)
-		} else if (routePrefix[0] === "#") {
+		} else if (route.prefix[0] === "#") {
 			onremove = function() {
 				$window.removeEventListener("hashchange", resolveRoute, false)
 			}
@@ -160,25 +160,77 @@ module.exports = function($window, mountRedraw) {
 		setPath(path, data, options)
 	}
 	route.get = function() {return currentPath}
-	route.prefix = function(prefix) {routePrefix = prefix}
-	var link = function(options, vnode) {
-		vnode.dom.setAttribute("href", routePrefix + vnode.attrs.href)
-		vnode.dom.onclick = function(e) {
-			if (e.ctrlKey || e.metaKey || e.shiftKey || e.which === 2) return
-			e.preventDefault()
-			e.redraw = false
-			var href = this.getAttribute("href")
-			if (href.indexOf(routePrefix) === 0) href = href.slice(routePrefix.length)
-			route.set(href, undefined, options)
-		}
-	}
-	route.link = function(args) {
-		if (args.tag == null) return link.bind(link, args)
-		return link({}, args)
+	route.prefix = "#!"
+	route.Link = {
+		view: function(vnode) {
+			var options = vnode.attrs.options
+			// Remove these so they don't get overwritten
+			var attrs = {}, onclick, href
+			assign(attrs, vnode.attrs)
+			attrs.component = null
+			attrs.options = null
+			attrs.key = null
+
+			// Do this now so we can get the most current `href` and `disabled`.
+			// Those attributes may also be specified in the selector, and we
+			// should honor that.
+			var child = m(vnode.attrs.component || "a", attrs, vnode.children)
+
+			// Let's provide a *right* way to disable a route link, rather than
+			// letting people screw up accessibility on accident.
+			//
+			// The attribute is coerced so users don't get surprised over
+			// `disabled: 0` resulting in a button that's somehow routable
+			// despite being visibly disabled.
+			if (child.attrs.disabled = Boolean(child.attrs.disabled)) {
+				child.attrs.href = null
+				child.attrs["aria-disabled"] = "true"
+				// If you *really* do want to do this on a disabled link, use
+				// an `oncreate` hook to add it.
+				child.attrs.onclick = null
+			} else {
+				onclick = child.attrs.onclick
+				href = child.attrs.href
+				child.attrs.href = route.prefix + href
+				child.attrs.onclick = function(e) {
+					var result
+					if (typeof onclick === "function") {
+						result = onclick.call(e.currentTarget, e)
+					} else if (onclick == null || typeof onclick !== "object") {
+						// do nothing
+					} else if (typeof onclick.handleEvent === "function") {
+						onclick.handleEvent(e)
+					}
+
+					// Adapted from React Router's implementation:
+					// https://github.com/ReactTraining/react-router/blob/520a0acd48ae1b066eb0b07d6d4d1790a1d02482/packages/react-router-dom/modules/Link.js
+					//
+					// Try to be flexible and intuitive in how we handle links.
+					// Fun fact: links aren't as obvious to get right as you
+					// would expect. There's a lot more valid ways to click a
+					// link than this, and one might want to not simply click a
+					// link, but right click or command-click it to copy the
+					// link target, etc. Nope, this isn't just for blind people.
+					if (
+						// Skip if `onclick` prevented default
+						result === false || !e.defaultPrevented &&
+						// Ignore everything but left clicks
+						(e.button === 0 || e.which === 0 || e.which === 1) &&
+						// Let the browser handle `target=_blank`, etc.
+						(!e.currentTarget.target || e.currentTarget.target === "_self") &&
+						// No modifier keys
+						!e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey
+					) return
+					e.preventDefault()
+					e.redraw = false
+					route.set(href, null, options)
+				}
+			}
+			return child
+		},
 	}
 	route.param = function(key) {
-		if(typeof attrs !== "undefined" && typeof key !== "undefined") return attrs[key]
-		return attrs
+		return attrs && key != null ? attrs[key] : attrs
 	}
 
 	return route

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -27,7 +27,7 @@ o.spec("route", function() {
 
 					mountRedraw = apiMountRedraw(coreRenderer($window), throttleMock.schedule, console)
 					route = apiRouter($window, mountRedraw)
-					route.prefix(prefix)
+					route.prefix = prefix
 				})
 
 				o.afterEach(function() {
@@ -427,7 +427,7 @@ o.spec("route", function() {
 					})
 				})
 
-				o("changes location on route.link", function() {
+				o("changes location on route.Link", function() {
 					var e = $window.document.createEvent("MouseEvents")
 
 					e.initEvent("click", true, true)
@@ -436,10 +436,7 @@ o.spec("route", function() {
 					route(root, "/", {
 						"/" : {
 							view: function() {
-								return m("a", {
-									href: "/test",
-									oncreate: route.link
-								})
+								return m(route.Link, {href: "/test"})
 							}
 						},
 						"/test" : {
@@ -458,7 +455,7 @@ o.spec("route", function() {
 					o($window.location.href).equals(env.protocol + "//" + (env.hostname === "/" ? "" : env.hostname) + slash + (prefix ? prefix + "/" : "") + "test")
 				})
 
-				o("passes options on route.link", function() {
+				o("passes options on route.Link", function() {
 					var opts = {}
 					var e = $window.document.createEvent("MouseEvents")
 
@@ -468,9 +465,9 @@ o.spec("route", function() {
 					route(root, "/", {
 						"/" : {
 							view: function() {
-								return m("a", {
+								return m(route.Link, {
 									href: "/test",
-									oncreate: route.link(opts)
+									options: opts,
 								})
 							}
 						},
@@ -486,6 +483,146 @@ o.spec("route", function() {
 
 					o(route.set.callCount).equals(1)
 					o(route.set.args[2]).equals(opts)
+				})
+
+				o("route.Link can render without routes or dom access", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {href: "/test", foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("A")
+					o(root.firstChild.href).equals(prefix + "/test")
+					o(root.firstChild.hasAttribute("aria-disabled")).equals(false)
+					o(root.firstChild.hasAttribute("disabled")).equals(false)
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
+				})
+
+				o("route.Link can render other tag without routes or dom access", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {component: "button", href: "/test", foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("BUTTON")
+					o(root.firstChild.attributes["href"].value).equals(prefix + "/test")
+					o(root.firstChild.hasAttribute("aria-disabled")).equals(false)
+					o(root.firstChild.hasAttribute("disabled")).equals(false)
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
+				})
+
+				o("route.Link can render other selector without routes or dom access", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {component: "button[href=/test]", foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("BUTTON")
+					o(root.firstChild.attributes["href"].value).equals(prefix + "/test")
+					o(root.firstChild.hasAttribute("aria-disabled")).equals(false)
+					o(root.firstChild.hasAttribute("disabled")).equals(false)
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
+				})
+
+				o("route.Link can render not disabled", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {href: "/test", disabled: false, foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("A")
+					o(root.firstChild.href).equals(prefix + "/test")
+					o(root.firstChild.hasAttribute("aria-disabled")).equals(false)
+					o(root.firstChild.hasAttribute("disabled")).equals(false)
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
+				})
+
+				o("route.Link can render falsy disabled", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {href: "/test", disabled: 0, foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("A")
+					o(root.firstChild.href).equals(prefix + "/test")
+					o(root.firstChild.hasAttribute("aria-disabled")).equals(false)
+					o(root.firstChild.hasAttribute("disabled")).equals(false)
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
+				})
+
+				o("route.Link can render disabled", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {href: "/test", disabled: true, foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("A")
+					o(root.firstChild.href).equals("")
+					o(root.firstChild.attributes["aria-disabled"].value).equals("true")
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.attributes["disabled"].value).equals("")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
+				})
+
+				o("route.Link can render truthy disabled", function() {
+					$window = browserMock(env)
+					var render = coreRenderer($window)
+					route = apiRouter(null, null)
+					route.prefix = prefix
+					root = $window.document.body
+
+					render(root, m(route.Link, {href: "/test", disabled: 1, foo: "bar"}, "text"))
+
+					o(root.childNodes.length).equals(1)
+					o(root.firstChild.nodeName).equals("A")
+					o(root.firstChild.href).equals("")
+					o(root.firstChild.attributes["aria-disabled"].value).equals("true")
+					o(root.firstChild.attributes["foo"].value).equals("bar")
+					o(root.firstChild.attributes["disabled"].value).equals("")
+					o(root.firstChild.childNodes.length).equals(1)
+					o(root.firstChild.firstChild.nodeName).equals("#text")
+					o(root.firstChild.firstChild.nodeValue).equals("text")
 				})
 
 				o("accepts RouteResolver with onmatch that returns Component", function(done) {

--- a/api/tests/test-routerGetSet.js
+++ b/api/tests/test-routerGetSet.js
@@ -25,7 +25,7 @@ o.spec("route.get/route.set", function() {
 
 					mountRedraw = apiMountRedraw(coreRenderer($window), throttleMock.schedule, console)
 					route = apiRouter($window, mountRedraw)
-					route.prefix(prefix)
+					route.prefix = prefix
 				})
 
 				o.afterEach(function() {

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,18 +57,18 @@ m.route.set("/home")
 var currentRoute = m.route.get()
 ```
 
-#### m.route.prefix(prefix) - [docs](route.md#mrouteprefix)
+#### m.route.prefix = prefix - [docs](route.md#mrouteprefix)
 
-Call this before `m.route()`
+Invoke this before `m.route()` to change the routing prefix.
 
 ```javascript
-m.route.prefix("#!")
+m.route.prefix = "#!"
 ```
 
-#### m.route.link() - [docs](route.md#mroutelink)
+#### m(m.route.Link, ...) - [docs](route.md#mroutelink)
 
 ```javascript
-m("a[href='/Home']", {oncreate: m.route.link}, "Go to home page")
+m(m.route.Link, {href: "/Home"}, "Go to home page")
 ```
 
 ---

--- a/docs/autoredraw.md
+++ b/docs/autoredraw.md
@@ -63,14 +63,14 @@ m.request("/api/v1/users", {background: true}).then(function() {
 
 ### After route changes
 
-Mithril automatically redraws after [`m.route.set()`](route.md#mrouteset) calls (or route changes via links that use [`m.route.link`](route.md#mroutelink)
+Mithril automatically redraws after [`m.route.set()`](route.md#mrouteset) calls and after route changes via links using [`m.route.Link`](route.md#mroutelink).
 
 ```javascript
 var RoutedComponent = {
 	view: function() {
 		return [
 			// a redraw happens asynchronously after the route changes
-			m("a", {href: "/", oncreate: m.route.link}),
+			m(m.route.Link, {href: "/"}),
 			m("div", {
 				onclick: function() {
 					m.route.set("/")

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -61,15 +61,15 @@
     - The `.schedule`, `.unschedule`, and `.render` properties of the former `redrawService` are all removed.
     - If you want to know how to work around it, look at the call to `mount` in Mithril's source for `m.route`. That should help you in finding ways around the removed feature. (It doesn't take that much more code.)
 - api: `m.version` has been removed. If you really need the version for whatever reason, just read the `version` field of `mithril/package.json` directly. ([#2466](https://github.com/MithrilJS/mithril.js/pull/2466) [@isiahmeadows](https://github.com/isiahmeadows))
-- route: `m.route.prefix(...)` is now `m.route.prefix = ...`.
+- route: `m.route.prefix(...)` is now `m.route.prefix = ...`. ([#2469](https://github.com/MithrilJS/mithril.js/pull/2469) [@isiahmeadows](https://github.com/isiahmeadows))
     - This is a fully fledged property, so you can not only write to it, but you can also read from it.
     - This aligns better with user intuition.
-- route: `m.route.link` function removed in favor of `m.route.Link` component.
+- route: `m.route.link` function removed in favor of `m.route.Link` component. ([#2469](https://github.com/MithrilJS/mithril.js/pull/2469) [@isiahmeadows](https://github.com/isiahmeadows))
     - An optional `options` object is accepted as an attribute. This was initially targeting the old `m.route.link` function and was transferred to this. ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
     - The new component handles many more edge cases around user interaction, including accessibility.
     - Link navigation can be disabled and cancelled.
     - Link targets can be trivially changed.
-- API: Full DOM no longer required to execute `require("mithril")`. You just need to set the necessary globals to *something*, even if `null` or `undefined`, so they can be properly used.
+- API: Full DOM no longer required to execute `require("mithril")`. You just need to set the necessary globals to *something*, even if `null` or `undefined`, so they can be properly used. ([#2469](https://github.com/MithrilJS/mithril.js/pull/2469) [@isiahmeadows](https://github.com/isiahmeadows))
     - This enables isomorphic use of `m.route.Link` and `m.route.prefix`.
     - This enables isomorphic use of `m.request`, provided the `background: true` option is set and that an `XMLHttpRequest` polyfill is included as necessary.
     - Note that methods requiring DOM operations will still throw errors, such as `m.render(...)`, `m.redraw()`, and `m.route(...)`.

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -63,9 +63,16 @@
 - api: `m.version` has been removed. If you really need the version for whatever reason, just read the `version` field of `mithril/package.json` directly. ([#2466](https://github.com/MithrilJS/mithril.js/pull/2466) [@isiahmeadows](https://github.com/isiahmeadows))
 - route: `m.route.prefix(...)` is now `m.route.prefix = ...`.
     - This is a fully fledged property, so you can not only write to it, but you can also read from it.
+    - This aligns better with user intuition.
 - route: `m.route.link` function removed in favor of `m.route.Link` component.
     - An optional `options` object is accepted as an attribute. This was initially targeting the old `m.route.link` function and was transferred to this. ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
-    - The new component handles many more edge cases around user interaction.
+    - The new component handles many more edge cases around user interaction, including accessibility.
+    - Link navigation can be disabled and cancelled.
+    - Link targets can be trivially changed.
+- API: Full DOM no longer required to execute `require("mithril")`. You just need to set the necessary globals to *something*, even if `null` or `undefined`, so they can be properly used.
+    - This enables isomorphic use of `m.route.Link` and `m.route.prefix`.
+    - This enables isomorphic use of `m.request`, provided the `background: true` option is set and that an `XMLHttpRequest` polyfill is included as necessary.
+    - Note that methods requiring DOM operations will still throw errors, such as `m.render(...)`, `m.redraw()`, and `m.route(...)`.
 
 
 #### News

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -61,6 +61,11 @@
     - The `.schedule`, `.unschedule`, and `.render` properties of the former `redrawService` are all removed.
     - If you want to know how to work around it, look at the call to `mount` in Mithril's source for `m.route`. That should help you in finding ways around the removed feature. (It doesn't take that much more code.)
 - api: `m.version` has been removed. If you really need the version for whatever reason, just read the `version` field of `mithril/package.json` directly. ([#2466](https://github.com/MithrilJS/mithril.js/pull/2466) [@isiahmeadows](https://github.com/isiahmeadows))
+- route: `m.route.prefix(...)` is now `m.route.prefix = ...`.
+    - This is a fully fledged property, so you can not only write to it, but you can also read from it.
+- route: `m.route.link` function removed in favor of `m.route.Link` component.
+    - An optional `options` object is accepted as an attribute. This was initially targeting the old `m.route.link` function and was transferred to this. ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
+    - The new component handles many more edge cases around user interaction.
 
 
 #### News
@@ -68,7 +73,6 @@
 - Mithril now only officially supports IE11, Firefox ESR, and the last two versions of Chrome/FF/Edge/Safari. ([#2296](https://github.com/MithrilJS/mithril.js/pull/2296))
 - API: Introduction of `m.redraw.sync()` ([#1592](https://github.com/MithrilJS/mithril.js/pull/1592))
 - API: Event handlers may also be objects with `handleEvent` methods ([#1949](https://github.com/MithrilJS/mithril.js/pull/1949), [#2222](https://github.com/MithrilJS/mithril.js/pull/2222)).
-- API: `m.route.link` accepts an optional `options` object ([#1930](https://github.com/MithrilJS/mithril.js/pull/1930))
 - API: `m.request` better error message on JSON parse error - ([#2195](https://github.com/MithrilJS/mithril.js/pull/2195), [@codeclown](https://github.com/codeclown))
 - API: `m.request` supports `timeout` as attr - ([#1966](https://github.com/MithrilJS/mithril.js/pull/1966))
 - API: `m.request` supports `responseType` as attr - ([#2193](https://github.com/MithrilJS/mithril.js/pull/2193))

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -99,6 +99,7 @@
 - API: `m.buildPathname` and `m.parsePathname` added. ([#2361](https://github.com/MithrilJS/mithril.js/pull/2361))
 - route: Use `m.mount(root, null)` to unsubscribe and clean up after a `m.route(root, ...)` call. ([#2453](https://github.com/MithrilJS/mithril.js/pull/2453))
 - render: new `redraw` parameter exposed any time a child event handler is used ([#2458](https://github.com/MithrilJS/mithril.js/pull/2458) [@isiahmeadows](https://github.com/isiahmeadows))
+- route: `m.route.SKIP` can be returned from route resolvers to skip to the next route ([#2469](https://github.com/MithrilJS/mithril.js/pull/2469) [@isiahmeadows](https://github.com/isiahmeadows))
 
 #### Bug fixes
 

--- a/docs/hyperscript.md
+++ b/docs/hyperscript.md
@@ -44,7 +44,7 @@ You can also use an HTML-like syntax called [JSX](jsx.md), using Babel to conver
 
 Argument     | Type                                       | Required | Description
 ------------ | ------------------------------------------ | -------- | ---
-`selector`   | `String|Object`                            | Yes      | A CSS selector or a [component](components.md)
+`selector`   | `String|Object|Function`                   | Yes      | A CSS selector or a [component](components.md)
 `attrs`      | `Object`                                   | No       | HTML attributes or element properties
 `children`   | `Array<Vnode>|String|Number|Boolean`       | No       | Child [vnodes](vnodes.md#structure). Can be written as [splat arguments](signatures.md#splats)
 **returns**  | `Vnode`                                    |          | A [vnode](vnodes.md#structure)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ It's small (< 10kb gzip), fast and provides routing and XHR utilities out of the
 <div style="display:flex;margin:0 0 30px;">
 	<div style="width:50%;">
 		<h5>Download size</h5>
-		<small>Mithril (9.4kb)</small>
+		<small>Mithril (9.5kb)</small>
 		<div style="animation:grow 0.08s;background:#1e5799;height:3px;margin:0 10px 10px 0;transform-origin:0;width:4%;"></div>
 		<small style="color:#aaa;">Vue + Vue-Router + Vuex + fetch (40kb)</small>
 		<div style="animation:grow 0.4s;background:#1e5799;height:3px;margin:0 10px 10px 0;transform-origin:0;width:20%"></div>

--- a/docs/signatures.md
+++ b/docs/signatures.md
@@ -53,3 +53,31 @@ For example, `parseFloat` has the signature `String -> Number`, i.e. it takes a 
 
 Functions with multiple arguments are denoted with parenthesis: `(String, Array) -> Number`
 
+---
+
+### Component signatures
+
+Components are denoted via calls to `m`, but with the selector argument set to a constant named in the relevant prose:
+
+`vnode = m(m.route.Link, attributes, children)`
+
+Argument               | Type                                 | Required | Description
+---------------------- | ------------------------------------ | -------- | ---
+`attributes.href`      | `Object`                             | Yes      | The target route to navigate to.
+`attributes.component` | `String|Object|Function`             | No      | This sets the tag name to use. Must be a valid selector for [`m`](hyperscript.md) if given, defaults to `"a"`.
+`attributes.options`   | `Object`                             | No      | This sets the options passed to [`m.route.set`](#mrouteset).
+`attributes`           | `Object`                             | No       | Other attributes to apply to the returned vnode may be passed.
+`children`             | `Array<Vnode>|String|Number|Boolean` | No       | Child [vnodes](vnodes.md) for this link.
+**returns**            | `Vnode`                              |          | A [vnode](vnodes.md).
+
+Children here, if specified, are assumed to be able to be written as [splat arguments](#splats), unless otherwise specified in prose.
+
+An element with no sensible children and/or attributes may elect to elide the relevant parameter entirely, so it might look closer to this:
+
+`vnode = m(Component, attributes)`
+
+Argument          | Type     | Required | Description
+----------------- | -------- | -------- | ---
+`attributes.href` | `Object` | Yes      | The
+`attributes`      | `Object` | No       | Other attributes to apply to the returned vnode
+**returns**       | `Vnode`  |          | A [vnode](vnodes.md)

--- a/docs/simple-application.md
+++ b/docs/simple-application.md
@@ -447,13 +447,16 @@ module.exports = {
 	oninit: User.loadList,
 	view: function() {
 		return m(".user-list", User.list.map(function(user) {
-			return m("a.user-list-item", {href: "/edit/" + user.id, oncreate: m.route.link}, user.firstName + " " + user.lastName)
+			return m(m.route.Link, {
+				class: "user-list-item",
+				href: "/edit/" + user.id,
+			}, user.firstName + " " + user.lastName)
 		}))
 	}
 }
 ```
 
-Here we changed `.user-list-item` to `a.user-list-item`. We added an `href` that references the route we want, and finally we added `oncreate: m.route.link`. This makes the link behave like a routed link (as opposed to merely behaving like a regular link). What this means is that clicking the link would change the part of URL that comes after the hashbang `#!` (thus changing the route without unloading the current HTML page)
+Here we swapped out the `.user-list-item` vnode with an `m.route.Link` with that class and the same children. We added an `href` that references the route we want. What this means is that clicking the link would change the part of URL that comes after the hashbang `#!` (thus changing the route without unloading the current HTML page). Behind the scenes, it uses an `<a>` to implement the link, and it all just works.
 
 If you refresh the page in the browser, you should now be able to click on a person and be taken to a form. You should also be able to press the back button in the browser to go back from the form to the list of people.
 
@@ -555,7 +558,7 @@ module.exports = {
 	view: function(vnode) {
 		return m("main.layout", [
 			m("nav.menu", [
-				m("a[href='/list']", {oncreate: m.route.link}, "Users")
+				m(m.route.Link, {href: "/list"}, "Users")
 			]),
 			m("section", vnode.children)
 		])
@@ -563,7 +566,7 @@ module.exports = {
 }
 ```
 
-This component is fairly straightforward, it has a `<nav>` with a link to the list of users. Similar to what we did to the `/edit` links, this link uses `m.route.link` to activate routing behavior in the link.
+This component is fairly straightforward, it has a `<nav>` with a link to the list of users. Similar to what we did to the `/edit` links, this link uses `m.route.Link` to create a routable link.
 
 Notice there's also a `<section>` element with `vnode.children` as children. `vnode` is a reference to the vnode that represents an instance of the Layout component (i.e. the vnode returned by a `m(Layout)` call). Therefore, `vnode.children` refer to any children of that vnode.
 

--- a/examples/threaditjs/app.js
+++ b/examples/threaditjs/app.js
@@ -83,7 +83,7 @@ var Header = {
 				m("a[href='http://threaditjs.com']", "ThreaditJS Home"),
 			]),
 			m("h2", [
-				m("a[href='/']", {oncreate: m.route.link}, "ThreaditJS: Mithril"),
+				m(m.route.Link, {href: "/"}, "ThreaditJS: Mithril"),
 			]),
 		]
 	}
@@ -102,7 +102,7 @@ var Home = {
 					threads.map(function(thread) {
 						return [
 							m("p", [
-								m("a", {href: "/thread/" + thread.id, oncreate: m.route.link}, m.trust(T.trimTitle(thread.text))),
+								m(m.route.Link, {href: "/thread/" + thread.id}, m.trust(T.trimTitle(thread.text))),
 							]),
 							m("p.comment_count", thread.comment_count + " comment(s)"),
 							m("hr"),

--- a/examples/todomvc/todomvc.js
+++ b/examples/todomvc/todomvc.js
@@ -115,9 +115,9 @@ var Todos = {
 					state.remaining === 1 ? " item left" : " items left",
 				]),
 				m("ul#filters", [
-					m("li", m("a[href='/']", {oncreate: m.route.link, class: state.showing === "" ? "selected" : ""}, "All")),
-					m("li", m("a[href='/active']", {oncreate: m.route.link, class: state.showing === "active" ? "selected" : ""}, "Active")),
-					m("li", m("a[href='/completed']", {oncreate: m.route.link, class: state.showing === "completed" ? "selected" : ""}, "Completed")),
+					m("li", m(m.route.Link, {href: "/", class: state.showing === "" ? "selected" : ""}, "All")),
+					m("li", m(m.route.Link, {href: "/active", class: state.showing === "active" ? "selected" : ""}, "Active")),
+					m("li", m(m.route.Link, {href: "/completed", class: state.showing === "completed" ? "selected" : ""}, "Completed")),
 				]),
 				m("button#clear-completed", {onclick: function() {state.dispatch("clear")}}, "Clear completed"),
 			]) : null,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "node bundler/cli browser.js -output mithril.js -watch",
     "build": "npm run build-browser & npm run build-min",
     "build-browser": "node bundler/cli browser.js -output mithril.js",
-    "build-min": "node bundler/cli browser.js -output mithril.min.js -minify",
+    "build-min": "node bundler/cli browser.js -output mithril.min.js -minify -save",
     "precommit": "lint-staged",
     "lintdocs": "node docs/lint",
     "gendocs": "node docs/generate",

--- a/render/render.js
+++ b/render/render.js
@@ -3,7 +3,7 @@
 var Vnode = require("../render/vnode")
 
 module.exports = function($window) {
-	var $doc = $window.document
+	var $doc = $window && $window.document
 	var currentRedraw
 
 	var nameSpace = {

--- a/render/tests/test-render.js
+++ b/render/tests/test-render.js
@@ -12,6 +12,10 @@ o.spec("render", function() {
 		render = vdom($window)
 	})
 
+	o("initializes without DOM", function() {
+		vdom()
+	})
+
 	o("renders plain text", function() {
 		render(root, "a")
 		o(root.childNodes.length).equals(1)

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -104,7 +104,7 @@ o.spec("api", function() {
 				})
 				o("m.route.prefix", function(done) {
 					root = window.document.createElement("div")
-					m.route.prefix("#")
+					m.route.prefix = "#"
 					m.route(root, "/a", {
 						"/a": createComponent({view: function() {return m("div")}})
 					})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- `m.route.prefix(...)` &rarr; `m.route.prefix = ...`
- `oncreate: m.route.link` &rarr; `m(m.route.Link, ...)`
- Add `m.route.SKIP`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2387
Fixes #2072
Fixes #1792 
Fixes #2354 (not in the way they wanted, but it at leasts unblocks them)
Fixes quite a few issues reported on Gitter.

For `m.route.Link`:

- More intuitive
- More accessible
- More ergonomic
- It can be disabled
- It can be cancelled
- It can be changed
- Oh, and you can use it isomorphically.

For `m.route.prefix`

- You can *read* it.
- You can write to it, of course.
- It's literally just setting a property.

For `m.route.SKIP`

- You can type-check routes, now.
- You can hide routes and pretend they don't exist.
- You can check existence of something and fall back later.

For the router itself (and the rest of Mithril):

- You can now `require("mithril")` and all its submodules without a DOM at all. There is a catch: you can't instantiate any routes, you can't mount anything, and you can't invoke `m.render` in any capacity. You can only use `m.route.Link`, `m.route.prefix`, hyperscript stuff, and `mithril/stream`, and you can use `m.request` with `background: true` if you use a global XHR polyfill. (You can't use `m.request` without `background: true` except with a DOM to redraw with.) The goal here is to try to get out of the way for simple testing and to defer the inevitable `TypeError`s for the relevant DOM methods to runtime.

	The factory requires no arguments, and in terms of globals, you can just figure out based on what errors are thrown what globals to define. Their values don't matter - they just need to be set to *something*, even if it's just `null` or `undefined`, before Mithril executes.

Had to make quite a few other changes throughout the docs and tests to
update them accordingly. Oh, and that massive router overhaul enabled me
to do all this.

Also, slip in a few drive-by fixes to the mocks so they're a little
easier to work with and can accept more URLs. This was required for a
few of the tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added and updated a *lot* of tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated `docs/change-log.md`
