### PR TITLE
Unbreak `m.trust`

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -18,6 +18,8 @@
 ### Upcoming...
 
 - Fix `ospec require` with relative paths
+- Fix double-rendering of trusted content within `contenteditable` elements ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))
+- Fix error on `m.trust` updating ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))
 
 -->
 

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -17,7 +17,6 @@
 
 ### Upcoming...
 
-- Fix `ospec require` with relative paths
 - Fix double-rendering of trusted content within `contenteditable` elements ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))
 - Fix error on `m.trust` updating ([#2516](https://github.com/MithrilJS/mithril.js/pull/2516) [@isiahmeadows](https://github.com/isiahmeadows))
 

--- a/ospec/change-log.md
+++ b/ospec/change-log.md
@@ -12,6 +12,7 @@
 - [1.3 and earlier](#13-and-earlier)
 
 ### Upcoming...
+- Fix `require` with relative paths
 
 ### 4.0.0
 - Pull ESM support out

--- a/render/render.js
+++ b/render/render.js
@@ -608,13 +608,14 @@ module.exports = function($window) {
 		if (vnode.attrs == null || (
 			vnode.attrs.contenteditable == null && // attribute
 			vnode.attrs.contentEditable == null // property
-		)) return
+		)) return false
 		var children = vnode.children
 		if (children != null && children.length === 1 && children[0].tag === "<") {
 			var content = children[0].children
 			if (vnode.dom.innerHTML !== content) vnode.dom.innerHTML = content
 		}
 		else if (vnode.text != null || children != null && children.length !== 0) throw new Error("Child node of a contenteditable must be trusted")
+		return true
 	}
 
 	//remove

--- a/render/render.js
+++ b/render/render.js
@@ -434,7 +434,11 @@ module.exports = function($window) {
 			removeHTML(parent, old)
 			createHTML(parent, vnode, ns, nextSibling)
 		}
-		else vnode.dom = old.dom, vnode.domSize = old.domSize
+		else {
+			vnode.dom = old.dom
+			vnode.domSize = old.domSize
+			vnode.instance = old.instance
+		}
 	}
 	function updateFragment(parent, old, vnode, hooks, nextSibling, ns) {
 		updateNodes(parent, old.children, vnode.children, hooks, nextSibling, ns)

--- a/render/tests/test-createHTML.js
+++ b/render/tests/test-createHTML.js
@@ -81,4 +81,14 @@ o.spec("createHTML", function() {
 		o(vnode.dom.nextSibling.nodeName).equals("text")
 		o(vnode.dom.nextSibling.namespaceURI).equals("http://www.w3.org/2000/svg")
 	})
+	o("creates the dom correctly with a contenteditable parent", function() {
+		var div = {tag: "div", attrs: {contenteditable: true}, children: [{tag: "<", children: "<a></a>"}]}
+
+		render(root, div)
+		var tags = []
+		for (var i = 0; i < div.dom.childNodes.length; i++) {
+			tags.push(div.dom.childNodes[i].nodeName)
+		}
+		o(tags).deepEquals(["A"])
+	})
 })

--- a/render/tests/test-updateHTML.js
+++ b/render/tests/test-updateHTML.js
@@ -47,14 +47,68 @@ o.spec("updateHTML", function() {
 		o(updated.domSize).equals(0)
 		o(root.childNodes.length).equals(0)
 	})
+	function childKeysOf(elem, key) {
+		var keys = key.split(".")
+		var result = []
+		for (var i = 0; i < elem.childNodes.length; i++) {
+			var child = elem.childNodes[i]
+			for (var j = 0; j < keys.length; j++) child = child[keys[j]]
+			result.push(child)
+		}
+		return result
+	}
 	o("updates the dom correctly with a contenteditable parent", function() {
 		var div = {tag: "div", attrs: {contenteditable: true}, children: [{tag: "<", children: "<a></a>"}]}
 
 		render(root, div)
-		var tags = []
-		for (var i = 0; i < div.dom.childNodes.length; i++) {
-			tags.push(div.dom.childNodes[i].nodeName)
-		}
-		o(tags).deepEquals(["A"])
+		o(childKeysOf(div.dom, "nodeName")).deepEquals(["A"])
+	})
+	o("updates dom with multiple text children", function() {
+		var vnode = [{tag: "#", children: "a"}, {tag: "<", children: "<a></a>"}, {tag: "<", children: "<b></b>"}]
+		var replacement = [{tag: "#", children: "a"}, {tag: "<", children: "<c></c>"}, {tag: "<", children: "<d></d>"}]
+
+		render(root, vnode)
+		render(root, replacement)
+
+		o(childKeysOf(root, "nodeName")).deepEquals(["#text", "C", "D"])
+	})
+	o("updates dom with multiple text children in other parents", function() {
+		var vnode = [
+			{tag: "div", attrs: {}, children: [{tag: "#", children: "a"}, {tag: "<", children: "<a></a>"}]},
+			{tag: "div", attrs: {}, children: [{tag: "#", children: "b"}, {tag: "<", children: "<b></b>"}]},
+		]
+		var replacement = [
+			{tag: "div", attrs: {}, children: [{tag: "#", children: "c"}, {tag: "<", children: "<c></c>"}]},
+			{tag: "div", attrs: {}, children: [{tag: "#", children: "d"}, {tag: "<", children: "<d></d>"}]},
+		]
+
+		render(root, vnode)
+		render(root, replacement)
+
+		o(childKeysOf(root, "nodeName")).deepEquals(["DIV", "DIV"])
+		o(childKeysOf(root.childNodes[0], "nodeName")).deepEquals(["#text", "C"])
+		o(root.childNodes[0].firstChild.nodeValue).equals("c")
+		o(childKeysOf(root.childNodes[1], "nodeName")).deepEquals(["#text", "D"])
+		o(root.childNodes[1].firstChild.nodeValue).equals("d")
+	})
+	o("correctly diffs if followed by another trusted vnode", function() {
+		render(root, [
+			{tag: "<", children: "<span>A</span>"},
+			{tag: "<", children: "<span>A</span>"},
+		])
+		o(childKeysOf(root, "nodeName")).deepEquals(["SPAN", "SPAN"])
+		o(childKeysOf(root, "firstChild.nodeValue")).deepEquals(["A", "A"])
+		render(root, [
+			{tag: "<", children: "<span>B</span>"},
+			{tag: "<", children: "<span>A</span>"},
+		])
+		o(childKeysOf(root, "nodeName")).deepEquals(["SPAN", "SPAN"])
+		o(childKeysOf(root, "firstChild.nodeValue")).deepEquals(["B", "A"])
+		render(root, [
+			{tag: "<", children: "<span>B</span>"},
+			{tag: "<", children: "<span>B</span>"},
+		])
+		o(childKeysOf(root, "nodeName")).deepEquals(["SPAN", "SPAN"])
+		o(childKeysOf(root, "firstChild.nodeValue")).deepEquals(["B", "B"])
 	})
 })

--- a/render/tests/test-updateHTML.js
+++ b/render/tests/test-updateHTML.js
@@ -47,4 +47,14 @@ o.spec("updateHTML", function() {
 		o(updated.domSize).equals(0)
 		o(root.childNodes.length).equals(0)
 	})
+	o("updates the dom correctly with a contenteditable parent", function() {
+		var div = {tag: "div", attrs: {contenteditable: true}, children: [{tag: "<", children: "<a></a>"}]}
+
+		render(root, div)
+		var tags = []
+		for (var i = 0; i < div.dom.childNodes.length; i++) {
+			tags.push(div.dom.childNodes[i].nodeName)
+		}
+		o(tags).deepEquals(["A"])
+	})
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fix double-rendering of trusted content within `contenteditable` elements
- Fix error on `m.trust` updating

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2502 
Fixes #2498 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new tests for each and verified each failed without the appropriate fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
