### PR TITLE
docs: More info on using JSX with Mithril

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -187,7 +187,7 @@ You can use hooks in your production environment to run the production build scr
 #### Making `m` accessible globally
 In order to access `m` globally from all your project first import `webpack` in your `webpack.config.js` like this:
 ```
-const webpack = require('webpack');
+const webpack = require('webpack')
 ```
 Then create a new plugin in the `plugins` property of the Webpack configuration object:
 ```js
@@ -383,7 +383,7 @@ When using Mithril's router it's recommended to use the `m.route.Link` component
 ```
 Or if you prefer:
 ```jsx
-const Link = m.route.Link;
+const Link = m.route.Link
 // and then in your JSX
 <Link href="/home">Go home</Link>
 ```

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -368,13 +368,13 @@ function SummaryView() {
 
 ---
 
-### Converting HTML
+### Tips and tricks
+
+#### Converting HTML
 
 In Mithril, well-formed HTML is generally valid JSX. Little more than just pasting raw HTML is required for things to just work. About the only things you'd normally have to do are change unquoted property values like `attr=value` to `attr="value"` and change void elements like `<input>` to `<input />`, this being due to JSX being based on XML and not HTML.
 
 When using hyperscript, you often need to translate HTML to hyperscript syntax to use it. To help speed up this process along, you can use a [community-created HTML-to-Mithril-template converter](https://arthurclemens.github.io/mithril-template-converter/index.html) to do much of it for you.
-
-### Tips and tricks
 
 #### Using `m.route.Link`
 

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -373,7 +373,7 @@ function SummaryView() {
 
 ### Tips and tricks
 
-#### Converting HTML
+#### Converting HTML to JSX
 
 In Mithril, well-formed HTML is generally valid JSX. Little more than just pasting raw HTML is required for things to just work. About the only things you'd normally have to do are change unquoted property values like `attr=value` to `attr="value"` and change void elements like `<input>` to `<input />`, this being due to JSX being based on XML and not HTML.
 

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -206,11 +206,15 @@ See [the Webpack docs](https://webpack.js.org/plugins/provide-plugin/) for more 
 ### Differences with React
 JSX in Mithril has some subtle but important differences compared to React's JSX.
 
-#### `class` vs `className`
-React follows a purist JavaScript approach hence `class` is a reserved word that cannot be used in JSX. In Mithril both are valid since we believe `class` is more idiomatic to HTML markup.
+#### Attribute and style property case conventions
+React requires you use the camel-cased DOM property names instead of HTML attribute names for all attributes other than `data-*` and `aria-*` attributes. For example using `className` instead of `class` and `htmlFor` instead of `for`. In Mithril, it's more idiomatic to use the lowercase HTML attribute names instead. Mithril always falls back to setting attributes if a property doesn't exist which aligns more intuitively with HTML. Note that in most cases, the DOM property and HTML attribute names are either the same or very similar. For example `value`/`checked` for inputs and the `tabindex` global attribute vs the `elem.tabIndex` property on HTML elements. Very rarely do they differ beyond case: the `elem.className` property for the `class` attribute or the `elem.htmlFor` property for the `for` attribute are among the few exceptions.
+
+Similarly, React always uses the camel-cased style property names exposed in the DOM via properties of `elem.style` (like `cssHeight` and `backgroundColor`). Mithril supports both that and the kebab-cased CSS property names (like `height` and `background-color`) and idiomatically prefers the latter. Only `cssHeight`, `cssFloat`, and vendor-prefixed properties differ in more than case.
 
 #### DOM events
-Mithril uses the native syntax for binding DOM events. Instead of using React's `onClick` or `onSubmit` syntax (which are handlers for its synthetic event system) you'd use the native `onclick` or `onsubmit`. Mithril supports all DOM element event bindings.
+React upper-cases the first character of all event handlers: `onClick` listens for `click` events and `onSubmit` for `submit` events. Some are further altered as they're multiple words concatenated together. For instance, `onMouseMove` listens for `mousemove` events. Mithril does not do this case mapping but instead just prepends `on` to the native event, so you'd add listeners for `onclick` and `onmousemove` to listen to those two events respectively. This corresponds much more closely to HTML's naming scheme and is much more intuitive if you come from an HTML or vanilla DOM background.
+
+React supports scheduling event listeners during the capture phase (in the first pass, out to in, as opposed to the default bubble phase going in to out in the second pass) by appending `Capture` to that event. Mithril currently lacks such functionality, but it could gain this in the future. If this is necessary you can manually add and remove your own listeners in [lifecycle hooks](lifecycle.md).
 
 ---
 

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -3,8 +3,10 @@
 - [Description](#description)
 - [Setup](#setup)
 - [Using Babel with Webpack](#using-babel-with-webpack)
+- [Differences with React](#differences-with-react)
 - [JSX vs hyperscript](#jsx-vs-hyperscript)
 - [Converting HTML](#converting-html)
+- [Tips and Tricks](#tips-and-tricks)
 
 ---
 
@@ -183,6 +185,34 @@ You can use hooks in your production environment to run the production build scr
 }
 ```
 
+#### Making `m` accessible globally
+To make `m` accessible globally to all your project first import `webpack` in `webpack.config.js` like this:
+```
+const webpack = require('webpack');
+```
+Then create a new plugin in the `plugins` property of the Webpack configuration object:
+```js
+{
+	plugins: [
+		new webpack.ProvidePlugin({
+			m: 'mithril'
+		})
+	]
+}
+```
+See [the Webpack docs](https://webpack.js.org/plugins/provide-plugin/) for more information on `ProvidePlugin`.
+
+---
+
+### Differences with React
+JSX in Mithril has some subtle but important differences compared to React's JSX.
+
+#### `class` vs `className`
+React follows a purist JavaScript approach hence `class` is a reserved word that cannot be used in JSX. In Mithril both are valid since we believe `class` is more idiomatic to HTML markup.
+
+#### DOM events
+Mithril uses the native syntax for binding DOM events. Instead of using React's `onClick` on `onSubmit` syntax (which are handlers for its synthetic event system) you'd use the native `onclick` or `onsubmit`. Mithril supports all DOM element events bindings.
+
 ---
 
 ### JSX vs hyperscript
@@ -343,3 +373,18 @@ function SummaryView() {
 In Mithril, well-formed HTML is generally valid JSX. Little more than just pasting raw HTML is required for things to just work. About the only things you'd normally have to do are change unquoted property values like `attr=value` to `attr="value"` and change void elements like `<input>` to `<input />`, this being due to JSX being based on XML and not HTML.
 
 When using hyperscript, you often need to translate HTML to hyperscript syntax to use it. To help speed up this process along, you can use a [community-created HTML-to-Mithril-template converter](https://arthurclemens.github.io/mithril-template-converter/index.html) to do much of it for you.
+
+### Tips and tricks
+
+#### Using `m.route.Link`
+
+When using Mithril's router it's recommended to use the `m.route.Link` component instead of the native `<a>` element to trigger route changes to prevent a full reload of the page. To use it in JSX you can simply:
+```jsx
+<m.route.Link href="/home">Go home</m.route.Link>
+```
+Or if you prefer:
+```jsx
+const Link = m.route.Link;
+// and then in your JSX
+<Link href="/home">Go home</Link>
+```

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -5,7 +5,6 @@
 - [Using Babel with Webpack](#using-babel-with-webpack)
 - [Differences with React](#differences-with-react)
 - [JSX vs hyperscript](#jsx-vs-hyperscript)
-- [Converting HTML](#converting-html)
 - [Tips and Tricks](#tips-and-tricks)
 
 ---

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -44,13 +44,14 @@ var link = <a href={url}>{greeting}!</a>
 // yields <a href="https://google.com">Hello!</a>
 ```
 
-Components can be used by using a convention of uppercasing the first letter of the component name:
+Components can be used by using a convention of uppercasing the first letter of the component name or by accessing it as a property:
 
 ```jsx
 m.render(document.body, <MyComponent />)
 // equivalent to m.render(document.body, m(MyComponent))
+<m.route.Link href="/home">Go home</m.route.Link>
+// equivalent to m(m.route.Link, {href: "/home"}, "Go home")
 ```
-
 ---
 
 ### Setup
@@ -378,16 +379,3 @@ function SummaryView() {
 In Mithril, well-formed HTML is generally valid JSX. Little more than just pasting raw HTML is required for things to just work. About the only things you'd normally have to do are change unquoted property values like `attr=value` to `attr="value"` and change void elements like `<input>` to `<input />`, this being due to JSX being based on XML and not HTML.
 
 When using hyperscript, you often need to translate HTML to hyperscript syntax to use it. To help speed up this process along, you can use a [community-created HTML-to-Mithril-template converter](https://arthurclemens.github.io/mithril-template-converter/index.html) to do much of it for you.
-
-#### Using `m.route.Link`
-
-When using Mithril's router it's recommended to use the `m.route.Link` component instead of the native `<a>` element to trigger route changes to prevent a full reload of the page. To use it in JSX you can simply:
-```jsx
-<m.route.Link href="/home">Go home</m.route.Link>
-```
-Or if you prefer:
-```jsx
-const Link = m.route.Link
-// and then in your JSX
-<Link href="/home">Go home</Link>
-```

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -186,7 +186,7 @@ You can use hooks in your production environment to run the production build scr
 ```
 
 #### Making `m` accessible globally
-To make `m` accessible globally to all your project first import `webpack` in `webpack.config.js` like this:
+In order to access `m` globally from all your project first import `webpack` in your `webpack.config.js` like this:
 ```
 const webpack = require('webpack');
 ```
@@ -211,7 +211,7 @@ JSX in Mithril has some subtle but important differences compared to React's JSX
 React follows a purist JavaScript approach hence `class` is a reserved word that cannot be used in JSX. In Mithril both are valid since we believe `class` is more idiomatic to HTML markup.
 
 #### DOM events
-Mithril uses the native syntax for binding DOM events. Instead of using React's `onClick` on `onSubmit` syntax (which are handlers for its synthetic event system) you'd use the native `onclick` or `onsubmit`. Mithril supports all DOM element events bindings.
+Mithril uses the native syntax for binding DOM events. Instead of using React's `onClick` or `onSubmit` syntax (which are handlers for its synthetic event system) you'd use the native `onclick` or `onsubmit`. Mithril supports all DOM element event bindings.
 
 ---
 


### PR DESCRIPTION
## Description
* Added a new section on configuring a Webpack plugin for having `m` globally accessible
* Added a new section with differences compared to React's JSX
* Added a new section with tips and tricks (and moved the "Converting HTML" in there)

## Motivation and Context
Expanding the info on using JSX so that Mithril is more approachable to users coming from React or other libraries/frameworks.

## How Has This Been Tested?
No testing...

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
