### PR TITLE
change link to go to ospec instead of mocha

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@
 
 ### Setup
 
-Testing Mithril applications is relatively easy. The easiest way to get started is with [ospec](https://github.com/MithrilJS/mithril.js/blob/next/ospec/README.md), [mithril-query](https://github.com/MithrilJS/mithril-query), and JSDOM. Installing those is pretty easy: open up a terminal and run this command.
+Testing Mithril applications is relatively easy. The easiest way to get started is with [ospec](https://github.com/MithrilJS/ospec), [mithril-query](https://github.com/MithrilJS/mithril-query), and JSDOM. Installing those is pretty easy: open up a terminal and run this command.
 
 ```bash
 npm install --save-dev ospec mithril-query jsdom

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -8,7 +8,7 @@
 
 ### Setup
 
-Testing Mithril applications is relatively easy. The easiest way to get started is with [ospec](https://mochajs.org/), [mithril-query](https://github.com/MithrilJS/mithril-query), and JSDOM. Installing those is pretty easy: open up a terminal and run this command.
+Testing Mithril applications is relatively easy. The easiest way to get started is with [ospec](https://github.com/MithrilJS/mithril.js/blob/next/ospec/README.md), [mithril-query](https://github.com/MithrilJS/mithril-query), and JSDOM. Installing those is pretty easy: open up a terminal and run this command.
 
 ```bash
 npm install --save-dev ospec mithril-query jsdom


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change the link to point to ospec docs in github.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ospec link went to mochajs 
<!--- If it fixes an open issue, please link to the issue here. -->
[issue 2575](https://github.com/MithrilJS/mithril.js/issues/2575)
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
N/A
<!--- Include details of your testing environment, and the tests you ran to -->
N/A
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
