### PR TITLE
Remove dependance on global window and document

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -5,8 +5,9 @@ var df = require("../render/domFor")
 var delayedRemoval = df.delayedRemoval
 var domFor = df.domFor
 
-module.exports = function($window) {
-	var $doc = $window && $window.document
+module.exports = function() {
+	var $window
+	var $doc
 
 	var nameSpace = {
 		svg: "http://www.w3.org/2000/svg",
@@ -916,6 +917,8 @@ module.exports = function($window) {
 	var currentDOM
 
 	return function(dom, vnodes, redraw) {
+		$window = dom.ownerDocument.defaultView;
+		$doc = $window && $window.document;
 		if (!dom) throw new TypeError("DOM element being rendered to does not exist.")
 		if (currentDOM != null && dom.contains(currentDOM)) {
 			throw new TypeError("Node is currently being rendered to and thus is locked.")

--- a/render/render.js
+++ b/render/render.js
@@ -5,8 +5,7 @@ var df = require("../render/domFor")
 var delayedRemoval = df.delayedRemoval
 var domFor = df.domFor
 
-module.exports = function($window) {
-	var $doc = $window && $window.document
+module.exports = function() {
 	var nameSpace = {
 		svg: "http://www.w3.org/2000/svg",
 		math: "http://www.w3.org/1998/Math/MathML"
@@ -16,7 +15,7 @@ module.exports = function($window) {
 	var currentRender
 
 	function getDocument(dom) {
-		return dom.ownerDocument || $doc;
+		return dom.ownerDocument;
 	}
 
 	function getNameSpace(vnode) {
@@ -919,8 +918,6 @@ module.exports = function($window) {
 	var currentDOM
 
 	return function(dom, vnodes, redraw) {
-		$doc = dom.ownerDocument;
-
 		if (!dom) throw new TypeError("DOM element being rendered to does not exist.")
 		if (currentDOM != null && dom.contains(currentDOM)) {
 			throw new TypeError("Node is currently being rendered to and thus is locked.")

--- a/render/render.js
+++ b/render/render.js
@@ -42,9 +42,9 @@ module.exports = function() {
 
 	// IE11 (at least) throws an UnspecifiedError when accessing document.activeElement when
 	// inside an iframe. Catch and swallow this error, and heavy-handidly return null.
-	function activeElement(document) {
+	function activeElement(dom) {
 		try {
-			return document.activeElement
+			return getDocument(dom).activeElement
 		} catch (e) {
 			return null
 		}
@@ -695,7 +695,7 @@ module.exports = function() {
 				/* eslint-disable no-implicit-coercion */
 				//setting input[value] to same value by typing on focused element moves cursor to end in Chrome
 				//setting input[type=file][value] to same value causes an error to be generated if it's non-empty
-				if ((vnode.tag === "input" || vnode.tag === "textarea") && vnode.dom.value === "" + value && (isFileInput || vnode.dom === activeElement(getDocument(vnode.dom)))) return
+				if ((vnode.tag === "input" || vnode.tag === "textarea") && vnode.dom.value === "" + value && (isFileInput || vnode.dom === activeElement(vnode.dom))) return
 				//setting select[value] to same value while having select open blinks select dropdown in Chrome
 				if (vnode.tag === "select" && old !== null && vnode.dom.value === "" + value) return
 				//setting option[value] to same value while having select open blinks select dropdown in Chrome
@@ -724,7 +724,7 @@ module.exports = function() {
 			&& key !== "title" // creates "null" as title
 			&& !(key === "value" && (
 				vnode.tag === "option"
-				|| vnode.tag === "select" && vnode.dom.selectedIndex === -1 && vnode.dom === activeElement(getDocument(vnode.dom))
+				|| vnode.tag === "select" && vnode.dom.selectedIndex === -1 && vnode.dom === activeElement(vnode.dom)
 			))
 			&& !(vnode.tag === "input" && key === "type")
 		) {
@@ -773,7 +773,7 @@ module.exports = function() {
 		}
 	}
 	function isFormAttribute(vnode, attr) {
-		return attr === "value" || attr === "checked" || attr === "selectedIndex" || attr === "selected" && vnode.dom === activeElement(getDocument(vnode.dom)) || vnode.tag === "option" && vnode.dom.parentNode === activeElement(getDocument(vnode.dom))
+		return attr === "value" || attr === "checked" || attr === "selectedIndex" || attr === "selected" && vnode.dom === activeElement(vnode.dom) || vnode.tag === "option" && vnode.dom.parentNode === activeElement(vnode.dom)
 	}
 	function isLifecycleMethod(attr) {
 		return attr === "oninit" || attr === "oncreate" || attr === "onupdate" || attr === "onremove" || attr === "onbeforeremove" || attr === "onbeforeupdate"
@@ -925,7 +925,7 @@ module.exports = function() {
 		var prevRedraw = currentRedraw
 		var prevDOM = currentDOM
 		var hooks = []
-		var active = activeElement(getDocument(dom))
+		var active = activeElement(dom)
 		var namespace = dom.namespaceURI
 
 		currentDOM = dom
@@ -938,7 +938,7 @@ module.exports = function() {
 			updateNodes(dom, dom.vnodes, vnodes, hooks, null, namespace === "http://www.w3.org/1999/xhtml" ? undefined : namespace)
 			dom.vnodes = vnodes
 			// `document.activeElement` can return null: https://html.spec.whatwg.org/multipage/interaction.html#dom-document-activeelement
-			if (active != null && activeElement(getDocument(dom)) !== active && typeof active.focus === "function") active.focus()
+			if (active != null && activeElement(dom) !== active && typeof active.focus === "function") active.focus()
 			for (var i = 0; i < hooks.length; i++) hooks[i]()
 		} finally {
 			currentRedraw = prevRedraw

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -718,6 +718,7 @@ module.exports = function(options) {
 			},
 			createDocumentFragment: function() {
 				return {
+					ownerDocument: $window.document,
 					nodeType: 11,
 					nodeName: "#document-fragment",
 					appendChild: appendChild,

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -307,6 +307,7 @@ module.exports = function(options) {
 					parentNode: null,
 					childNodes: [],
 					attributes: {},
+					ownerDocument: $window.document,
 					contains: function(child) {
 						while (child != null) {
 							if (child === this) return true
@@ -738,6 +739,7 @@ module.exports = function(options) {
 			get activeElement() {return activeElement},
 		},
 	}
+	$window.document.defaultView = $window
 	$window.document.documentElement = $window.document.createElement("html")
 	appendChild.call($window.document.documentElement, $window.document.createElement("head"))
 	$window.document.body = $window.document.createElement("body")


### PR DESCRIPTION
Use window and document from render target instead of using globals.
This makes unit and intergration testing much easier.

## Description
$window and $doc get set when `render` is called, and are based on the passed `dom`

## Motivation and Context
This decouples mithril from its environment and instead only couples it to DOM.
This allows tests environments to be more easily established, making testing in Node etc easier.
This also allows tests to run in parallel, which, while not needed for mithril it's self, can be useful in larger applications that use mithril.

## How Has This Been Tested?
All the existing tests pass

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated `docs/changelog.md`

Happy to check the last points off above if this PR is likely to get merged.