### PR TITLE
stringifying xhr error response

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -93,13 +93,17 @@ module.exports = function($window, oncompletion) {
 							resolve(response)
 						}
 						else {
-							var completeErrorResponse = function() {
-								try { message = ev.target.responseText }
-								catch (e) { message = JSON.stringify(response) }
-								var error = new Error(message)
-								error.code = ev.target.status
-								error.response = response
-								reject(error)
+							var completeErrorResponse = function () {
+								if (ev.target.responseType == "json") {
+									reject(response)
+								} else {
+									try { message = ev.target.responseText }
+									catch (e) { message = response }
+									var error = new Error(message)
+									error.code = ev.target.status
+									error.response = response
+									reject(error)
+								}
 							}
 
 							if (xhr.status === 0) {

--- a/request/request.js
+++ b/request/request.js
@@ -95,7 +95,7 @@ module.exports = function($window, oncompletion) {
 						else {
 							var completeErrorResponse = function() {
 								try { message = ev.target.responseText }
-								catch (e) { message = response }
+								catch (e) { message = JSON.stringify(response) }
 								var error = new Error(message)
 								error.code = ev.target.status
 								error.response = response


### PR DESCRIPTION
When an XHR error response is returned with responseType set to 'json' the error reponse is not handled correctly.

## Description
When the responseText is type JSON the response is still assigned to the new Error which is expecting a string.

## Motivation and Context
This PR is an attempt to address https://github.com/MithrilJS/mithril.js/issues/2802

## How Has This Been Tested?
I ran `yarn test request/tests/test-request.js` 
I saw a bunch of warnings and errors that were unrelated I believe.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
