### PR TITLE
docs: absolute url in version selector to avoid 404 errors (2 of 2)

### DIFF
--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -95,7 +95,7 @@ async function archiveDocsSelect() {
 	var options = archiveDirs
 		.map((ad) => `<option>${ad}</option>`)
 		.join("")
-	return `<select id="archive-docs" onchange="location.href='archive/' + this.value + '/index.html'">${options}</select>`
+	return `<select id="archive-docs" onchange="location.href='/archive/' + this.value + '/index.html'">${options}</select>`
 }
 
 function encodeHTML (str) {


### PR DESCRIPTION
Fixes #2832 (2 of 2 pull requests).

See my comment at https://github.com/MithrilJS/mithril.js/pull/2835#issuecomment-1535657892.