### PR TITLE
[refactor] Refactoring of hyperscript.js and render.js, including performance improvements

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -6,7 +6,6 @@ var m = require("../render/hyperscript")
 var buildPathname = require("../pathname/build")
 var parsePathname = require("../pathname/parse")
 var compileTemplate = require("../pathname/compileTemplate")
-var assign = require("../util/assign")
 var censor = require("../util/censor")
 
 var sentinel = {}
@@ -78,7 +77,7 @@ module.exports = function($window, mountRedraw) {
 			.slice(route.prefix.length)
 		var data = parsePathname(path)
 
-		assign(data.params, $window.history.state)
+		Object.assign(data.params, $window.history.state)
 
 		function reject(e) {
 			console.error(e)

--- a/pathname/build.js
+++ b/pathname/build.js
@@ -1,7 +1,6 @@
 "use strict"
 
 var buildQueryString = require("../querystring/build")
-var assign = require("../util/assign")
 
 // Returns `path` from `template` + `params`
 module.exports = function(template, params) {
@@ -16,7 +15,7 @@ module.exports = function(template, params) {
 	var path = template.slice(0, pathEnd)
 	var query = {}
 
-	assign(query, params)
+	Object.assign(query, params)
 
 	var resolved = path.replace(/:([^\/\.-]+)(\.{3})?/g, function(m, key, variadic) {
 		delete query[key]

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -6,7 +6,7 @@ var hasOwn = require("../util/hasOwn")
 var assign = require("../util/assign")
 
 var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
-var selectorCache = {}
+var selectorCache = Object.create(null)
 
 function isEmpty(object) {
 	for (var key in object) if (hasOwn.call(object, key)) return false

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -56,6 +56,13 @@ function execSelector(state, vnode) {
 
 	if (hasClass) attrs.class = null
 
+	// workaround for #2622 (reorder keys in attrs to set "type" first)
+	// The DOM does things to inputs based on the "type", so it needs set first.
+	// See: https://github.com/MithrilJS/mithril.js/issues/2622
+	if (state.tag === "input" && hasOwn.call(attrs, "type")) {
+		attrs = assign({type: attrs.type}, attrs)
+	}
+
 	vnode.attrs = attrs
 
 	return vnode

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -3,7 +3,6 @@
 var Vnode = require("../render/vnode")
 var hyperscriptVnode = require("./hyperscriptVnode")
 var hasOwn = require("../util/hasOwn")
-var assign = require("../util/assign")
 
 var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = Object.create(null)
@@ -40,7 +39,7 @@ function execSelector(state, vnode) {
 	vnode.tag = state.tag
 
 	if (state.attrs != null) {
-		attrs = assign({}, state.attrs, attrs)
+		attrs = Object.assign({}, state.attrs, attrs)
 
 		if (className != null || state.attrs.className != null) attrs.className =
 			className != null
@@ -60,7 +59,7 @@ function execSelector(state, vnode) {
 	// The DOM does things to inputs based on the "type", so it needs set first.
 	// See: https://github.com/MithrilJS/mithril.js/issues/2622
 	if (state.tag === "input" && hasOwn.call(attrs, "type")) {
-		attrs = assign({type: attrs.type}, attrs)
+		attrs = Object.assign({type: attrs.type}, attrs)
 	}
 
 	vnode.attrs = attrs

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -41,16 +41,18 @@ function execSelector(state, vnode) {
 
 	if (state.attrs != null) {
 		attrs = assign({}, state.attrs, attrs)
-	}
 
-	if (className != null || state.attrs.className != null) attrs.className =
-		className != null
-			? state.attrs.className != null
-				? String(state.attrs.className) + " " + String(className)
-				: className
-			: state.attrs.className != null
-				? state.attrs.className
-				: null
+		if (className != null || state.attrs.className != null) attrs.className =
+			className != null
+				? state.attrs.className != null
+					? String(state.attrs.className) + " " + String(className)
+					: className
+				: state.attrs.className != null
+					? state.attrs.className
+					: null
+	} else {
+		if (className != null) attrs.className = className
+	}
 
 	if (hasClass) attrs.class = null
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -28,6 +28,7 @@ function compileSelector(selector) {
 		}
 	}
 	if (classes.length > 0) attrs.className = classes.join(" ")
+	if (isEmpty(attrs)) attrs = null
 	return selectorCache[selector] = {tag: tag, attrs: attrs}
 }
 
@@ -38,7 +39,7 @@ function execSelector(state, vnode) {
 
 	vnode.tag = state.tag
 
-	if (!isEmpty(state.attrs)) {
+	if (state.attrs != null) {
 		attrs = assign({}, state.attrs, attrs)
 	}
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -3,6 +3,7 @@
 var Vnode = require("../render/vnode")
 var hyperscriptVnode = require("./hyperscriptVnode")
 var hasOwn = require("../util/hasOwn")
+var assign = require("../util/assign")
 
 var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["'\]]|.)*?)\5)?\])/g
 var selectorCache = {}
@@ -38,20 +39,9 @@ function execSelector(state, vnode) {
 	vnode.tag = state.tag
 
 	if (!isEmpty(state.attrs)) {
-		var newAttrs = {}
-
-		for (var key in attrs) {
-			if (hasOwn.call(attrs, key)) newAttrs[key] = attrs[key]
-		}
-
-		attrs = newAttrs
+		attrs = assign({}, state.attrs, attrs)
 	}
 
-	for (var key in state.attrs) {
-		if (hasOwn.call(state.attrs, key) && key !== "className" && !hasOwn.call(attrs, key)){
-			attrs[key] = state.attrs[key]
-		}
-	}
 	if (className != null || state.attrs.className != null) attrs.className =
 		className != null
 			? state.attrs.className != null

--- a/render/render.js
+++ b/render/render.js
@@ -671,9 +671,8 @@ module.exports = function() {
 
 	//attrs
 	function setAttrs(vnode, attrs, ns) {
-		var isFileInput = attrs != null && vnode.tag === "input" && attrs.type === "file"
 		for (var key in attrs) {
-			setAttr(vnode, key, null, attrs[key], ns, isFileInput)
+			setAttr(vnode, key, null, attrs[key], ns)
 		}
 	}
 	function setAttr(vnode, key, old, value, ns, isFileInput) {
@@ -685,6 +684,7 @@ module.exports = function() {
 			if (key === "value") {
 				// Only do the coercion if we're actually going to check the value.
 				/* eslint-disable no-implicit-coercion */
+				var isFileInput = vnode.tag === "input" && vnode.attrs.type === "file"
 				//setting input[value] to same value by typing on focused element moves cursor to end in Chrome
 				//setting input[type=file][value] to same value causes an error to be generated if it's non-empty
 				if ((vnode.tag === "input" || vnode.tag === "textarea") && vnode.dom.value === "" + value && (isFileInput || vnode.dom === activeElement(vnode.dom))) return
@@ -747,9 +747,8 @@ module.exports = function() {
 			console.warn("Don't reuse attrs object, use new object for every redraw, this will throw in next major")
 		}
 		if (attrs != null) {
-			var isFileInput = vnode.tag === "input" && attrs.type === "file"
 			for (var key in attrs) {
-				setAttr(vnode, key, old && old[key], attrs[key], ns, isFileInput)
+				setAttr(vnode, key, old && old[key], attrs[key], ns)
 			}
 		}
 		var val

--- a/render/render.js
+++ b/render/render.js
@@ -671,18 +671,13 @@ module.exports = function() {
 
 	//attrs
 	function setAttrs(vnode, attrs, ns) {
-		// If you assign an input type that is not supported by IE 11 with an assignment expression, an error will occur.
-		//
-		// Also, the DOM does things to inputs based on the value, so it needs set first.
-		// See: https://github.com/MithrilJS/mithril.js/issues/2622
-		if (vnode.tag === "input" && attrs.type != null) vnode.dom.setAttribute("type", attrs.type)
 		var isFileInput = attrs != null && vnode.tag === "input" && attrs.type === "file"
 		for (var key in attrs) {
 			setAttr(vnode, key, null, attrs[key], ns, isFileInput)
 		}
 	}
 	function setAttr(vnode, key, old, value, ns, isFileInput) {
-		if (key === "key" || key === "is" || value == null || isLifecycleMethod(key) || (old === value && !isFormAttribute(vnode, key)) && typeof value !== "object" || key === "type" && vnode.tag === "input") return
+		if (key === "key" || key === "is" || value == null || isLifecycleMethod(key) || (old === value && !isFormAttribute(vnode, key)) && typeof value !== "object") return
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
 		else if (key === "style") updateStyle(vnode.dom, old, value)
@@ -702,7 +697,9 @@ module.exports = function() {
 				if (isFileInput && "" + value !== "") { console.error("`value` is read-only on file inputs!"); return }
 				/* eslint-enable no-implicit-coercion */
 			}
-			vnode.dom[key] = value
+			// If you assign an input type that is not supported by IE 11 with an assignment expression, an error will occur.
+			if (vnode.tag === "input" && key === "type") vnode.dom.setAttribute(key, value)
+			else vnode.dom[key] = value
 		} else {
 			if (typeof value === "boolean") {
 				if (value) vnode.dom.setAttribute(key, "")
@@ -750,11 +747,6 @@ module.exports = function() {
 			console.warn("Don't reuse attrs object, use new object for every redraw, this will throw in next major")
 		}
 		if (attrs != null) {
-			// If you assign an input type that is not supported by IE 11 with an assignment expression, an error will occur.
-			//
-			// Also, the DOM does things to inputs based on the value, so it needs set first.
-			// See: https://github.com/MithrilJS/mithril.js/issues/2622
-			if (vnode.tag === "input" && attrs.type != null) vnode.dom.setAttribute("type", attrs.type)
 			var isFileInput = vnode.tag === "input" && attrs.type === "file"
 			for (var key in attrs) {
 				setAttr(vnode, key, old && old[key], attrs[key], ns, isFileInput)

--- a/render/render.js
+++ b/render/render.js
@@ -675,7 +675,7 @@ module.exports = function() {
 			setAttr(vnode, key, null, attrs[key], ns)
 		}
 	}
-	function setAttr(vnode, key, old, value, ns, isFileInput) {
+	function setAttr(vnode, key, old, value, ns) {
 		if (key === "key" || key === "is" || value == null || isLifecycleMethod(key) || (old === value && !isFormAttribute(vnode, key)) && typeof value !== "object") return
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)

--- a/util/assign.js
+++ b/util/assign.js
@@ -1,4 +1,0 @@
-// This exists so I'm only saving it once.
-"use strict"
-
-module.exports = Object.assign

--- a/util/assign.js
+++ b/util/assign.js
@@ -1,10 +1,4 @@
 // This exists so I'm only saving it once.
 "use strict"
 
-var hasOwn = require("./hasOwn")
-
-module.exports = Object.assign || function(target, source) {
-	for (var key in source) {
-		if (hasOwn.call(source, key)) target[key] = source[key]
-	}
-}
+module.exports = Object.assign


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Refactor hyperscript.js and render.js. In particular, the replacement of fix #2622 appears to have significantly improved the performance regression.

## Description
<!--- Describe your changes in detail -->
This change is a refactoring aimed at improving code outlook and performance.
- hyperscript.js now uses Object.assign() to merge attrs. Also, Object.assign() controls the order in which attributes are applied, which addresses issue #2622 alternatively.
- In render.js, performance was improved by eliminating the past #2622 fix. Also, isFileInput has been moved into setAttr() to improve code outlook.
- Polyfill for Object.assign() is removed. The polyfill doesn't support multiple source objects (like in this pr), and almost all browsers now natively support Object.assign().

<details>
<summary>results of `npm run perf` </summary>

before (v2.2.8)
> construct large vnode tree x 18,987 ops/sec ±0.79% (126 runs sampled)
> rerender identical vnode x 3,898,180 ops/sec ±0.52% (127 runs sampled)
> rerender same tree x 55,444 ops/sec ±1.71% (128 runs sampled)
> add large nested tree x 6,701 ops/sec ±1.22% (123 runs sampled)
> mutate styles/properties x 78.77 ops/sec ±3.08% (75 runs sampled)
> repeated add/removal x 3,052 ops/sec ±1.15% (126 runs sampled)
> Completed perf tests in 60100ms

after ("rerender same tree" is improved)
> construct large vnode tree x 19,972 ops/sec ±0.81% (123 runs sampled)
> rerender identical vnode x 3,889,751 ops/sec ±1.03% (127 runs sampled)
> rerender same tree x 88,338 ops/sec ±0.27% (125 runs sampled)
> add large nested tree x 7,014 ops/sec ±1.61% (119 runs sampled)
> mutate styles/properties x 77.55 ops/sec ±1.12% (73 runs sampled)
> repeated add/removal x 3,067 ops/sec ±2.48% (90 runs sampled)
> Completed perf tests in 59057ms

cf. v2.0.4 (by backported test-perf.js and m.censor)
> construct large vnode tree x 13,149 ops/sec ±0.51% (124 runs sampled)
> rerender identical vnode x 5,084,840 ops/sec ±0.49% (127 runs sampled)
> rerender same tree x 82,781 ops/sec ±0.18% (128 runs sampled)
> add large nested tree x 6,611 ops/sec ±2.56% (101 runs sampled)
> mutate styles/properties x 79.76 ops/sec ±0.86% (73 runs sampled)
> repeated add/removal x 3,067 ops/sec ±0.97% (125 runs sampled)
> Completed perf tests in 59579ms

</details>

As shown above, `npm run perf` is improved, especially for "rerender same tree".

I have also run test-perf.js in a real browser to see the performance improvement.
(If necessary, I would like to measure and tabulate performance later.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As for performance, it is sufficiently sophisticated at v2.0.4. However, subsequent bug fixes and enhancements seem to have caused some performance regression. I measured the performance of v2.0.4 and later versions with `npm run perf` and found that https://github.com/MithrilJS/mithril.js/pull/2578/commits/7c7d76d524e6b4c4df2eec5a6f22935f7a400d8f of #2578 has a negative impact on performance.
The commit https://github.com/MithrilJS/mithril.js/pull/2578/commits/7c7d76d524e6b4c4df2eec5a6f22935f7a400d8f fixes #2622 by changing setAttr(s), but I noticed that it can be resolved by hyperscript(execSelector) instead of setAttr(s).
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `npm run test`
- I also confirmed with flems that #2622 is not reproduced.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
