### PR TITLE
Implement enableAutoRedraw when mounting

### DIFF
--- a/api/mount-redraw.js
+++ b/api/mount-redraw.js
@@ -27,7 +27,7 @@ module.exports = function(render, schedule, console) {
 
 	redraw.sync = sync
 
-	function mount(root, component) {
+	function mount(root, component, enableAutoRedraw=true) {
 		if (component != null && component.view == null && typeof component !== "function") {
 			throw new TypeError("m.mount expects a component, not a vnode.")
 		}
@@ -41,7 +41,7 @@ module.exports = function(render, schedule, console) {
 
 		if (component != null) {
 			subscriptions.push(root, component)
-			render(root, Vnode(component), redraw)
+			render(root, Vnode(component), enableAutoRedraw && redraw)
 		}
 	}
 

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -158,6 +158,32 @@ o.spec("api", function() {
 						done()
 					}, FRAME_BUDGET)
 				})
+
+				o("disabled autoredraw - manual still works", function(done) {
+					var $window = domMock()
+
+					root = window.document.createElement("div")
+					let count = 0
+					m.mount(root, createComponent({view: function() {
+						return m("div", {onclick: () => {
+							count++
+							m.redraw()
+						}},
+						m("span", "count is " + count)
+						)
+					}}), false)
+
+					var e = $window.document.createEvent("MouseEvents")
+					e.initEvent("click", true, true)
+					root.childNodes[0].dispatchEvent(e)
+
+					setTimeout(() => {
+						o(root.childNodes[0].childNodes[0].childNodes[0].nodeValue).equals("count is 1")
+						done()
+					}, FRAME_BUDGET)
+				})
+
+				m.redraw()
 			})
 
 			o.spec("m.route", function() {

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -2,6 +2,7 @@
 
 var o = require("ospec")
 var browserMock = require("../test-utils/browserMock")
+var domMock = require("../test-utils/domMock")
 var components = require("../test-utils/components")
 
 o.spec("api", function() {
@@ -88,7 +89,54 @@ o.spec("api", function() {
 					o(root.childNodes.length).equals(1)
 					o(root.firstChild.nodeName).equals("DIV")
 				})
+
+				o("enabled autoredraw", function(done) {
+					var $window = domMock()
+
+					root = window.document.createElement("div")
+					let count = 0
+					m.mount(root, createComponent({view: function() {
+						return m("div", { onclick: () => {
+							  count++
+							}},
+							m("span", "count is " + count)
+						)
+					}}))
+
+					var e = $window.document.createEvent("MouseEvents")
+					e.initEvent("click", true, true)
+					root.childNodes[0].dispatchEvent(e)
+
+					setTimeout(() => {
+						o(root.childNodes[0].childNodes[0].childNodes[0].nodeValue).equals("count is 1")
+						done()
+					}, FRAME_BUDGET)
+				})
+
+				o("disabled autoredraw", function(done) {
+					var $window = domMock()
+
+					root = window.document.createElement("div")
+					let count = 0
+					m.mount(root, createComponent({view: function() {
+						return m("div", { onclick: () => {
+							  count++
+							}},
+							m("span", "count is " + count)
+						)
+					}}), false)
+
+					var e = $window.document.createEvent("MouseEvents")
+					e.initEvent("click", true, true)
+					root.childNodes[0].dispatchEvent(e)
+
+					setTimeout(() => {
+						o(root.childNodes[0].childNodes[0].childNodes[0].nodeValue).equals("count is 0")
+						done()
+					}, FRAME_BUDGET)
+				})
 			})
+
 			o.spec("m.route", function() {
 				o("works", function(done) {
 					root = window.document.createElement("div")
@@ -147,18 +195,6 @@ o.spec("api", function() {
 				})
 			})
 			o.spec("m.redraw", function() {
-				o("disabled", function(done) {
-					var count = 0
-					root = window.document.createElement("div")
-					m.mount(root, createComponent({view: function() {count++}}), false)
-					o(count).equals(1)
-					setTimeout(function() {
-
-						o(count).equals(0)
-
-						done()
-					}, FRAME_BUDGET)
-				})
 				o("works", function(done) {
 					var count = 0
 					root = window.document.createElement("div")

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -147,6 +147,20 @@ o.spec("api", function() {
 				})
 			})
 			o.spec("m.redraw", function() {
+				o("disabled", function(done) {
+					var count = 0
+					root = window.document.createElement("div")
+					m.mount(root, createComponent({view: function() {count++}}), false)
+					o(count).equals(1)
+					m.redraw()
+					o(count).equals(1)
+					setTimeout(function() {
+
+						o(count).equals(1)
+
+						done()
+					}, FRAME_BUDGET)
+				})
 				o("works", function(done) {
 					var count = 0
 					root = window.document.createElement("div")

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -90,7 +90,7 @@ o.spec("api", function() {
 					o(root.firstChild.nodeName).equals("DIV")
 				})
 
-				o("enabled autoredraw", function(done) {
+				o("enabled autoredraw - default", function(done) {
 					var $window = domMock()
 
 					root = window.document.createElement("div")
@@ -102,6 +102,29 @@ o.spec("api", function() {
 						m("span", "count is " + count)
 						)
 					}}))
+
+					var e = $window.document.createEvent("MouseEvents")
+					e.initEvent("click", true, true)
+					root.childNodes[0].dispatchEvent(e)
+
+					setTimeout(() => {
+						o(root.childNodes[0].childNodes[0].childNodes[0].nodeValue).equals("count is 1")
+						done()
+					}, FRAME_BUDGET)
+				})
+
+				o("enabled autoredraw - explicit", function(done) {
+					var $window = domMock()
+
+					root = window.document.createElement("div")
+					let count = 0
+					m.mount(root, createComponent({view: function() {
+						return m("div", {onclick: () => {
+							count++
+						}},
+						m("span", "count is " + count)
+						)
+					}}), true)
 
 					var e = $window.document.createEvent("MouseEvents")
 					e.initEvent("click", true, true)

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -152,11 +152,9 @@ o.spec("api", function() {
 					root = window.document.createElement("div")
 					m.mount(root, createComponent({view: function() {count++}}), false)
 					o(count).equals(1)
-					m.redraw()
-					o(count).equals(1)
 					setTimeout(function() {
 
-						o(count).equals(1)
+						o(count).equals(0)
 
 						done()
 					}, FRAME_BUDGET)

--- a/tests/test-api.js
+++ b/tests/test-api.js
@@ -96,10 +96,10 @@ o.spec("api", function() {
 					root = window.document.createElement("div")
 					let count = 0
 					m.mount(root, createComponent({view: function() {
-						return m("div", { onclick: () => {
-							  count++
-							}},
-							m("span", "count is " + count)
+						return m("div", {onclick: () => {
+							count++
+						}},
+						m("span", "count is " + count)
 						)
 					}}))
 
@@ -119,10 +119,10 @@ o.spec("api", function() {
 					root = window.document.createElement("div")
 					let count = 0
 					m.mount(root, createComponent({view: function() {
-						return m("div", { onclick: () => {
-							  count++
-							}},
-							m("span", "count is " + count)
+						return m("div", {onclick: () => {
+							count++
+						}},
+						m("span", "count is " + count)
 						)
 					}}), false)
 


### PR DESCRIPTION
## Description
Allow disabling the automount system when mounting a component.

## Motivation and Context
If you prefer to explicitly redraw, rather than use the built in autoredraw system, there is no way to prevent the redraw being triggered globally on events, such as onclick. While I believe you can do `e.redraw = false`, you would have to do this on every handler.

Potentially resolves https://github.com/MithrilJS/mithril.js/issues/1951

## How Has This Been Tested?
I added two tests, they may be a bit "integrationy" so please let me know.

- "enabled autoredraw - default" ensures that enableAutoRedraw is enabled by default and redraws as expected, therefore preventing breaking changes.
- "enabled autoredraw - explicit" ensures that when enableAutoRedraw is explicitly set to true, it redraws as expected
- "disabled autoredraw" ensures that when enableAutoRedraw is set to false, it does not redraw on events
- "disabled autoredraw - manual still works" ensures that when enableAutoRedraw is set to false, it will still redraw if `m.redraw` is manually called.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
