### PR TITLE
ES6 and m.trust docs patch

### DIFF
--- a/docs/es6.md
+++ b/docs/es6.md
@@ -19,7 +19,7 @@ Once you've got that downloaded, open a terminal and run these commands:
 
 ```bash
 # Replace this with the actual path to your project. Quote it if it has spaces,
-# and single-quote it if you're on Linux/Mac and it contains a `$` anywhere.
+# and single-quote it if you're on Linux/Mac and it contains a `$$` anywhere.
 cd "/path/to/your/project"
 
 # If you have a `package.json` there already, skip this command.

--- a/docs/trust.md
+++ b/docs/trust.md
@@ -97,7 +97,7 @@ There are countless non-obvious ways of creating malicious code, so it is highly
 
 Even though there are many obscure ways to make an HTML string run JavaScript, `<script>` tags are one thing that does not run when it appears in an HTML string.
 
-For historical reasons, browsers ignore `<script>` tags that are inserted into the DOM via innerHTML. They do this because once the element is ready (and thus, has an accessible innerHTML property), the rendering engines cannot backtrack to the parsing-stage if the script calls something like document.write("</body>").
+For historical reasons, browsers ignore `<script>` tags that are inserted into the DOM via innerHTML. They do this because once the element is ready (and thus, has an accessible innerHTML property), the rendering engines cannot backtrack to the parsing-stage if the script calls something like `document.write("</body>")`.
 
 This browser behavior may seem surprising to a developer coming from jQuery, because jQuery implements code specifically to find script tags and run them in this scenario. Mithril follows the browser behavior. If jQuery behavior is desired, you should consider either moving the code out of the HTML string and into an `oncreate` [lifecycle method](lifecycle-methods.md), or use jQuery (or re-implement its script parsing code).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
While reading through some of the documentation I saw some issues with both the ES6 and `m.trust` pages.  The ES6 page uses the dollar sign wrapped in backticks which causes an issue due to the usage of `String.prototype.replace` in `scripts/generate-docs.js`.  As for `m.trust`, a closing BODY tag was sneaking through to the html.  I just wrapped that code piece in backticks which resolved that.
<!--- Describe your changes in detail -->

## Motivation and Context
Saw an issue and easy enough to fix myself and provide an option for resolution.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
I ran the tests although it did fail on `test:js` which I'm not sure why.  I didn't touch any of what that would be testing.

```
> mithril@2.0.4 test:js C:\Users\<user>\projects\mithril.js
> node ospec/bin/ospec


the done parser > tolerates comments:
true
  should equal
false
    at C:\Users\<user>\projects\mithril.js\ospec\tests\test-ospec.js:715:12

––––––
1 out of 14124 assertions failed in 3808ms
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md` (wasn't sure if this was necessary or not)
