### PR TITLE
fix markdown editor example, bump marked.js version up

### DIFF
--- a/examples/editor/index.html
+++ b/examples/editor/index.html
@@ -12,7 +12,7 @@ h1,h2,h3,h4,h5,h6,p {margin:0 0 10px;}
 	</head>
 	<body>
 		<div id="editor"></div>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/0.6.0/marked.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/5.0.2/marked.min.js"></script>
 		<script src="../../mithril.js"></script>
 		<script>
 //model
@@ -31,7 +31,7 @@ var Editor = {
 				oninput: function (e) { state.update(e.target.value) },
 				value: state.text
 			}),
-			m(".preview", m.trust(marked(state.text))),
+			m(".preview", m.trust(marked.parse(state.text))),
 		]
 	}
 }


### PR DESCRIPTION
Fixes the strange behavior of markdown editor example.

## Description
Using newest version of marked.js, fixed strange behavior of markdown editor example.

## Motivation and Context
See #2845 

## How Has This Been Tested?
Manually tested on different macOS browsers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- ~~New feature (non-breaking change which adds functionality)~~
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~
- [x] Documentation change

## Checklist:
- [x] My code follows the code style of this project.
- ~~My change requires a change to the documentation.~~
- ~~I have updated the documentation accordingly.~~
- [x] I have read the **CONTRIBUTING** document.
- ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
- ~~I have updated `docs/changelog.md`~~
