### PR TITLE
Fix ospec --require with relative paths

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -17,6 +17,8 @@
 
 ### Upcoming...
 
+- Fix `ospec require` with relative paths
+
 -->
 
 ### v2.0.3

--- a/ospec/bin/ospec
+++ b/ospec/bin/ospec
@@ -30,7 +30,7 @@ var cwd = process.cwd()
 if (args.require) {
 	args.require.forEach(function(module) {
 		// eslint-disable-next-line global-require
-		if (module) require(require.resolve(module, {basedir: cwd}))
+		if (module) require(require.resolve(module, {paths: [cwd]}))
 	})
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix `ospec --require` with relative paths
The `basedir` option passed to `require.resolve` doesn't seem to be supported for the node implementation of require (https://nodejs.org/api/modules.html#modules_require_resolve_request_options)

Instead, there is a `paths` argument. Replacing `{basedir: cwd}` with `{paths: [cwd]}` fixes this.

## Motivation and Context
This fixes this issue https://github.com/MithrilJS/mithril.js/issues/2489

## How Has This Been Tested?
Locally installed ospec module and tested that `ospec/bin/ospec` works as specified in https://mithril.js.org/testing.html
Ran `npm test` locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ x ] I have updated `docs/change-log.md`
