### PR TITLE
WiP: Inline scope components

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,12 +1,13 @@
 name: auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ next ]
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
       - uses: ahmadnassri/action-dependabot-auto-merge@v2

--- a/render/render.js
+++ b/render/render.js
@@ -411,6 +411,11 @@ module.exports = function($window) {
 			}
 			else updateComponent(parent, old, vnode, hooks, nextSibling, ns)
 		}
+		else if(typeof oldTag === "function" && oldTag.toString() === tag.toString()) {
+			vnode.state = old.state
+
+			updateComponent(parent, old, vnode, hooks, nextSibling, ns)
+		}
 		else {
 			removeNode(parent, old)
 			createNode(parent, vnode, hooks, ns, nextSibling)

--- a/render/tests/test-inlineComponent.js
+++ b/render/tests/test-inlineComponent.js
@@ -1,0 +1,46 @@
+"use strict"
+
+var o = require("ospec")
+var window = require("../../test-utils/browserMock")()
+
+if (typeof global !== "undefined") {
+	global.window = window
+	global.document = window.document
+	global.requestAnimationFrame = function(callback){callback()}
+}
+
+var m = require("../../index")
+
+o.spec("inline component", function() {
+	o.beforeEach(function() {
+		m.render(document.body, null)
+	})
+
+	o("allows closure components to be identified by source equality", function(){
+		var oninit = o.spy()
+		var view = o.spy()
+		var onremove = o.spy()
+
+		m.mount(document.body, {
+			view: function() {
+				return m(function Component() {
+					return {
+						oninit,
+						onremove,
+						view: function() {
+							view()
+
+							return ""
+						},
+					}
+				})
+			}
+		})
+
+		m.redraw()
+
+		o(oninit.callCount).equals(1)("1 initialisation")
+		o(view.callCount).equals(2)("2 view executions")
+		o(onremove.callCount).equals(0)("0 teardowns")
+	})
+})


### PR DESCRIPTION
## Description
Add a new clause in the `updateNode` render loop which determines scope components to be equivalent if their source is identical. 

## Motivation and Context
The ability to declare a component inline allows for ad-hoc state capture without the rigmarole of breaking out to define a component elsewhere, determine what contextual reference access it needs, write the `attrs` interface accordingly, and then invoke it at call-site. In fact it facilitates iterative component development by enabling authors to experiment with component logic while benefiting from full call-site context reference access – leaving restrictive interface design as a formal 'ejection' exercise rather than a constant site of friction. 

The internal logic determining equivalence relies on `oldTag.toString() === tag.toString`. Object and class components do not have as straightforward source-sniffing APIs, and the idiomatic style of OOP component-based application design means there is less benefit to the inter-scope access inline components provide.

## How Has This Been Tested?
I've written a new test module but – strangely – these only pass if I run it alone, ie `npm run test:js ./render/test-inlineComponent.js`; maybe it's something to do with my slap-dash global Mithril instantiation at the top of the test file?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
