### PR TITLE
docs: fix broken npm run watch:docs

### DIFF
--- a/docs/stream.md
+++ b/docs/stream.md
@@ -462,7 +462,7 @@ Pending streams can be created by calling `stream()` with no parameters.
 var pending = stream()
 ```
 
-If a stream is dependent on more than one stream, any of its parent streams is in a pending state, the dependent streams is also in a pending state, and does not update its value.
+If a stream is dependent on more than one stream and any of its parent streams is in a pending state, the dependent stream is also in a pending state, and does not update its value.
 
 ```javascript
 var a = stream(5)
@@ -558,13 +558,13 @@ console.log(serialized) // logs 123
 
 Unlike libraries like Knockout, Mithril.js streams do not trigger re-rendering of templates. Redrawing happens in response to event handlers defined in Mithril.js component views, route changes, or after [`m.request`](request.md) calls resolve.
 
-If redrawing is desired in response to other asynchronous events (e.g. `setTimeout`/`setInterval`, websocket subscription, 3rd party library event handler, etc), you should manually call [`m.redraw()`](redraw.md)
+If redrawing is desired in response to other asynchronous events (e.g. `setTimeout`/`setInterval`, websocket subscription, 3rd party library event handler, etc.), you should manually call [`m.redraw()`](redraw.md).
 
 ---
 
 ### What is Fantasy Land
 
-[Fantasy Land](https://github.com/fantasyland/fantasy-land) specifies interoperability of common algebraic structures. In plain english, that means that libraries that conform to Fantasy Land specs can be used to write generic functional style code that works regardless of how these libraries implement the constructs.
+[Fantasy Land](https://github.com/fantasyland/fantasy-land) specifies interoperability of common algebraic structures. In plain English, that means that libraries that conform to Fantasy Land specs can be used to write generic functional style code that works regardless of how these libraries implement the constructs.
 
 For example, say we want to create a generic function called `plusOne`. The naive implementation would look like this:
 
@@ -574,7 +574,7 @@ function plusOne(a) {
 }
 ```
 
-The problem with this implementation is that it can only be used with a number. However it's possible that whatever logic produces a value for `a` could also produce an error state (wrapped in a Maybe or an Either from a library like [Sanctuary](https://github.com/sanctuary-js/sanctuary) or [Ramda-Fantasy](https://github.com/ramda/ramda-fantasy)), or it could be a Mithril.js stream, or a [flyd](https://github.com/paldepind/flyd) stream, etc. Ideally, we wouldn't want to write a similar version of the same function for every possible type that `a` could have and we wouldn't want to be writing wrapping/unwrapping/error handling code repeatedly.
+The problem with this implementation is that it can only be used with a number. However it's possible that whatever logic produces a value for `a` could also produce an error state (wrapped in a Maybe or an Either from a library like [Sanctuary](https://github.com/sanctuary-js/sanctuary) or [Ramda-Fantasy](https://github.com/ramda/ramda-fantasy)), or it could be a Mithril.js stream, a [Flyd](https://github.com/paldepind/flyd) stream, etc. Ideally, we wouldn't want to write a similar version of the same function for every possible type that `a` could have and we wouldn't want to be writing wrapping/unwrapping/error handling code repeatedly.
 
 This is where Fantasy Land can help. Let's rewrite that function in terms of a Fantasy Land algebra:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,9 +309,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -1954,7 +1954,7 @@
     "node_modules/istanbul/node_modules/async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
       "dev": true
     },
     "node_modules/istanbul/node_modules/esprima": {
@@ -4066,9 +4066,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -5321,7 +5321,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
           "dev": true
         },
         "esprima": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,9 +2502,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -5741,9 +5741,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -38,7 +38,7 @@ function execSelector(state, vnode) {
 	vnode.tag = state.tag
 	vnode.attrs = {}
 
-	if (!isEmpty(state.attrs) && !isEmpty(attrs)) {
+	if (!isEmpty(state.attrs)) {
 		var newAttrs = {}
 
 		for (var key in attrs) {

--- a/render/tests/test-hyperscript.js
+++ b/render/tests/test-hyperscript.js
@@ -580,6 +580,15 @@ o.spec("hyperscript", function() {
 			o(nodeB.attrs.className).equals("b")
 			o(nodeB.attrs.a).equals("b")
 		})
+		o("handles shared empty attrs (#2821)", function() {
+			var attrs = {}
+
+			var nodeA = m(".a", attrs)
+			var nodeB = m(".b", attrs)
+
+			o(nodeA.attrs.className).equals("a")
+			o(nodeB.attrs.className).equals("b")
+		})
 		o("doesnt modify passed attributes object", function() {
 			var attrs = {a: "b"}
 			m(".a", attrs)

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -292,7 +292,7 @@ if (require.main === module) {
 	require("./_command")({
 		exec: generate,
 		async watch() {
-			const generator = (await makeGenerator())
+			const generator = await makeGenerator()
 
 			function isLayoutFile(relative) {
 				return relative === "layout.html"
@@ -303,21 +303,21 @@ if (require.main === module) {
 			}
 
 			async function updateGenerator() {
-				generator.generate()
+				await generator.generate()
 			}
 
 			async function updateFile(file) {
 				const relative = path.relative(r("docs"), file)
 				if (isLayoutFile(relative)) {
 					generator.setLayout(await loadLayoutFile())
-					generator.generate()
+					await generator.generate()
 				} else if (isNavigationFile(relative)) {
 					const [guides, methods] = await loadNavigationFiles()
 					generator.setGuides(guides)
 					generator.setMethods(methods)
-					generator.generate()
+					await generator.generate()
 				} else {
-					generator.generateSingle(file)
+					await generator.generateSingle(file)
 				}
 			}
 
@@ -329,7 +329,7 @@ if (require.main === module) {
 					throw `Error: the navigation file "${relative}" is required!`
 				}
 				const relativeDist = relative.replace(/\.md$/, ".html")
-				generator.eachTarget(relativeDist, (dest) => fs.unlink(dest))
+				await generator.eachTarget(relativeDist, (dest) => fs.unlink(dest))
 				console.log("Removed: " + relative)
 			}
 

--- a/scripts/generate-docs.js
+++ b/scripts/generate-docs.js
@@ -292,14 +292,14 @@ if (require.main === module) {
 	require("./_command")({
 		exec: generate,
 		async watch() {
-			let generator = (await makeGenerator())
+			const generator = (await makeGenerator())
 
 			function isLayoutFile(relative) {
-				return relative === 'layout.html'
+				return relative === "layout.html"
 			}
 
 			function isNavigationFile(relative) {
-				return ['nav-guides.md', 'nav-methods.md'].includes(relative)
+				return ["nav-guides.md", "nav-methods.md"].includes(relative)
 			}
 
 			async function updateGenerator() {
@@ -310,9 +310,9 @@ if (require.main === module) {
 				const relative = path.relative(r("docs"), file)
 				if (isLayoutFile(relative)) {
 					generator.setLayout(await loadLayoutFile())
-					generator.generate()					
+					generator.generate()
 				} else if (isNavigationFile(relative)) {
-					let [guides, methods] = await loadNavigationFiles()
+					const [guides, methods] = await loadNavigationFiles()
 					generator.setGuides(guides)
 					generator.setMethods(methods)
 					generator.generate()
@@ -324,11 +324,9 @@ if (require.main === module) {
 			async function removeFile(file) {
 				const relative = path.relative(r("docs"), file)
 				if (isLayoutFile(relative)) {
-					console.error(`Error: the layout file "${relative}" is required!`);
-					process.exit(1);					
+					throw `Error: the layout file "${relative}" is required!`
 				} else if (isNavigationFile(relative)) {
-					console.error(`Error: the navigation file "${relative}" is required!`);
-					process.exit(1);
+					throw `Error: the navigation file "${relative}" is required!`
 				}
 				const relativeDist = relative.replace(/\.md$/, ".html")
 				generator.eachTarget(relativeDist, (dest) => fs.unlink(dest))


### PR DESCRIPTION
Fixes #2840.

Since the behaviour of the current script was not so obvious, I set the requirements as follows and edited the script therefore.

If the layout.html was deleted:
- throw error "Error: the layout "layout.html" file is required!"

If the layout.html was updated:
- loads the layout file and regenerates all html files in dist

If a navigation file (nav-guides.md|nav-methods.md) was deleted:
- throw error "Error: the navigation file "nav-guides.md" is required!"

If a navigation file was updated:
- loads the navigation files and regenerates all pages in dist

If a markdown file was deleted:
- deletes the html page from dist

If a markdown file was updated:
- regenerates the html page in dist

If a markdown file was added:
- generates the html page in dist

If an asset file was deleted:
- deletes the asset file from dist

If an asset file was updated:
- updates the asset file in dist

If an asset file was added:
- adds the asset file to dist

