### PR TITLE
A note on JSX events

### DIFF
--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -25,6 +25,7 @@ function MyComponent() {
 }
 
 // can be written as:
+
 function MyComponent() {
 	return {
 		view: () => (
@@ -344,36 +345,19 @@ function SummaryView() {
 
 While JSX events are usually named using camelCase, lowercase names should be used when JSX is used with Mithril.
 
-```javascript
-function MyComponent() {
-    return {
-        view: () =>
-            m("main", [
-                m("input", {
-                    type: "button",
-                    onclick: () => console.log('clicked'),
-                    value: "Click me!"
-                })
-            ])
-    }
-}
-```
-
-Should be written as:
-
 ```jsx
-function MyComponent() {
-    return {
-        view: () => (
-            <main>
-                <input type="button" onclick={() => console.log('clicked')} value="Click me!"/>
-            </main>
-        )
-    }
-}
-```
+m("main", [
+	m("input", { type: "text", oninput: ... }),
+	m("input", { type: "button", value: "Click me", onclick: ... })
+])
 
----
+// can be written as:
+
+<main>
+    <input type="text" oninput={...}/>
+    <input type="button" value="Click me" onclick={...}/>
+</main>
+```
 
 ### Converting HTML
 

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -2,8 +2,10 @@
 
 - [Description](#description)
 - [Setup](#setup)
+- [Production build](#production-build)
 - [Using Babel with Webpack](#using-babel-with-webpack)
 - [JSX vs hyperscript](#jsx-vs-hyperscript)
+- [A note on event listeners](#a-note-on-event-listeners)
 - [Converting HTML](#converting-html)
 
 ---

--- a/docs/jsx.md
+++ b/docs/jsx.md
@@ -338,6 +338,41 @@ function SummaryView() {
 
 ---
 
+### A note on event listeners
+
+While JSX events are usually named using camelCase, lowercase names should be used when JSX is used with Mithril.
+
+```javascript
+function MyComponent() {
+    return {
+        view: () =>
+            m("main", [
+                m("input", {
+                    type: "button",
+                    onclick: () => console.log('clicked'),
+                    value: "Click me!"
+                })
+            ])
+    }
+}
+```
+
+Should be written as:
+
+```jsx
+function MyComponent() {
+    return {
+        view: () => (
+            <main>
+                <input type="button" onclick={() => console.log('clicked')} value="Click me!"/>
+            </main>
+        )
+    }
+}
+```
+
+---
+
 ### Converting HTML
 
 In Mithril, well-formed HTML is generally valid JSX. Little more than just pasting raw HTML is required for things to just work. About the only things you'd normally have to do are change unquoted property values like `attr=value` to `attr="value"` and change void elements like `<input>` to `<input />`, this being due to JSX being based on XML and not HTML.


### PR DESCRIPTION
## Description
Naming JSX events according to their documentation produces unexpected results with incorrectly named events when using JSX with Mithril. This PR introduces a short note about this on the JSX resource page.

## Motivation and Context
This change helps new users to correctly name events when using JSX with Mithril. This note should be added as the JSX documentation will instruct to use conventional JSX event naming. The information is relevant for beginners as well as existing users of JSX.

## How Has This Been Tested?
The JSX code example has been tested locally to work as expected with:
mithril 2.0.4
@babel/core 7.12.10
@babel/plugin-transform-react-jsx
webpack 5.11.0

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
