### PR TITLE
Global error management

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var hyperscript = require("./hyperscript")
 var request = require("./request")
 var mountRedraw = require("./mount-redraw")
 var domFor = require("./render/domFor")
+var errorManager = require("./util/errorManager")
 
 var m = function m() { return hyperscript.apply(this, arguments) }
 m.m = hyperscript
@@ -22,5 +23,6 @@ m.buildPathname = require("./pathname/build")
 m.vnode = require("./render/vnode")
 m.censor = require("./util/censor")
 m.domFor = domFor.domFor
+m.errorManager = errorManager.em
 
 module.exports = m

--- a/render/render.js
+++ b/render/render.js
@@ -155,10 +155,10 @@ module.exports = function($window) {
 		if (vnode.attrs != null) initLifecycle(vnode.attrs, vnode, hooks)
 		try {
 			vnode.instance = Vnode.normalize(callHook.call(vnode.state.view, vnode))
-			if (vnode.instance === vnode) throw Error("A view cannot return the vnode it received as argument")
 		} catch (e) {
-			errorManager.fail(e, vnode)
+			vnode.instance = Vnode.normalize(errorManager.fail(e, vnode, true))
 		}
+		if (vnode.instance === vnode) errorManager.fail("A view cannot return the vnode it received as argument", vnode, false)
 		sentinel.$$reentrantLock$$ = null
 	}
 	function createComponent(parent, vnode, hooks, ns, nextSibling) {
@@ -466,8 +466,12 @@ module.exports = function($window) {
 		}
 	}
 	function updateComponent(parent, old, vnode, hooks, nextSibling, ns) {
-		vnode.instance = Vnode.normalize(callHook.call(vnode.state.view, vnode))
-		if (vnode.instance === vnode) throw Error("A view cannot return the vnode it received as argument")
+		try {
+			vnode.instance = Vnode.normalize(callHook.call(vnode.state.view, vnode))
+		} catch (e) {
+			vnode.instance = Vnode.normalize(errorManager.fail(e, vnode, true))
+		}
+		if (vnode.instance === vnode) errorManager.fail("A view cannot return the vnode it received as argument", vnode, false)
 		updateLifecycle(vnode.state, vnode, hooks)
 		if (vnode.attrs != null) updateLifecycle(vnode.attrs, vnode, hooks)
 		if (vnode.instance != null) {

--- a/util/errorManager.js
+++ b/util/errorManager.js
@@ -33,10 +33,10 @@ module.exports = {
         })
     },
 
-    fail(error, vnode) {
-      this.executeListeners(
+    fail(error, vnode, inView) {
+      return this.executeListeners(
         this.failEventListeners,
-        {error:error, vnode:vnode},
+        {error:error, vnode:vnode, inView:inView},
         () => {
           this.debugVnode(0, vnode)
           if (error instanceof Error) 
@@ -67,8 +67,8 @@ module.exports = {
     executeListeners(listeners, param, defaultHandler) {
       let stopProcessing = false;
       for (let i=0 ; i<listeners.length ; i++) {
-        listeners[i](param, () => {stopProcessing=true})
-        if (stopProcessing) return
+        let returnValue = listeners[i](param, () => {stopProcessing=true})
+        if (stopProcessing) return returnValue
       }
       defaultHandler()
     },

--- a/util/errorManager.js
+++ b/util/errorManager.js
@@ -1,0 +1,42 @@
+"use strict"
+
+// Log levels are:
+// * 0 error
+// * 1 warning
+// * 2 info
+// * 3 debug
+
+module.exports = {
+  em: {
+    log(level, message) {
+      switch (level) {
+        case 0:
+          console.error(message)
+          break;
+        case 1:
+          console.warn(message)
+          break;
+        case 2:
+          console.info(message)
+          break;
+        case 3:
+          console.debug(message)
+          break;
+      }
+    },
+
+    fail(error, vnode) {
+      this.debugVnode(0, vnode)
+      if (e instanceof Error) 
+        throw error
+      else
+        throw new Error(e)
+    },
+
+    debugVnode(level, vnode) {
+      if (vnode) {
+        this.log(level, "Context: " + JSON.stringify(vnode))
+      }
+    }
+  }
+}

--- a/util/errorManager.js
+++ b/util/errorManager.js
@@ -8,35 +8,76 @@
 
 module.exports = {
   em: {
+    logEventListeners:[],
+    failEventListeners:[],
+
     log(level, message) {
-      switch (level) {
-        case 0:
-          console.error(message)
-          break;
-        case 1:
-          console.warn(message)
-          break;
-        case 2:
-          console.info(message)
-          break;
-        case 3:
-          console.debug(message)
-          break;
-      }
+      this.executeListeners(
+        this.logEventListeners, 
+        {level:level,message:message},
+        () => {
+          switch (level) {
+            case 0:
+              console.error(message)
+              break;
+            case 1:
+              console.warn(message)
+              break;
+            case 2:
+              console.info(message)
+              break;
+            case 3:
+              console.debug(message)
+              break;
+          }
+        })
     },
 
     fail(error, vnode) {
-      this.debugVnode(0, vnode)
-      if (e instanceof Error) 
-        throw error
-      else
-        throw new Error(e)
+      this.executeListeners(
+        this.failEventListeners,
+        {error:error, vnode:vnode},
+        () => {
+          this.debugVnode(0, vnode)
+          if (error instanceof Error) 
+            throw error
+          else
+            throw new Error(error)
+        }
+      )
     },
 
     debugVnode(level, vnode) {
       if (vnode) {
         this.log(level, "Context: " + JSON.stringify(vnode))
       }
+    },
+
+    addEventListener(name, callback) {
+      switch (name) {
+        case "log":
+          this.addToArray(this.logEventListeners, callback)
+          break
+        case "fail":
+          this.addToArray(this.failEventListeners, callback)
+          break
+      }
+    },
+
+    executeListeners(listeners, param, defaultHandler) {
+      let stopProcessing = false;
+      for (let i=0 ; i<listeners.length ; i++) {
+        listeners[i](param, () => {stopProcessing=true})
+        if (stopProcessing) return
+      }
+      defaultHandler()
+    },
+
+    addToArray(array, object) {
+      for (let i=0 ; i<array.length ; i++) {
+        if (array[i] === object) return
+      }
+      array.push(object)
     }
   }
 }

--- a/util/errorManager.js
+++ b/util/errorManager.js
@@ -49,7 +49,7 @@ module.exports = {
 
     debugVnode(level, vnode) {
       if (vnode) {
-        this.log(level, "Context: " + JSON.stringify(vnode))
+        this.log(level, "Component: " + vnode.tag.name + " with attributes " + JSON.stringify(vnode.attrs))
       }
     },
 


### PR DESCRIPTION
## Description
I introduced an object called errorManager in mithril. Its goal is to be a centralized place to handle errors and logging.


## Motivation and Context
Note: This is not supposed to be merged "as-is", but I am looking for feedback as to whether this type of change could be merged if I push it all the way (and also whether I did it the "right" way or not).

This change is here to help people that write apps with mithril handle errors (such as exceptions) in their code. This has two main goals:
 * Monitoring: If you have an app that is deployed in the wild, keeping track of the errors on the client side is a must have. `console.log` cannot handle that. You need to call back somewhere to log all (or a sample of) errors happening. With this change the user can plug its own callbacks.
 * Recovery: When one small component in your app throws an exception in its view component, currently, the app is dead and will not recover. I need a way to display that something is wrong and let the user try something else on another page.

Remains to be done (in my view):

* Propagate the usage to other places where console.log/warn/throw is used
* Wrap other component methods than `view` (`oninit`, `oncreate`, ...)
* define one more component method: `onerror`. Default behavior should use this method if it exists.
* Write documentation

## How Has This Been Tested?
* manually for now

https://pieroxy.net/test-mithril/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
