### PR TITLE
docs: Add release dates to all change-log files

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -25,6 +25,7 @@
 - Fix error on `m.trust` updating ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))
 
 ### v2.0.3
+_2019-07-28_
 
 - Ensure vnodes are removed correctly in the face of `onbeforeremove` resolving after new nodes are added ([#2492](https://github.com/MithrilJS/mithril.js/pull/2492) [@isiahmeadows](https://github.com/isiahmeadows))
 - Fix prototype pollution vulnerability in `m.parseQueryString` ([#2494](https://github.com/MithrilJS/mithril.js/pull/2494) [@isiahmeadows](https://github.com/isiahmeadows))
@@ -32,10 +33,12 @@
 *v2.0.2 was skipped as it had a critical flaw and was immediately unpublished.*
 
 ### v2.0.1
+_2019-07-24_
 
 Same as v2.0.0, but with a publish that didn't have a botched upload.
 
 ### v2.0.0
+_2019-07-24_
 
 #### Breaking changes
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -20,6 +20,7 @@
 -->
 
 ### v2.0.4
+_2019-08-18_
 
 - Fix double-rendering of trusted content within `contenteditable` elements ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))
 - Fix error on `m.trust` updating ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -15,6 +15,8 @@
 ### Upcoming...
 
 ### 4.0.1
+_2019-08-18_
+
 - Fix `require` with relative paths
 
 ### 4.0.0

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -18,9 +18,13 @@
 - Fix `require` with relative paths
 
 ### 4.0.0
+_2019-07-24_
+
 - Pull ESM support out
 
 ### 3.1.0
+_2019-02-07_
+
 - ospec: Test results now include `.message` and `.context` regardless of whether the test passed or failed. (#2227 @robertakarobin)
 <!-- Add new lines here. Version number will be decided later -->
 - Add `spy.calls` array property to get the `this` and `arguments` values for any arbitrary call. (#2221 @isiahmeadows)
@@ -28,11 +32,13 @@
 - Update `glob` dependency.
 
 ### 3.0.1
+_2018-06-30_
 
 #### Bug fix
 - Move `glob` from `devDependencies` to `dependencies`, fix the test runner ([#2186](https://github.com/MithrilJS/mithril.js/pull/2186) [@porsager](https://github.com/porsager)
 
 ### 3.0.0
+_2018-06-26_
 
 #### Breaking
 - Better input checking to prevent misuses of the library. Misues of the library will now throw errors, rather than report failures. This may uncover bugs in your test suites. Since it is potentially a disruptive update this change triggers a semver major bump. ([#2167](https://github.com/MithrilJS/mithril.js/pull/2167))
@@ -53,6 +59,7 @@
 - Fix a stack overflow when using `o.only()` with a large test suite ([#2171](https://github.com/MithrilJS/mithril.js/pull/2171))
 
 ### 2.1.0
+_2018-05-25_
 
 #### Features
 - Pinpoint the `o.only()` call site ([#2157](https://github.com/MithrilJS/mithril.js/pull/2157))
@@ -63,6 +70,7 @@
 
 
 ### 2.0.0
+_2018-05-09_
 
 - Added `--require` feature to the ospec executable ([#2144](https://github.com/MithrilJS/mithril.js/pull/2144), [@gilbert](https://github.com/gilbert))
 - In Node.js, ospec only uses colors when the output is sent to a terminal ([#2143](https://github.com/MithrilJS/mithril.js/pull/2143))
@@ -78,12 +86,14 @@
 
 
 ### 1.4.1
+_2018-05-03_
 
 - Identical to v1.4.0, but with UNIX-style line endings so that BASH is happy.
 
 
 
 ### 1.4.0
+_2017-12-01_
 
 - Added support for async functions and promises in tests ([#1928](https://github.com/MithrilJS/mithril.js/pull/1928), [@StephanHoyer](https://github.com/StephanHoyer))
 - Error handling for async tests with `done` callbacks supports error as first argument ([#1928](https://github.com/MithrilJS/mithril.js/pull/1928))

--- a/stream/change-log.md
+++ b/stream/change-log.md
@@ -7,6 +7,8 @@
 ### Upcoming...
 
 ### 2.0.0
+_2019-02-07_
+
 - when a stream conditionally returns HALT, dependant stream will also end ([#2200](https://github.com/MithrilJS/mithril.js/pull/2200), [#2369](https://github.com/MithrilJS/mithril.js/pull/2369))
 - Add `stream.lift` as a user-friendly alternative to `merge -> map` or `combine` ([#1944](https://github.com/MithrilJS/mithril.js/issues/1944))
 - renamed HALT to SKIP ([#2207](https://github.com/MithrilJS/mithril.js/pull/2207))
@@ -15,4 +17,6 @@
 - fixed `stream.end` propagation ([#2369](https://github.com/MithrilJS/mithril.js/pull/2369))
 
 ### 1.1.0
+_2017-07-13_
+
 - Move the "use strict" directive inside the IIFE [#1831](https://github.com/MithrilJS/mithril.js/issues/1831) ([#1893](https://github.com/MithrilJS/mithril.js/pull/1893))


### PR DESCRIPTION
I'd like to introduce release dates to the change log files.
Release dates are human-friendly and add a bit of historical perspective to change-log files.

@pygy [liked it](https://github.com/MithrilJS/mithril.js/pull/2139/files/87796d612861bb4f770d6631252b71cec7912821#r186195052) when I added dates to the original ospec/change-log.md, but then later they got purged for the sake of cross-changelog consistency, and at my objection @isiahmeadows [suggested](https://github.com/MithrilJS/mithril.js/commit/beb129c5fbf11810a47d3b12d60b55e4b52806bc#r32254656) I make a PR adding dates across the board.

Better late than never, I guess...