### PR TITLE
Update fetch() browser support in docs

### DIFF
--- a/docs/request.md
+++ b/docs/request.md
@@ -494,7 +494,7 @@ Mithril's `m.request` uses `XMLHttpRequest` instead of `fetch()` for a number of
 - `fetch` is not fully standardized yet, and may be subject to specification changes.
 - `XMLHttpRequest` calls can be aborted before they resolve (e.g. to avoid race conditions in for instant search UIs).
 - `XMLHttpRequest` provides hooks for progress listeners for long running requests (e.g. file uploads).
-- `XMLHttpRequest` is supported by all browsers, whereas `fetch()` is not supported by Internet Explorer, Safari and Android (non-Chromium).
+- `XMLHttpRequest` is supported by all browsers, whereas `fetch()` is not supported by Internet Explorer and Android (non-Chromium).
 
 Currently, due to lack of browser support, `fetch()` typically requires a [polyfill](https://github.com/github/fetch), which is over 11kb uncompressed - nearly three times larger than Mithril's XHR module.
 

--- a/docs/request.md
+++ b/docs/request.md
@@ -494,7 +494,7 @@ Mithril's `m.request` uses `XMLHttpRequest` instead of `fetch()` for a number of
 - `fetch` is not fully standardized yet, and may be subject to specification changes.
 - `XMLHttpRequest` calls can be aborted before they resolve (e.g. to avoid race conditions in for instant search UIs).
 - `XMLHttpRequest` provides hooks for progress listeners for long running requests (e.g. file uploads).
-- `XMLHttpRequest` is supported by all browsers, whereas `fetch()` is not supported by Internet Explorer and Android (non-Chromium).
+- `XMLHttpRequest` is supported by all browsers, whereas `fetch()` is not supported by Internet Explorer and older Android (prior to 5.0 Lollipop).
 
 Currently, due to lack of browser support, `fetch()` typically requires a [polyfill](https://github.com/github/fetch), which is over 11kb uncompressed - nearly three times larger than Mithril's XHR module.
 


### PR DESCRIPTION
As [Can I use](https://caniuse.com/#feat=fetch) shows `fetch()` supported since Safari 10.1 and iOS Safari 10.3.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed Safari from the list of browsers that don't support `fetch()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This info is outdated.

Other changes to consider (not included in the pull request at the moment):

I don't know: if the first point is still valid or not, as both [Fetch](https://fetch.spec.whatwg.org/) and [XMLHttpRequest](https://xhr.spec.whatwg.org/) specifications were updated this month. Seems both are subject to specification changes.

The second point seems outdated: it's possible to cancel a request using a [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController). [Browser support](https://caniuse.com/#feat=abortcontroller) is almost the same as `fetch()`.

The third point is still valid: fetch standard [still misses upload progress hooks](https://github.com/whatwg/fetch/issues/607).

About the polyfill size there's [this polyfill](https://bundlephobia.com/result?p=unfetch@4.1.0): 1 kB min, 554 b min+gzip, without AbortController support. According to [BundlePhobia](https://bundlephobia.com/result?p=whatwg-fetch@3.0.0), whatwg-fetch is 7.9 kB min and 2.7 kB min+gzip, which raises a question: the "over 11kB" claim is from non-minified code? If so isn't it a bad metric, as it's affected by comments?

Seems the other points, like integration with the autoredrawing subsystem and interpolation, are still valid.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
