### PR TITLE
fix(gh-pages): Correct Ospec link

### DIFF
--- a/archive/v2.2.2/api.html
+++ b/archive/v2.2.2/api.html
@@ -49,7 +49,7 @@
 </ul>
 </li>
 <li>Tooling<ul>
-<li><a href=https://github.com/MithrilJS/mithril.js/blob/master/ospec>Ospec</a></li>
+<li><a href=https://github.com/MithrilJS/ospec>Ospec</a></li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
The previous link led to a 404 page; Ospec is no longer part of the main code base

## Description
The Ospec link has been changed from `https://github.com/MithrilJS/mithril.js/blob/master/ospec` to `https://github.com/MithrilJS/ospec`

## Motivation and Context
Fixes #2859

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`
