### PR TITLE
Catch malformed URI Components

### DIFF
--- a/querystring/parse.js
+++ b/querystring/parse.js
@@ -1,5 +1,13 @@
 "use strict"
 
+function decodeURIComponentSave(str) {
+	try {
+		return decodeURIComponent(str)
+	} catch(err) {
+		return str
+	}
+}
+
 module.exports = function(string) {
 	if (string === "" || string == null) return {}
 	if (string.charAt(0) === "?") string = string.slice(1)
@@ -7,8 +15,8 @@ module.exports = function(string) {
 	var entries = string.split("&"), counters = {}, data = {}
 	for (var i = 0; i < entries.length; i++) {
 		var entry = entries[i].split("=")
-		var key = decodeURIComponent(entry[0])
-		var value = entry.length === 2 ? decodeURIComponent(entry[1]) : ""
+		var key = decodeURIComponentSave(entry[0])
+		var value = entry.length === 2 ? decodeURIComponentSave(entry[1]) : ""
 
 		if (value === "true") value = true
 		else if (value === "false") value = false

--- a/querystring/tests/test-parseQueryString.js
+++ b/querystring/tests/test-parseQueryString.js
@@ -20,6 +20,10 @@ o.spec("parseQueryString", function() {
 		var data = parseQueryString("?%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23=%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23")
 		o(data).deepEquals({";:@&=+$,/?%#": ";:@&=+$,/?%#"})
 	})
+	o("handles wrongly escaped values", function() {
+		var data = parseQueryString("?test=%c5%a1%e8ZM%80%82H")
+		o(data).deepEquals({test: "%c5%a1%e8ZM%80%82H"})
+	})
 	o("handles escaped slashes followed by a number", function () {
 		var data = parseQueryString("?hello=%2Fen%2F1")
 		o(data.hello).equals("/en/1")


### PR DESCRIPTION
Fix for error thrown when a value contains non-valid / malformed URI Component
Example: test=%c5%a1%e8ZM%80%82H
will throw "URI malformed"

This update will leave the value as-is when an error is thrown

