### PR TITLE
docs: fix regex for parsing page title

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -161,7 +161,7 @@ class Generator {
 		)
 
 		const markedHtml = marked(body)
-		const title = body.match(/^#([^\n\r]+)/i) || []
+		const title = body.match(/^#\s+([^\n\r]+)/m) || []
 
 		let result = this._layout
 		if (title[1]) {


### PR DESCRIPTION
Fixes https://github.com/MithrilJS/mithril.js/issues/2833. I tested the generated documentation on my dev machine successfully.