### PR TITLE
Bypass css text

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -800,10 +800,10 @@ module.exports = function($window) {
 			// Styles are equivalent, do nothing.
 		} else if (style == null) {
 			// New style is missing, just clear it.
-			element.style.cssText = ""
+			element.style = ""
 		} else if (typeof style !== "object") {
 			// New style is a string, let engine deal with patching.
-			element.style.cssText = style
+			element.style = style
 		} else if (old == null || typeof old !== "object") {
 			// `old` is missing or a string, `style` is an object.
 			element.style.cssText = ""

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -346,9 +346,8 @@ module.exports = function(options) {
 					get style() {
 						return style
 					},
-					set style(_){
-						// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style#Setting_style
-						throw new Error("setting element.style is not portable")
+					set style(value){
+						this.style.cssText = value
 					},
 					get className() {
 						return this.attributes["class"] ? this.attributes["class"].value : ""

--- a/test-utils/tests/test-domMock.js
+++ b/test-utils/tests/test-domMock.js
@@ -665,16 +665,13 @@ o.spec("domMock", function() {
 			o(div.style.background).equals("url('/*foo*/')")
 
 		})
-		o("setting style throws", function () {
+		o("setting style updates style.cssText", function () {
 			var div = $document.createElement("div")
-			var err = false
-			try {
-				div.style = ""
-			} catch (e) {
-				err = e
-			}
+			div.style = "background: red;"
 
-			o(err instanceof Error).equals(true)
+			o(div.style.background).equals("red")
+			o(div.style.cssText).equals("background: red;")
+
 		})
 	})
 	o.spec("events", function() {


### PR DESCRIPTION
Shave a few bytes by setting `element.style` directly, rather than `element.style.cssText`, since the former is now supported everywhere relevant.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Internal tweak (non-breaking change which saves a few bytes of payload).
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
