### PR TITLE
Allow Mithril to be loaded in non-browser environments without modification

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,7 @@ PSA: changes to [`mithril/stream`](stream.md) are now specified in this changelo
 - Fix issue where new redraw handlers weren't copied over on update. ([#2578](https://github.com/MithrilJS/mithril.js/pull/2578) [@isiahmeadows](https://github.com/isiahmeadows))
 - Make changes to file inputs gracefully handled, and don't break if the current value and old value mismatch (and the new value isn't empty), but instead just log an error. ([#2578](https://github.com/MithrilJS/mithril.js/pull/2578) [@isiahmeadows](https://github.com/isiahmeadows))
     - This mainly exists just to kick the can down the road - this is the only case I'm aware of where the DOM itself would be responsible for throwing an error. A proper fix to the greater issue of error handling is much more complex, and I'd rather not block users any longer over this one specific issue.
+- Allow Mithril to be loaded in non-browser environments without modification. ([#2633](https://github.com/MithrilJS/mithril.js/pull/2633) [@isiahmeadows](https://github.com/isiahmeadows))
 
 Important note: if you were using any of these undocumented tools, they are no longer available as of this release. This is not considered a breaking change as they were written for internal usage and as of v2 are all 100% unsupported in userland.
 

--- a/mount-redraw.js
+++ b/mount-redraw.js
@@ -2,4 +2,4 @@
 
 var render = require("./render")
 
-module.exports = require("./api/mount-redraw")(render, requestAnimationFrame, console)
+module.exports = require("./api/mount-redraw")(render, typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : null, typeof console !== "undefined" ? console : null)

--- a/render.js
+++ b/render.js
@@ -1,3 +1,3 @@
 "use strict"
 
-module.exports = require("./render/render")(window)
+module.exports = require("./render/render")(typeof window !== "undefined" ? window : null)

--- a/request.js
+++ b/request.js
@@ -3,4 +3,4 @@
 var PromisePolyfill = require("./promise/promise")
 var mountRedraw = require("./mount-redraw")
 
-module.exports = require("./request/request")(window, PromisePolyfill, mountRedraw.redraw)
+module.exports = require("./request/request")(typeof window !== "undefined" ? window : null, PromisePolyfill, mountRedraw.redraw)

--- a/route.js
+++ b/route.js
@@ -2,4 +2,4 @@
 
 var mountRedraw = require("./mount-redraw")
 
-module.exports = require("./api/router")(window, mountRedraw)
+module.exports = require("./api/router")(typeof window !== "undefined" ? window : null, mountRedraw)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Recast the global reads to all be guarded with `typeof`, so that if they aren't defined, they're just `null`.

Note that this does *not* involve documentation changes, as that's going to require a lot more effort and is best left as a follow-up. (Our support for this is undocumented anyways, and the relevant docs are for hooking it up with JSDOM. This only really matters in practice if you're using `mithril-node-render`.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This has been a fairly common gotcha, and I'd like to actually fix it rather than repeatedly tell users how to work around it in about 2-3 different ways (depending on how they test their app). This in effect moves that workaround into core, but without polluting the global scope like #2613.

Closes #2613 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `require("./.")` in the package root from a fresh Node REPL and no errors occurred.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated `docs/changelog.md`
