### PR TITLE
fix es6.md

### DIFF
--- a/docs/es6.md
+++ b/docs/es6.md
@@ -19,10 +19,10 @@ Once you've got that downloaded, open a terminal and run these commands:
 
 ```bash
 # Replace this with the actual path to your project. Quote it if it has spaces,
-# and single-quote it if you're on Linux/Mac and it contains a `$` anywhere.
+# and single-quote it if you're on Linux/Mac and it contains a $ anywhere.
 cd "/path/to/your/project"
 
-# If you have a `package.json` there already, skip this command.
+# If you have a package.json there already, skip this command.
 npm init
 ```
 


### PR DESCRIPTION
It seems hard to display a backticked `$` in a bash code block within a comment, so my suggestion is to remove the backticks in the whole code block (for consistency), as I've done here.