### PR TITLE
reject request on XHR timeout

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -155,6 +155,13 @@ module.exports = function($window, Promise, oncompletion) {
 				}
 			}
 
+			xhr.ontimeout = function (ev) {
+				if (aborted) return;
+				var error = new Error("Request timeout");
+				error.timeout = ev.target.timeout;
+				reject(error);
+			}
+
 			if (typeof args.config === "function") {
 				xhr = args.config(xhr, args, url) || xhr
 

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -18,7 +18,9 @@ o.spec("request", function() {
 		o("works via GET", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function() {
-					return {status: 200, responseText: JSON.stringify({a: 1})}
+					return new Promise(function (resolve) {
+						resolve({status: 200, responseText: JSON.stringify({a: 1})})
+					})
 				}
 			})
 			request({method: "GET", url: "/item"}).then(function(data) {
@@ -694,7 +696,9 @@ o.spec("request", function() {
 		o("rejects on error in extract", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function() {
-					return {status: 200, responseText: JSON.stringify({a: 1})}
+					return new Promise(function (resolve) {
+						resolve({status: 200, responseText: JSON.stringify({a: 1})})
+					})
 				}
 			})
 			request({
@@ -704,6 +708,30 @@ o.spec("request", function() {
 				o(e instanceof Error).equals(true)
 				o(e.message).equals("error")
 			}).then(function() {
+				done()
+			})
+		})
+		o("rejects on timeout", function(done) {
+			var timeout = 50
+			var gotTimeoutError = false
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return new Promise(function (resolve) {
+						setTimeout(function () {
+							resolve({status: 200, responseText: JSON.stringify({a: 1})})
+						}, timeout*2)
+					})
+				}
+			})
+			request(
+				{method: "GET", url: "/item", timeout: timeout}
+			).catch(function(e) {
+				gotTimeoutError	 = true
+				o(e instanceof Error).equals(true)
+				o(e.message).equals("Request timeout")
+				o(e.timeout).equals(timeout)
+			}).then(function () {
+				o(gotTimeoutError).equals(true)
 				done()
 			})
 		})


### PR DESCRIPTION
Hacks xhrMock to support promises in the handlers so that a timeout
event can be fired and appropriately reject the request promise.

## Description

Adds a handler to XMLHttpRequests 'ontimeout' event so that request will reject client-side timeouts.

## Motivation and Context

Fixes https://github.com/MithrilJS/mithril.js/issues/2559

## How Has This Been Tested?

Tested with a test in test-request.js and also manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
