### PR TITLE
implement m.domFor() and use it internally to move and remove nodes. Fix #2780

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var hyperscript = require("./hyperscript")
 var request = require("./request")
 var mountRedraw = require("./mount-redraw")
+var domFor = require("./render/dom-for")
 
 var m = function m() { return hyperscript.apply(this, arguments) }
 m.m = hyperscript
@@ -20,5 +21,6 @@ m.parsePathname = require("./pathname/parse")
 m.buildPathname = require("./pathname/build")
 m.vnode = require("./render/vnode")
 m.censor = require("./util/censor")
+m.domFor = domFor.domFor
 
 module.exports = m

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "mithril",
       "version": "2.2.2",
       "license": "MIT",
-      "dependencies": {
-        "ospec": "4.0.0"
-      },
       "bin": {
         "ospec": "ospec/bin/ospec"
       },
@@ -30,7 +27,7 @@
         "marked": "^4.0.10",
         "minimist": "^1.2.0",
         "npm-run-all": "^4.1.5",
-        "ospec": "^4.0.1",
+        "ospec": "4.1.6",
         "pinpoint": "^1.1.0",
         "request": "^2.88.0",
         "request-promise-native": "^1.0.7",
@@ -2760,10 +2757,12 @@
       }
     },
     "node_modules/ospec": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.1.tgz",
-      "integrity": "sha512-fgWIk1eLDidfB+ixTo3PL3HuuO6iX2LhgWxdnWwqRu2rJdpTowgeAP0RHgt3DSUVyszs964fMuq1tB7Ov2C38A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.6.tgz",
+      "integrity": "sha512-Rq+kpRz/ombmIy+g0fAV7mwehtHyQT/J7IjmwVEBw6nbYPxycWgJS3c8BQ0n36kgWOIP5I2SE124cEdunqSH+g==",
       "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -5948,9 +5947,9 @@
       }
     },
     "ospec": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.1.tgz",
-      "integrity": "sha512-fgWIk1eLDidfB+ixTo3PL3HuuO6iX2LhgWxdnWwqRu2rJdpTowgeAP0RHgt3DSUVyszs964fMuq1tB7Ov2C38A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/ospec/-/ospec-4.1.6.tgz",
+      "integrity": "sha512-Rq+kpRz/ombmIy+g0fAV7mwehtHyQT/J7IjmwVEBw6nbYPxycWgJS3c8BQ0n36kgWOIP5I2SE124cEdunqSH+g==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "marked": "^4.0.10",
     "minimist": "^1.2.0",
     "npm-run-all": "^4.1.5",
-    "ospec": "^4.0.1",
+    "ospec": "4.1.6",
     "pinpoint": "^1.1.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
@@ -59,8 +59,5 @@
       "eslint . --fix",
       "git add"
     ]
-  },
-  "dependencies": {
-    "ospec": "4.0.0"
   }
 }

--- a/render/dom-for.js
+++ b/render/dom-for.js
@@ -1,0 +1,24 @@
+"use strict"
+
+var delayedRemoval = module.exports.delayedRemoval = new WeakMap
+
+module.exports.domFor = function *domFor(vnode, {generation} = {generation: undefined}) {
+	let {dom, domSize} = vnode
+	if (dom != null) {
+		if (domSize == null) {
+			if (delayedRemoval.get(dom) === generation) {
+				yield dom
+			}
+		} else {
+			let i = 0, next
+			while (i < domSize) {
+				next = dom.nextSibling
+				if (delayedRemoval.get(dom) === generation) {
+					yield dom
+					i++
+				}
+				dom = next
+			}
+		}
+	}
+}

--- a/render/tests/test-dom-for.js
+++ b/render/tests/test-dom-for.js
@@ -1,0 +1,176 @@
+var o = require("ospec")
+var components = require("../../test-utils/components")
+var domMock = require("../../test-utils/domMock")
+var vdom = require("../../render/render")
+var m = require("../../render/hyperscript")
+var fragment = require("../../render/fragment")
+var domFor = require('../../render/dom-for').domFor
+
+o.spec("domFor(vnode)", function() {
+	var $window, root, render
+	o.beforeEach(function() {
+		$window = domMock()
+		root = $window.document.createElement("div")
+		render = vdom($window)
+	})
+    o('works for simple vnodes', function() {
+        render(root, m('div', {oncreate(vnode){
+            let n = 0
+            for (const dom of domFor(vnode)) {
+                o(dom).equals(root.firstChild)
+                o(++n).equals(1)
+            }
+        }}))
+    })
+    o('works for fragments', function () {
+        render(root, fragment({
+            oncreate(vnode){
+                let n = 0
+                for (const dom of domFor(vnode)) {
+                    o(dom).equals(root.childNodes[n])
+                    n++
+                }
+                o(n).equals(2)
+            }
+        }, [
+            m('a'),
+            m('b')
+        ]))
+    })
+    o('works in fragments with children that have delayed removal', function() {
+        function oncreate(vnode){
+            o(root.childNodes.length).equals(3)
+            o(root.childNodes[0].nodeName).equals('A')
+            o(root.childNodes[1].nodeName).equals('B')
+            o(root.childNodes[2].nodeName).equals('C')
+
+            const iter = domFor(vnode)
+            o(iter.next()).deepEquals({done:false, value: root.childNodes[0]})
+            o(iter.next()).deepEquals({done:false, value: root.childNodes[1]})
+            o(iter.next()).deepEquals({done:false, value: root.childNodes[2]})
+            o(iter.next().done).deepEquals(true)
+            o(root.childNodes.length).equals(3)
+        }
+        function onupdate(vnode) {
+            // the b node is still present in the DOM
+            o(root.childNodes.length).equals(3)
+            o(root.childNodes[0].nodeName).equals('A')
+            o(root.childNodes[1].nodeName).equals('B')
+            o(root.childNodes[2].nodeName).equals('C')
+
+            const iter = domFor(vnode)
+            o(iter.next()).deepEquals({done:false, value: root.childNodes[0]})
+            o(iter.next()).deepEquals({done:false, value: root.childNodes[2]})
+            o(iter.next().done).deepEquals(true)
+            o(root.childNodes.length).equals(3)
+        }
+        
+        render(root, fragment(
+            {oncreate, onupdate},
+            [
+                m('a'),
+                m('b', {onbeforeremove(){return {then(){}, finally(){}}}}),
+                m('c')
+            ]
+        ))
+        render(root, fragment(
+            {oncreate, onupdate},
+            [
+                m('a'),
+                null,
+                m('c'),
+            ]
+        ))
+
+    })
+    components.forEach(function(cmp){
+		o.spec(cmp.kind, function(){
+			var createComponent = cmp.create
+            o('works for components that return one element', function() {
+                const C = createComponent({
+                    view(){return m('div')},
+                    oncreate(vnode){
+                        let n = 0
+                        for (const dom of domFor(vnode)) {
+                            o(dom).equals(root.firstChild)
+                            o(++n).equals(1)
+                        }
+                    }
+                })
+                render(root, m(C))
+            })
+            o('works for components that return fragments', function () {
+                const oncreate = o.spy(function oncreate(vnode){
+                    o(root.childNodes.length).equals(3)
+                    o(root.childNodes[0].nodeName).equals('A')
+                    o(root.childNodes[1].nodeName).equals('B')
+                    o(root.childNodes[2].nodeName).equals('C')
+        
+                    const iter = domFor(vnode)
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[0]})
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[1]})
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[2]})
+                    o(iter.next().done).deepEquals(true)
+                    o(root.childNodes.length).equals(3)
+                })
+                const C = createComponent({
+                    view({children}){return children},
+                    oncreate
+                })
+                render(root, m(C, [
+                    m('a'),
+                    m('b'),
+                    m('c')
+                ]))
+                o(oncreate.callCount).equals(1)
+            })
+            o('works for components that return fragments with delayed removal', function () {
+                const onbeforeremove = o.spy(function onbeforeremove(){return {then(){}, finally(){}}})
+                const oncreate = o.spy(function oncreate(vnode){
+                    o(root.childNodes.length).equals(3)
+                    o(root.childNodes[0].nodeName).equals('A')
+                    o(root.childNodes[1].nodeName).equals('B')
+                    o(root.childNodes[2].nodeName).equals('C')
+        
+                    const iter = domFor(vnode)
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[0]})
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[1]})
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[2]})
+                    o(iter.next().done).deepEquals(true)
+                    o(root.childNodes.length).equals(3)
+                })
+                const onupdate = o.spy(function onupdate(vnode) {
+                    o(root.childNodes.length).equals(3)
+                    o(root.childNodes[0].nodeName).equals('A')
+                    o(root.childNodes[1].nodeName).equals('B')
+                    o(root.childNodes[2].nodeName).equals('C')
+        
+                    const iter = domFor(vnode)
+
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[0]})
+                    o(iter.next()).deepEquals({done:false, value: root.childNodes[2]})
+                    o(iter.next().done).deepEquals(true)
+                    o(root.childNodes.length).equals(3)            
+                })
+                const C = createComponent({
+                    view({children}){return children},
+                    oncreate,
+                    onupdate
+                })
+                render(root, m(C, [
+                    m('a'),
+                    m('b', {onbeforeremove}),
+                    m('c')
+                ]))
+                render(root, m(C, [
+                    m('a'),
+                    null,
+                    m('c')
+                ]))
+                o(oncreate.callCount).equals(1)
+                o(onupdate.callCount).equals(1)
+                o(onbeforeremove.callCount).equals(1)
+            })
+        })
+    })
+})

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -99,12 +99,15 @@ module.exports = function(options) {
 		}
 	}
 	function removeChild(child) {
+		if (child == null || typeof child !== 'object' || !("nodeType" in child)) {
+			throw new TypeError("Failed to execute removeChild, parameter is not of type 'Node'")
+		}
 		var index = this.childNodes.indexOf(child)
 		if (index > -1) {
 			this.childNodes.splice(index, 1)
 			child.parentNode = null
 		}
-		else throw new TypeError("Failed to execute 'removeChild'")
+		else throw new TypeError("Failed to execute 'removeChild', child not found in parent")
 	}
 	function insertBefore(child, reference) {
 		var ancestor = this


### PR DESCRIPTION
Add `m.domFor(vnode)`

## Description

This adds `m.domFor(vnode)` as described in #2780 (with a twist to deal with node removal between iterations)

The docs has yet to be written

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I've added tests for `domFor()` and tweaked the `onremove` tests to match the new implementation that relies on `.finally`, not `.then`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
