### PR TITLE
set window, document, requestAnimationFrame when missing

### DIFF
--- a/render.js
+++ b/render.js
@@ -11,7 +11,6 @@ try {
 	}
 }
 finally {
-	null
 }
 
 module.exports = require("./render/render")(window)

--- a/render.js
+++ b/render.js
@@ -3,13 +3,15 @@
 // When running in node, we get reference errors on import
 // unless we have window, document, requestAnimationFrame
 try {
-    var isRunningInNode = global.process.version  // a good enough proxy
-    if (isRunningInNode){
-        global.window = global.window || undefined
-        global.document = global.document || undefined
-        global.requestAnimationFrame = global.requestAnimationFrame || undefined
-    }
+	var isRunningInNode = global.process.version // a good enough proxy
+	if (isRunningInNode){
+		global.window = global.window || undefined
+		global.document = global.document || undefined
+		global.requestAnimationFrame = global.requestAnimationFrame || undefined
+	}
 }
-finally {}
+finally {
+	null
+}
 
 module.exports = require("./render/render")(window)

--- a/render.js
+++ b/render.js
@@ -1,3 +1,15 @@
 "use strict"
 
+// When running in node, we get reference errors on import
+// unless we have window, document, requestAnimationFrame
+try {
+    var isRunningInNode = global.process.version  // a good enough proxy
+    if (isRunningInNode){
+        global.window = global.window || undefined
+        global.document = global.document || undefined
+        global.requestAnimationFrame = global.requestAnimationFrame || undefined
+    }
+}
+finally {}
+
 module.exports = require("./render/render")(window)


### PR DESCRIPTION
## Description
When importing mithril as a module in node, it blows up because there is no `window`|`document`|`requestAnimationFrame`. 

This is particularly problematic for ECMAScript modules (as opposed to CommmonJS Modules) as there is no simple way to run code *before* importing a module. (There are a number of hacks using the dynamic `import()` function, but these aren't any fun).

This commit makes it such that when mithril appears to be imported from inside node (by checking if `global.process.version` exists), it will set the three variables to `undefined` if they don't exist.

## Motivation and Context
I'm doing some work with `mithril-node-render`, on it's homepage, it recommends doing:
```javascript
if (!global.window) {
  global.window = global.document = global.requestAnimationFrame = undefined
}
```
but this is not made easy with ECMAScript modules as mentioned above.

## How Has This Been Tested?
Tested in node 12 and 14.

## Types of changes
This is _kinda_ a bug fix.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/change-log.md`
