### PR TITLE
hyperscript: handles shared empty attrs, fixes #2821

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -38,7 +38,7 @@ function execSelector(state, vnode) {
 	vnode.tag = state.tag
 	vnode.attrs = {}
 
-	if (!isEmpty(state.attrs) && !isEmpty(attrs)) {
+	if (!isEmpty(state.attrs)) {
 		var newAttrs = {}
 
 		for (var key in attrs) {

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -580,6 +580,15 @@ o.spec("hyperscript", function() {
 			o(nodeB.attrs.className).equals("b")
 			o(nodeB.attrs.a).equals("b")
 		})
+		o("handles shared empty attrs (#2821)", function() {
+			var attrs = {}
+
+			var nodeA = m(".a", attrs)
+			var nodeB = m(".b", attrs)
+
+			o(nodeA.attrs.className).equals("a")
+			o(nodeB.attrs.className).equals("b")
+		})
 		o("doesnt modify passed attributes object", function() {
 			var attrs = {a: "b"}
 			m(".a", attrs)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Whenever there are selector-derived attrs, the attrs object will be regenerated and not shared.

## Description
<!--- Describe your changes in detail -->
When selector-derived attrs exist, the attrs object is regenerated. However, if the attrs object is empty, the attrs object is not regenerated, and the selector-derived attrs is unintentionally shared.
In this pr, the condition `!isEmpty(attrs)` was removed so that even if the attrs object is empty, the attrs object is regenerated if there are selector-derived attrs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One tiny bug #2821 has been fixed, and the code outlook is a bit better.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added test and ran `npm run build`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
