### PR TITLE
Clarify a couple of pitfalls I landed in

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -277,6 +277,9 @@ class ClassComponent {
 Class components must define a `view()` method, detected via `.prototype.view`, to get the tree to render.
 
 They can be consumed in the same way regular components can.
+Note the class itself is the component: it's `m(ClassComponent)` not `m(new ClassComponent())`,
+with any constructor called in place of the `oninit()` lifecycle method.
+
 
 ```javascript
 // EXAMPLE: via m.render

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -416,6 +416,9 @@ m.route(rootElem, "/", {
 })
 ```
 
+Note we've added the `key` property to the child of `Layout`,
+i.e. it's `m(Layout, m(Person, {key: ...}))` not `m(Layout, {key: ...}, m(Person, ...))`.
+
 ### Common gotchas
 
 There's several common gotchas that people run into with keys. Here's some of them, to help you understand why they don't work.


### PR DESCRIPTION
## Description

Non-functional doc changes that clarify a couple of pitfalls I fell into while learning mithril.  Trying to use a class instance as a component rather than the class itself leads weirdness as mithril ends up using the object instance as a prototype for a new object with shadowed properties. 

With single keyed fragments I missed the point about keying the child rather than the shared parent object and took a while to realize my mistake.  Maybe there's a better explanation for why it's that wya.

## Motivation and Context

Save time and simplify the learning curve.

## How Has This Been Tested?

Doc.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
