### PR TITLE
docs: fix regex to parse page title

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -161,7 +161,7 @@ class Generator {
 		)
 
 		const markedHtml = marked(body)
-		const title = body.match(/^#([^\n\r]+)/i) || []
+		const title = body.match(/#([^\n\r]+)/i) || []
 
 		let result = this._layout
 		if (title[1]) {
@@ -176,7 +176,7 @@ class Generator {
 
 		// insert parsed HTML
 		result = result.replace(/\[body\]/, markedHtml)
-		
+
 		// insert meta description
 		result = result.replace(/\[metaDescription\]/, metaDescription)
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -176,7 +176,7 @@ class Generator {
 
 		// insert parsed HTML
 		result = result.replace(/\[body\]/, markedHtml)
-
+		
 		// insert meta description
 		result = result.replace(/\[metaDescription\]/, metaDescription)
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -161,7 +161,7 @@ class Generator {
 		)
 
 		const markedHtml = marked(body)
-		const title = body.match(/#([^\n\r]+)/i) || []
+		const title = body.match(/^#\s+([^\n\r]+)/m) || []
 
 		let result = this._layout
 		if (title[1]) {


### PR DESCRIPTION
Fixes #2833. I tested the generated documentation on my dev machine successfully.

And sorry for the white noise, some vsc plugin goes crazy.