### PR TITLE
ospec: Add support for asynchronous test with arrow functions.

### DIFF
--- a/ospec/ospec.js
+++ b/ospec/ospec.js
@@ -166,7 +166,7 @@ else window.o = m()
 				}
 				if (fn.length > 0) {
 					var body = fn.toString()
-					arg = (body.match(/^(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*=>/) || body.match(/\((?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)]/) || []).pop()
+					arg = (body.match(/\((.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)].*\s=>/) || body.match(/^(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*=>/) || body.match(/\((?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*(.+?)(?:\s|\/\*[\s\S]*?\*\/|\/\/.*?\n)*[,\)]/) || []).pop()
 					if (body.indexOf(arg) === body.lastIndexOf(arg)) {
 						var e = new Error
 						e.stack = "'" + arg + "()' should be called at least once\n" + o.cleanStackTrace(task.err)

--- a/ospec/tests/test-ospec.js
+++ b/ospec/tests/test-ospec.js
@@ -305,6 +305,17 @@ o.spec("ospec", function() {
 					done()
 				})
 			})
+			o("hooks work as intended the third time (arrow function)", (done) => {
+				callAsync(function() {
+					var spy = o.spy()
+					spy(a)
+
+					o(a).equals(1)
+					o(b).equals(1)
+
+					done()
+				})
+			})
 		})
 	})
 


### PR DESCRIPTION
ospec: Asynchronous tests doesn't work with arrow functions

## Description
Add support for asynchronous test with arrow functions.

## Motivation and Context
Fix for #2541.

## How Has This Been Tested?
Added test with arrow function to `ospec/tests/test-ospec.js`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
