### PR TITLE
Expose compileSelector while retaining internal caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,5 +21,6 @@ m.buildPathname = require("./pathname/build")
 m.vnode = require("./render/vnode")
 m.PromisePolyfill = require("./promise/polyfill")
 m.censor = require("./util/censor")
+m.compileSelector = require("./render/compileselector")
 
 module.exports = m

--- a/render/compileselector.js
+++ b/render/compileselector.js
@@ -1,0 +1,23 @@
+"use strict"
+
+var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
+
+function compileSelector(selector) {
+	var match, tag = "div", classes = [], attrs = {}
+	while (match = selectorParser.exec(selector)) {
+		var type = match[1], value = match[2]
+		if (type === "" && value !== "") tag = value
+		else if (type === "#") attrs.id = value
+		else if (type === ".") classes.push(value)
+		else if (match[3][0] === "[") {
+			var attrValue = match[6]
+			if (attrValue) attrValue = attrValue.replace(/\\(["'])/g, "$1").replace(/\\\\/g, "\\")
+			if (match[4] === "class") classes.push(attrValue)
+			else attrs[match[4]] = attrValue === "" ? attrValue : attrValue || true
+		}
+	}
+	if (classes.length > 0) attrs.className = classes.join(" ")
+	return {tag: tag, attrs: attrs}
+}
+
+module.exports = compileSelector

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -3,31 +3,13 @@
 var Vnode = require("../render/vnode")
 var hyperscriptVnode = require("./hyperscriptVnode")
 var hasOwn = require("../util/hasOwn")
+var compileSelector = require("../render/compileselector")
 
-var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = {}
 
 function isEmpty(object) {
 	for (var key in object) if (hasOwn.call(object, key)) return false
 	return true
-}
-
-function compileSelector(selector) {
-	var match, tag = "div", classes = [], attrs = {}
-	while (match = selectorParser.exec(selector)) {
-		var type = match[1], value = match[2]
-		if (type === "" && value !== "") tag = value
-		else if (type === "#") attrs.id = value
-		else if (type === ".") classes.push(value)
-		else if (match[3][0] === "[") {
-			var attrValue = match[6]
-			if (attrValue) attrValue = attrValue.replace(/\\(["'])/g, "$1").replace(/\\\\/g, "\\")
-			if (match[4] === "class") classes.push(attrValue)
-			else attrs[match[4]] = attrValue === "" ? attrValue : attrValue || true
-		}
-	}
-	if (classes.length > 0) attrs.className = classes.join(" ")
-	return selectorCache[selector] = {tag: tag, attrs: attrs}
 }
 
 function execSelector(state, vnode) {
@@ -91,7 +73,7 @@ function hyperscript(selector) {
 
 	if (typeof selector === "string") {
 		vnode.children = Vnode.normalizeChildren(vnode.children)
-		if (selector !== "[") return execSelector(selectorCache[selector] || compileSelector(selector), vnode)
+		if (selector !== "[") return execSelector(selectorCache[selector] || (selectorCache[selector] = compileSelector(selector)), vnode)
 	}
 
 	vnode.tag = selector


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
compileSelector has been separated into its own file and is now exposed on the m object. @isiahmeadows, as per your request caching has been removed from the compileSelector function itself, however, mithril still maintains an internal selector cache. If a use wants to cache their own selectors they would do that externally, for example:

```javascript
const userSelectorCache = {}
const userSelectorToCompile = '.test'
const userMethodThatNeedsCompiledSelector = selector => {
  let compiledSelector = userSelectorCache[selector] || (userSelectorCache[selector] = m.compileSelector(selector));
  // do some things
  return compiledSelector;
}
userMethodThatNeedsCompiledSelector(userSelectorToCompile);
console.log(userSelectorCache) // will contain key ".test"
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using mithril as a framework it can be useful to utilize its compiled selector structure for components that need very optimized performance and are managed outside of the mithril redraw system. It also has the added benefit of being able to more quickly experiment during development as selector strings can easily be used with `m(selector)`, or an external function, such as `myLibrary(selector)`.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
No test cases existed for the compileSelector function in the current next branch. I am happy to add some, but it might take me a few days to get to them.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
