### PR TITLE
Fix inconsistent capitalizations of "JavaScript"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ mithril.js [![npm Version](https://img.shields.io/npm/v/mithril.svg)](https://ww
 
 ## What is Mithril?
 
-A modern client-side Javascript framework for building Single Page Applications. It's small (<!-- size -->9.79 KB<!-- /size --> gzipped), fast and provides routing and XHR utilities out of the box.
+A modern client-side JavaScript framework for building Single Page Applications. It's small (<!-- size -->9.79 KB<!-- /size --> gzipped), fast and provides routing and XHR utilities out of the box.
 
 Mithril is used by companies like Vimeo and Nike, and open source platforms like Lichess 👍.
 

--- a/ospec/README.md
+++ b/ospec/README.md
@@ -662,6 +662,6 @@ Explicitly disallowing modularity and configuration in test-space has a few bene
 
 - tests always look the same, even across different projects and teams
 - single source of documentation for entire testing API
-- no need to hunt down plugins to figure out what they do, especially if they replace common javascript idioms with fuzzy spoken language constructs (e.g. what does `.is()` do?)
+- no need to hunt down plugins to figure out what they do, especially if they replace common JavaScript idioms with fuzzy spoken language constructs (e.g. what does `.is()` do?)
 - no need to pollute project-space with ad-hoc configuration code
 - discourages side-tracking and yak-shaving

--- a/scripts/bundler-readme.md
+++ b/scripts/bundler-readme.md
@@ -11,7 +11,7 @@ This bundler attempts to aggressively bundle CommonJS modules by assuming the de
 
 Most browsers don't support ES6 `import/export` syntax, but we can achieve modularity by using CommonJS module syntax and transpiling it.
 
-Webpack is conservative and treats CommonJS modules as non-statically-analyzable since `require` and `module.exports` are legally allowed everywhere. Therefore, it must generate extra code to resolve dependencies at runtime (i.e. `__webpack_require()`). Rollup only works with ES6 modules. ES6 modules can be bundled more efficiently because they are statically analyzable, but some use cases are difficult to handle due to ES6's support for cyclic dependencies and hosting rules. This bundler assumes code is written in CommonJS style but follows a strict set of rules that emulate statically analyzable code and favors the usage of the factory pattern instead of relying on obscure corners of the Javascript language (hoisting rules and binding semantics).
+Webpack is conservative and treats CommonJS modules as non-statically-analyzable since `require` and `module.exports` are legally allowed everywhere. Therefore, it must generate extra code to resolve dependencies at runtime (i.e. `__webpack_require()`). Rollup only works with ES6 modules. ES6 modules can be bundled more efficiently because they are statically analyzable, but some use cases are difficult to handle due to ES6's support for cyclic dependencies and hosting rules. This bundler assumes code is written in CommonJS style but follows a strict set of rules that emulate statically analyzable code and favors the usage of the factory pattern instead of relying on obscure corners of the JavaScript language (hoisting rules and binding semantics).
 
 ### Caveats
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
"Javascript"/"javascript" → "JavaScript"

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #2398, or at least I can't find any more incorrect capitalizations. Well, there is <https://github.com/MithrilJS/mithril.js/blob/next/render/tests/test-attributes.js#L175>, but that's probably irrelevant (not a documentation file).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Searched all files in VS Code using case-sensitive search terms "javascript" and "Javascript".

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`