### PR TITLE
Correctly handle invalid escapes in routes based on 0a5ead31c9fbd7b153c521c7f9d3df7bf826ce6c

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -12,6 +12,14 @@ var censor = require("../util/censor")
 
 var sentinel = {}
 
+function decodeURIComponentSave(component) {
+	try {
+		return decodeURIComponent(component)
+	} catch(e) {
+		return component
+	}
+}
+
 module.exports = function($window, mountRedraw) {
 	var callAsync = $window == null
 		// In case Mithril's loaded globally without the DOM, let's not break
@@ -67,7 +75,7 @@ module.exports = function($window, mountRedraw) {
 		// since the representation is consistently a relatively poorly
 		// optimized cons string.
 		var path = prefix.concat()
-			.replace(/(?:%[a-f89][a-f0-9])+/gim, decodeURIComponent)
+			.replace(/(?:%[a-f89][a-f0-9])+/gim, decodeURIComponentSave)
 			.slice(route.prefix.length)
 		var data = parsePathname(path)
 

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -145,6 +145,19 @@ o.spec("route", function() {
 					o(root.firstChild.nodeValue).equals('{"ö":"ö"} /ö?ö=ö')
 				})
 
+				o("resolves to route w/ matching invalid escape", function() {
+					$window.location.href = prefix + "/%C3%B6abc%def"
+					route(root, "/öabc%def", {
+						"/öabc%def" : {
+							view: lock(function() {
+								return route.get()
+							})
+						}
+					})
+
+					o(root.firstChild.nodeValue).equals("/öabc%def")
+				})
+
 				o("handles parameterized route", function() {
 					$window.location.href = prefix + "/test/x"
 					route(root, "/test/:a", {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,7 @@ PSA: changes to [`mithril/stream`](stream.md) are now specified in this changelo
 - Adapt handling of no content (204) responses to match XHR Spec ([#2624](https://github.com/MithrilJS/mithril.js/pull/2641)) [@Evoke-PHP](https://github.com/Evoke-PHP)
 - Add `URLSearchParams` support to `m.request` ([#2695](https://github.com/MithrilJS/mithril.js/pull/2695) [@Coteh](https://github.com/Coteh))
 - Standardise vnode text representation ([#2670](https://github.com/MithrilJS/mithril.js/pull/2670)) [@barneycarroll](https://github.com/barneycarroll)
+- API: Invalid escapes in routes are now safely handled. [@StephanHoyer](https://github.com/StephanHoyer) based on older [fix](https://github.com/MithrilJS/mithril.js/pull/2061) by [@dead-claudia](https://github.com/dead-claudia)
 
 Important note: if you were using any of these undocumented tools, they are no longer available as of this release. This is not considered a breaking change as they were written for internal usage and as of v2 are all 100% unsupported in userland.
 


### PR DESCRIPTION
fixes #2061

@dead-claudia I just redid your change but slightly different in order to handle a mix of wrong and right encodings properly. Could you take a look please?