### PR TITLE
replace slave label with replica

### DIFF
--- a/examples/dbmonster/ENV.js
+++ b/examples/dbmonster/ENV.js
@@ -138,14 +138,14 @@ var ENV = ENV || (function() {
       data = [];
       for (var i = 1; i <= ENV.rows; i++) {
         data.push({ dbname: 'cluster' + i, query: "", formatElapsed: "", elapsedClassName: "" });
-        data.push({ dbname: 'cluster' + i + ' slave', query: "", formatElapsed: "", elapsedClassName: "" });
+        data.push({ dbname: 'cluster' + i + ' replica', query: "", formatElapsed: "", elapsedClassName: "" });
       }
     }
     if (!data) { // first init when keepIdentity
       data = [];
       for (var i = 1; i <= ENV.rows; i++) {
         data.push({ dbname: 'cluster' + i });
-        data.push({ dbname: 'cluster' + i + ' slave' });
+        data.push({ dbname: 'cluster' + i + ' replica' });
       }
       oldData = data;
     }


### PR DESCRIPTION
## Description
One of the example is using the antiquated word "slave" for a database replica. I updated the language and tested the change.

## Motivation and Context
If possible, I'd like to live in a world where we avoid that word.

## How Has This Been Tested?
I've tested the example on my local machine and it seems to work perfectly fine:

![Screen Shot 2020-06-19 at 08 06 50](https://user-images.githubusercontent.com/159852/85147564-e7b0ef80-b203-11ea-90a6-87a226a88d82.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
