### PR TITLE
Reject request on XHR timeout

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -79,7 +79,7 @@ module.exports = function($window, Promise, oncompletion) {
 			var assumeJSON = (args.serialize == null || args.serialize === JSON.serialize) && !(body instanceof $window.FormData)
 			var responseType = args.responseType || (typeof args.extract === "function" ? "" : "json")
 
-			var xhr = new $window.XMLHttpRequest(), aborted = false
+			var xhr = new $window.XMLHttpRequest(), aborted = false, isTimeout = false
 			var original = xhr, replacedAbort
 			var abort = xhr.abort
 
@@ -141,12 +141,25 @@ module.exports = function($window, Promise, oncompletion) {
 						}
 						if (success) resolve(response)
 						else {
-							try { message = ev.target.responseText }
-							catch (e) { message = response }
-							var error = new Error(message)
-							error.code = ev.target.status
-							error.response = response
-							reject(error)
+							var completeErrorResponse = function() {
+								try { message = ev.target.responseText }
+								catch (e) { message = response }
+								var error = new Error(message)
+								error.code = ev.target.status
+								error.response = response
+								reject(error)
+							}
+
+							if (xhr.status === 0) {
+								// Use setTimeout to push this code block onto the event queue
+								// This allows `xhr.ontimeout` to run in the case that there is a timeout
+								// Without this setTimeout, `xhr.ontimeout` doesn't have a chance to reject
+								// as `xhr.onreadystatechange` will run before it
+								setTimeout(function() {
+									if (isTimeout) return
+									completeErrorResponse()
+								})
+							} else completeErrorResponse()
 						}
 					}
 					catch (e) {
@@ -156,10 +169,10 @@ module.exports = function($window, Promise, oncompletion) {
 			}
 
 			xhr.ontimeout = function (ev) {
-				if (aborted) return;
-				var error = new Error("Request timeout");
-				error.timeout = ev.target.timeout;
-				reject(error);
+				isTimeout = true
+				var error = new Error("Request timed out")
+				error.code = ev.target.status
+				reject(error)
 			}
 
 			if (typeof args.config === "function") {

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -677,6 +677,57 @@ o.spec("request", function() {
 				o(e instanceof Error).equals(true)
 			}).then(done)
 		})
+		o("rejects on request timeout", function(done) {
+			var timeout = 50
+			var timeToGetItem = timeout + 1
+
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return new Promise(function(resolve) {
+						setTimeout(function() {
+							resolve({status: 200})
+						}, timeToGetItem)
+					})
+				}
+			})
+
+			request({
+				method: "GET", url: "/item",
+				timeout: timeout
+			}).catch(function(e) {
+				o(e instanceof Error).equals(true)
+				o(e.message).equals("Request timed out")
+				o(e.code).equals(0)
+			}).then(function() {
+				done()
+			})
+		})
+		o("does not reject when time to request resource does not exceed timeout", function(done) {
+			var timeout = 50
+			var timeToGetItem = timeout - 1
+			var isRequestRejected = false
+
+			mock.$defineRoutes({
+				"GET /item": function() {
+					return new Promise(function(resolve) {
+						setTimeout(function() {
+							resolve({status: 200})
+						}, timeToGetItem)
+					})
+				}
+			})
+
+			request({
+				method: "GET", url: "/item",
+				timeout: timeout
+			}).catch(function(e) {
+				isRequestRejected = true
+				o(e.message).notEquals("Request timed out")
+			}).then(function() {
+				o(isRequestRejected).equals(false)
+				done()
+			})
+		})
 		o("does not reject on status error code when extract provided", function(done) {
 			mock.$defineRoutes({
 				"GET /item": function() {

--- a/test-utils/xhrMock.js
+++ b/test-utils/xhrMock.js
@@ -91,7 +91,8 @@ module.exports = function() {
 							return
 						}
 
-						if (typeof self.ontimeout === "function") self.ontimeout({target: self})
+						self.status = 0;
+						if (typeof self.ontimeout === "function") self.ontimeout({target: self, type:"timeout"})
 					}, self.timeout)
 				}
 


### PR DESCRIPTION
Derived from PR #2581. Allows requests to properly reject on event of a timeout. Following up from my previous [comment](https://github.com/MithrilJS/mithril.js/pull/2581#issuecomment-743921642).

## Description

* Adjusted timeout handling in `request.js` so that `ontimeout` has a chance to reject
* Adjusted tests for timeouts in `test-request.js`
* Adjusted `xhrMock.js` so the appropriate XHR status and event type are passed to `ontimeout`
* Reverted promisified mocked GET endpoints in `request/tests/test-request.js`, as per @isiahmeadows 's suggestion

## Motivation and Context
Fixes issue #2559

## How Has This Been Tested?
Tested manually via local .html file as well as in flems. Testing via two tests in `test-request.js`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. *
- [ ] I have updated `docs/changelog.md`

* `npm run test:js` runs and passed after my changes. `npm run test` results in unrelated issues with `stream.min.js` and linting issues.
