### PR TITLE
docs: Fix simple typo, subsequece -> subsequence

### DIFF
--- a/mithril.js
+++ b/mithril.js
@@ -778,7 +778,7 @@ var _12 = function($window) {
 	// takes a list of unique numbers (-1 is special and can
 	// occur multiple times) and returns an array with the indices
 	// of the items that are part of the longest increasing
-	// subsequece
+	// subsequence
 	var lisTemp = []
 	function makeLisIndices(a) {
 		var result = [0]

--- a/render/render.js
+++ b/render/render.js
@@ -514,7 +514,7 @@ module.exports = function($window) {
 	// takes a list of unique numbers (-1 is special and can
 	// occur multiple times) and returns an array with the indices
 	// of the items that are part of the longest increasing
-	// subsequece
+	// subsequence
 	var lisTemp = []
 	function makeLisIndices(a) {
 		var result = [0]


### PR DESCRIPTION
There is a small typo in mithril.js, render/render.js.

Should read `subsequence` rather than `subsequece`.

