### PR TITLE
Make errors and their messages more accurate and helpful

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -17,6 +17,14 @@
 
 ### Upcoming...
 
+*Note for later: release as semver-minor.*
+
+- Improved error messages in multiple places. ([#2536](https://github.com/MithrilJS/mithril.js/pull/2536) [@isiahmeadows](https://github.com/isiahmeadows))
+- The redraw reentrancy check was moved from `m.mount` to `m.render` and its error message was updated accordingly. ([#2536](https://github.com/MithrilJS/mithril.js/pull/2536) [@isiahmeadows](https://github.com/isiahmeadows))
+    - This is unlikely to break people because if you were to do it with `m.render` directly before now, you'd corrupt Mithril's internal representation and internal errors could occur as a result. Now, it just warns you.
+- For a better debugging experience with `m.route` route resolvers, errors on `onmatch` in the default route are left unhandled and errors in `onmatch` in other routes are logged to the console before redirecting. ([#2536](https://github.com/MithrilJS/mithril.js/pull/2536) [@isiahmeadows](https://github.com/isiahmeadows))
+- Bug fix with `m.redraw` where if you removed a root that was previously visited in the current redraw pass, it would lose its place and skip the next root.
+
 -->
 
 ### v2.0.4

--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -14,12 +14,12 @@ else window.o = m()
 	}
 	function o(subject, predicate) {
 		if (predicate === undefined) {
-			if (!isRunning()) throw new Error("Assertions should not occur outside test definitions")
+			if (!isRunning()) throw new Error("Assertions should not occur outside test definitions.")
 			return new Assert(subject)
 		} else {
-			if (isRunning()) throw new Error("Test definitions and hooks shouldn't be nested. To group tests use `o.spec()`")
+			if (isRunning()) throw new Error("Test definitions and hooks shouldn't be nested. To group tests, use 'o.spec()'.")
 			subject = String(subject)
-			if (subject.charCodeAt(0) === 1) throw new Error("test names starting with '\\x01' are reserved for internal use")
+			if (subject.charCodeAt(0) === 1) throw new Error("test names starting with '\\x01' are reserved for internal use.")
 			ctx[unique(subject)] = new Task(predicate, ensureStackTrace(new Error))
 		}
 	}
@@ -28,9 +28,9 @@ else window.o = m()
 	o.beforeEach = hook("\x01beforeEach")
 	o.afterEach = hook("\x01afterEach")
 	o.specTimeout = function (t) {
-		if (isRunning()) throw new Error("o.specTimeout() can only be called before o.run()")
-		if (hasOwn.call(ctx, "\x01specTimeout")) throw new Error("A default timeout has already been defined in this context")
-		if (typeof t !== "number") throw new Error("o.specTimeout() expects a number as argument")
+		if (isRunning()) throw new Error("o.specTimeout() can only be called before o.run().")
+		if (hasOwn.call(ctx, "\x01specTimeout")) throw new Error("A default timeout has already been defined in this context.")
+		if (typeof t !== "number") throw new Error("o.specTimeout() expects a number as argument.")
 		ctx["\x01specTimeout"] = t
 	}
 	o.new = init
@@ -139,7 +139,7 @@ else window.o = m()
 				// public API, may only be called once from use code (or after returned Promise resolution)
 				function done(err) {
 					if (!isDone) isDone = true
-					else throw new Error("`" + arg + "()` should only be called once")
+					else throw new Error("'" + arg + "()' should only be called once.")
 					if (timeout === undefined) console.warn("# elapsed: " + Math.round(new Date - s) + "ms, expected under " + delay + "ms\n" + o.cleanStackTrace(task.err))
 					finalizeAsync(err)
 				}
@@ -161,7 +161,7 @@ else window.o = m()
 					}, Math.min(delay, 2147483647))
 				}
 				function setDelay (t) {
-					if (typeof t !== "number") throw new Error("timeout() and o.timeout() expect a number as argument")
+					if (typeof t !== "number") throw new Error("timeout() and o.timeout() expect a number as argument.")
 					delay = t
 				}
 				if (fn.length > 0) {
@@ -169,7 +169,7 @@ else window.o = m()
 					arg = (body.match(/^(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*=>/) || body.match(/\((?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)]/) || []).pop()
 					if (body.indexOf(arg) === body.lastIndexOf(arg)) {
 						var e = new Error
-						e.stack = "`" + arg + "()` should be called at least once\n" + o.cleanStackTrace(task.err)
+						e.stack = "'" + arg + "()' should be called at least once\n" + o.cleanStackTrace(task.err)
 						throw e
 					}
 					try {
@@ -204,14 +204,14 @@ else window.o = m()
 	}
 	function unique(subject) {
 		if (hasOwn.call(ctx, subject)) {
-			console.warn("A test or a spec named `" + subject + "` was already defined")
+			console.warn("A test or a spec named '" + subject + "' was already defined.")
 			while (hasOwn.call(ctx, subject)) subject += "*"
 		}
 		return subject
 	}
 	function hook(name) {
 		return function(predicate) {
-			if (ctx[name]) throw new Error("This hook should be defined outside of a loop or inside a nested test group:\n" + predicate)
+			if (ctx[name]) throw new Error(name.slice(1) + " should be defined outside of a loop or inside a nested test group.")
 			ctx[name] = new Task(predicate, ensureStackTrace(new Error))
 		}
 	}
@@ -317,7 +317,7 @@ else window.o = m()
 		try {return JSON.stringify(value)} catch (e) {return String(value)}
 	}
 	function noTimeoutRightNow() {
-		throw new Error("o.timeout must be called snchronously from within a test definition or a hook")
+		throw new Error("o.timeout must be called snchronously from within a test definition or a hook.")
 	}
 	var colorCodes = {
 		red: "31m",

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -532,7 +532,7 @@ o.spec("ospec", function() {
 					err = e
 				}
 				o(err instanceof Error).equals(true)
-				o(err.message).equals("`oodone()` should only be called once")
+				o(err.message).equals("'oodone()' should only be called once.")
 			})
 			oo.run(function(results) {
 				o(results.length).equals(1)
@@ -551,7 +551,7 @@ o.spec("ospec", function() {
 					err = e
 				}
 				o(err instanceof Error).equals(true)
-				o(err.message).equals("`oodone()` should only be called once")
+				o(err.message).equals("'oodone()' should only be called once.")
 			})
 			oo.run(function(results) {
 				o(results.length).equals(1)
@@ -570,7 +570,7 @@ o.spec("ospec", function() {
 					err = e
 				}
 				o(err instanceof Error).equals(true)
-				o(err.message).equals("`oodone()` should only be called once")
+				o(err.message).equals("'oodone()' should only be called once.")
 			})
 			oo.run(function(results) {
 				o(results.length).equals(1)
@@ -590,7 +590,7 @@ o.spec("ospec", function() {
 					err = e
 				}
 				o(err instanceof Error).equals(true)
-				o(err.message).equals("`oodone()` should only be called once")
+				o(err.message).equals("'oodone()' should only be called once.")
 			})
 			oo.run(function(results) {
 				o(results.length).equals(1)

--- a/pathname/build.js
+++ b/pathname/build.js
@@ -6,7 +6,7 @@ var assign = require("./assign")
 // Returns `path` from `template` + `params`
 module.exports = function(template, params) {
 	if ((/:([^\/\.-]+)(\.{3})?:/).test(template)) {
-		throw new SyntaxError("Template parameter names *must* be separated")
+		throw new SyntaxError("Template parameter names must be separated by either a '/', '-', or '.'.")
 	}
 	if (params == null) return template
 	var queryIndex = template.indexOf("?")

--- a/promise/polyfill.js
+++ b/promise/polyfill.js
@@ -1,8 +1,8 @@
 "use strict"
 /** @constructor */
 var PromisePolyfill = function(executor) {
-	if (!(this instanceof PromisePolyfill)) throw new Error("Promise must be called with `new`")
-	if (typeof executor !== "function") throw new TypeError("executor must be a function")
+	if (!(this instanceof PromisePolyfill)) throw new Error("Promise must be called with 'new'.")
+	if (typeof executor !== "function") throw new TypeError("executor must be a function.")
 
 	var self = this, resolvers = [], rejectors = [], resolveCurrent = handler(resolvers, true), rejectCurrent = handler(rejectors, false)
 	var instance = self._instance = {resolvers: resolvers, rejectors: rejectors}
@@ -12,7 +12,7 @@ var PromisePolyfill = function(executor) {
 			var then
 			try {
 				if (shouldAbsorb && value != null && (typeof value === "object" || typeof value === "function") && typeof (then = value.then) === "function") {
-					if (value === self) throw new TypeError("Promise can't be resolved w/ itself")
+					if (value === self) throw new TypeError("Promise can't be resolved with itself.")
 					executeOnce(then.bind(value))
 				}
 				else {

--- a/render/tests/test-render.js
+++ b/render/tests/test-render.js
@@ -329,4 +329,65 @@ o.spec("render", function() {
 		render(root.childNodes[0], [{tag: "g"}])
 		o(root.childNodes[0].childNodes[0].namespaceURI).equals("http://www.w3.org/2000/svg")
 	})
+	o("does not allow reentrant invocations", function() {
+		var thrown = []
+		function A() {
+			var updated = false
+			try {render(root, {tag: A})} catch (e) {thrown.push("construct")}
+			return {
+				oninit: function() {
+					try {render(root, {tag: A})} catch (e) {thrown.push("oninit")}
+				},
+				oncreate: function() {
+					try {render(root, {tag: A})} catch (e) {thrown.push("oncreate")}
+				},
+				onbeforeupdate: function() {
+					try {render(root, {tag: A})} catch (e) {thrown.push("onbeforeupdate")}
+				},
+				onupdate: function() {
+					if (updated) return
+					updated = true
+					try {render(root, {tag: A})} catch (e) {thrown.push("onupdate")}
+				},
+				onbeforeremove: function() {
+					try {render(root, {tag: A})} catch (e) {thrown.push("onbeforeremove")}
+				},
+				onremove: function() {
+					try {render(root, {tag: A})} catch (e) {thrown.push("onremove")}
+				},
+				view: function() {
+					try {render(root, {tag: A})} catch (e) {thrown.push("view")}
+				},
+			}
+		}
+		render(root, {tag: A})
+		o(thrown).deepEquals([
+			"construct",
+			"oninit",
+			"view",
+			"oncreate",
+		])
+		render(root, {tag: A})
+		o(thrown).deepEquals([
+			"construct",
+			"oninit",
+			"view",
+			"oncreate",
+			"onbeforeupdate",
+			"view",
+			"onupdate",
+		])
+		render(root, [])
+		o(thrown).deepEquals([
+			"construct",
+			"oninit",
+			"view",
+			"oncreate",
+			"onbeforeupdate",
+			"view",
+			"onupdate",
+			"onbeforeremove",
+			"onremove",
+		])
+	})
 })

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -18,7 +18,11 @@ Vnode.normalizeChildren = function(input) {
 		// it, noticeably so.
 		for (var i = 1; i < input.length; i++) {
 			if ((input[i] != null && input[i].key != null) !== isKeyed) {
-				throw new TypeError("Vnodes must either always have keys or never have keys!")
+				throw new TypeError(
+					isKeyed && (input[i] != null || typeof input[i] === "boolean")
+						? "In fragments, vnodes must either all have keys or none have keys. You may wish to consider using an explicit keyed empty fragment, m.fragment({key: ...}), instead of a hole."
+						: "In fragments, vnodes must either all have keys or none have keys."
+				)
 			}
 		}
 		for (var i = 0; i < input.length; i++) {

--- a/stream/stream.js
+++ b/stream/stream.js
@@ -96,7 +96,7 @@ function Stream(value) {
 function combine(fn, streams) {
 	var ready = streams.every(function(s) {
 		if (s.constructor !== Stream)
-			throw new Error("Ensure that each item passed to stream.combine/stream.merge/lift is a stream")
+			throw new Error("Ensure that each item passed to stream.combine/stream.merge/lift is a stream.")
 		return s._state === "active"
 	})
 	var stream = ready

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -304,6 +304,13 @@ module.exports = function(options) {
 					parentNode: null,
 					childNodes: [],
 					attributes: {},
+					contains: function(child) {
+						while (child != null) {
+							if (child === this) return true
+							child = child.parentNode
+						}
+						return false
+					},
 					get firstChild() {
 						return this.childNodes[0] || null
 					},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- I updated error messages to be much more helpful
- For consistency, I normalized error messages to all be sentences and using `'` instead of `` ` `` to denote code and characters.
- I moved the reentrancy check from `m.mount` to `m.render` to be a little more helpful and accurate and updated the router accordingly.
	- Technically breaking in the edge case of calling `m.redraw.sync()` inside `oncreate` when rendering from `m.mount` the first time, but the fix here is generally pretty simple and it matches what we've been communicating as reality for `m.mount`.
- I changed the check in `m.route` to align with `m.render`. Minor and you'd be running into errors anyways.
- I corrected `m.route` to propagate the thrown error if it was thrown from the default route's `onmatch`.
- I changed `m.route` to log errors from `onmatch` on routes other than the default route, before redirecting.
- I fixed an obscure race condition in `m.mount`/`m.redraw` where if you unmounted an already-visited root during a redraw pass, it could lose its place. This no longer occurs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2535 
Fixes an issue discussed on Gitter a few times a while back. (It's been long enough it'll be difficult to find.)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests and updated tests accordingly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
