### PR TITLE
Send URLSearchParams as request body without extra configuration

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -76,7 +76,7 @@ module.exports = function($window, Promise, oncompletion) {
 		request: makeRequest(function(url, args, resolve, reject) {
 			var method = args.method != null ? args.method.toUpperCase() : "GET"
 			var body = args.body
-			var assumeJSON = (args.serialize == null || args.serialize === JSON.serialize) && !(body instanceof $window.FormData)
+			var assumeJSON = (args.serialize == null || args.serialize === JSON.serialize) && !(body instanceof $window.FormData || body instanceof $window.URLSearchParams)
 			var responseType = args.responseType || (typeof args.extract === "function" ? "" : "json")
 
 			var xhr = new $window.XMLHttpRequest(), aborted = false, isTimeout = false
@@ -190,7 +190,7 @@ module.exports = function($window, Promise, oncompletion) {
 
 			if (body == null) xhr.send()
 			else if (typeof args.serialize === "function") xhr.send(args.serialize(body))
-			else if (body instanceof $window.FormData) xhr.send(body)
+			else if (body instanceof $window.FormData || body instanceof $window.URLSearchParams) xhr.send(body)
 			else xhr.send(JSON.stringify(body))
 		}),
 		jsonp: makeRequest(function(url, args, resolve, reject) {

--- a/test-utils/xhrMock.js
+++ b/test-utils/xhrMock.js
@@ -12,8 +12,10 @@ module.exports = function() {
 	}
 
 	function FormData() {}
+	function URLSearchParams() {}
 	var $window = {
 		FormData: FormData,
+		URLSearchParams: URLSearchParams,
 		XMLHttpRequest: function XMLHttpRequest() {
 			var args = {}
 			var headers = {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR fixes an oddity I noticed in the way `m.request` handles `URLSearchParams` object. It now handles it in the same sort of way XHR and Fetch do it.

## Description
- I added an additional clause to `assumeJSON` check in `m.request` to make it so that passing in `URLSearchParams` object won't change the `Content-Type` header to `application/json`. It will stay as the default, which is `application/x-www-form-urlencoded`.
- I also added an additional clause to ensure that passing in `URLSearchParams` object without `serialize` method will pass the object straight through without serializing it, since it should not be serialized in this case.
- I also added `URLSearchParams` to `window` mock so that current tests continue to pass.

## Motivation and Context
I was making a request to an API using `m.request` that only takes `application/x-www-form-urlencoded` as the request body, and I used a `URLSearchParams` object to send my params in. I then noticed that `m.request` was not serializing it as expected when compared to similar request made using plain XHR and with Fetch.

The following examples illustrate this:

where:

```
const payload = {
    test: 'abc',
    test2: 'def',
};
```

XHR

```
const xhr = new XMLHttpRequest();
xhr.open('POST', `${SERVICE}/test_xhr`);
xhr.send(new URLSearchParams(payload));
```

![image](https://user-images.githubusercontent.com/3276350/122657702-0f4ad880-d134-11eb-8ad7-fe286f00a720.png)

Fetch

```
fetch(`${SERVICE}/test_fetch`, {
        method: 'POST',
        body: new URLSearchParams(payload),
});
```

![image](https://user-images.githubusercontent.com/3276350/122657703-1245c900-d134-11eb-9139-9f8ba7964d11.png)


m.request

```
m.request({
        url: `${SERVICE}/test_m`,
        method: 'POST',
        body: new URLSearchParams(payload),
});
```

![image](https://user-images.githubusercontent.com/3276350/122657712-1f62b800-d134-11eb-8cb1-e985b41d7242.png)

A workaround for this does exist, if you specify `serialize` function as the identity function like the following:

```
m.request({
        url: `${SERVICE}/test_m`,
        method: 'POST',
        body: new URLSearchParams(payload),
        serialize: (val) => val,
});
```

It will send `application/x-www-form-urlencoded` correctly:

![image](https://user-images.githubusercontent.com/3276350/122658002-5f2a9f00-d136-11eb-84f5-41534dc032f9.png)

This PR is to allow support for `URLSearchParams` object out-of-the-box, so it works in the way users expect from XHR and Fetch APIs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created the following example to verify current behaviour of `m.request` (as well as to compare it to XHR and Fetch) and to verify my changes:

```
const m = require('mithril');

const SERVICE = 'http://localhost:4000';

const payload = {
    test: 'abc',
    test2: 'def',
};

function mRequest(payload) {
    m.request({
        url: `${SERVICE}/test_m`,
        method: 'POST',
        body: new URLSearchParams(payload),
        // serialize: (val) => val,
    });
}

function fetchRequest(payload) {
    fetch(`${SERVICE}/test_fetch`, {
        method: 'POST',
        body: new URLSearchParams(payload),
    });
}

function xhrRequest(payload) {
    const xhr = new XMLHttpRequest();
    xhr.open('POST', `${SERVICE}/test_xhr`);
    xhr.send(new URLSearchParams(payload));
}

mRequest(payload);
fetchRequest(payload);
xhrRequest(payload);
```

Backend server at `http://localhost:4000` in this example can be anything, I created a quick one using express.

The following can be used as a minimal example, based on above example:

```
const m = require('mithril');

m.request({
    url: 'http://localhost:4000/test',
    method: 'POST',
    body: new URLSearchParams({
        test: 'abc',
        test2: 'def',
    }),
    // serialize: (val) => val,
});
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. *(caveat, see "Other Notes" below)*
- [X] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`

## Other Notes
One caveat however is that `URLSearchParams` is a [more recent](https://caniuse.com/urlsearchparams) addition to browsers than [FormData and other XHR features](https://caniuse.com/xhr2). Would it be a good idea to support older browsers in this case? And if so, would adding `window.URLSearchParams !== undefined` in both spots where I made my changes be enough? Or should I abstract out the check into a separate function at this point?

Also, I wanted to add a unit test for this. This is what I wrote initially: (in `test-request.js`)

```
o("works w/ URLSearchParams body without explicitly serializing", function(done) {
	mock.$defineRoutes({
		"POST /item": function(request) {
			return {status: 200, responseText: JSON.stringify({a: request.url, b: request.body})}
		}
	})
	request({method: "POST", url: "/item", body: new URLSearchParams({x: "y", z: "w"})}).then(function(data) {
		o(data).deepEquals({a: "/item", b: "x=y&z=w"})
	}).then(done)
});
```

However, it seems because DOM appears to be mocked for tests, this isn't possible. Is there another way a unit test can be added for this? Or is it acceptable to not have a unit test for this in this particular case?

