### PR TITLE
[refactor] Performance improvement of updateStyle()

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -778,13 +778,6 @@ module.exports = function() {
 	}
 
 	//style
-	var uppercaseRegex = /[A-Z]/g
-	function toLowerCase(capital) { return "-" + capital.toLowerCase() }
-	function normalizeKey(key) {
-		return key[0] === "-" && key[1] === "-" ? key :
-			key === "cssFloat" ? "float" :
-				key.replace(uppercaseRegex, toLowerCase)
-	}
 	function updateStyle(element, old, style) {
 		if (old === style) {
 			// Styles are equivalent, do nothing.
@@ -800,7 +793,10 @@ module.exports = function() {
 			// Add new style properties
 			for (var key in style) {
 				var value = style[key]
-				if (value != null) element.style.setProperty(normalizeKey(key), String(value))
+				if (value != null) {
+					if (key[0] === "-" && key[1] === "-") element.style.setProperty(key, String(value))
+					else element.style[key] = String(value)
+				}
 			}
 		} else {
 			// Both old & new are (different) objects.
@@ -808,13 +804,15 @@ module.exports = function() {
 			for (var key in style) {
 				var value = style[key]
 				if (value != null && (value = String(value)) !== String(old[key])) {
-					element.style.setProperty(normalizeKey(key), value)
+					if (key[0] === "-" && key[1] === "-") element.style.setProperty(key, value)
+					else element.style[key] = value
 				}
 			}
 			// Remove style properties that no longer exist
 			for (var key in old) {
 				if (old[key] != null && style[key] == null) {
-					element.style.removeProperty(normalizeKey(key))
+					if (key[0] === "-" && key[1] === "-") element.style.removeProperty(key)
+					else element.style[key] = ""
 				}
 			}
 		}

--- a/render/tests/test-createElement.js
+++ b/render/tests/test-createElement.js
@@ -46,13 +46,6 @@ o.spec("createElement", function() {
 
 		o(vnode.dom.style["--cssVar"]).equals("red")
 	})
-	o("censors cssFloat to float", function() {
-		var vnode = m("a", {style: {cssFloat: "left"}})
-
-		render(root, vnode)
-
-		o(vnode.dom.style.float).equals("left")
-	})
 	o("creates children", function() {
 		var vnode = m("div", m("a"), m("b"))
 		render(root, vnode)


### PR DESCRIPTION
This is a refactoring to improve the performance of `updateStyle()`.

## Description
In this PR, `style.setProperty()` in `updateStyle()` is used only when there is a dash "-" in the key. This seems to improve performance and reduce code size by eliminating `normalizeKey()` and `toLowerCase()`.

The benchmark "mutate styles/properties" on nodejs show  about an over 50% improvement as follows.
<details>
<summary>results of `npm run perf` </summary>
before (v2.2.9)

> construct large vnode tree x 19,407 ops/sec ±0.66% (124 runs sampled)
> rerender identical vnode x 3,853,625 ops/sec ±0.39% (128 runs sampled)
> rerender same tree x 89,246 ops/sec ±0.15% (126 runs sampled)
> add large nested tree x 7,300 ops/sec ±1.69% (120 runs sampled)
> mutate styles/properties x 76.49 ops/sec ±0.93% (72 runs sampled)
> repeated add/removal x 3,065 ops/sec ±2.28% (102 runs sampled)
> Completed perf tests in 60285ms

after ("mutate styles/properties" is improved)

> construct large vnode tree x 19,319 ops/sec ±0.61% (125 runs sampled)
> rerender identical vnode x 3,999,668 ops/sec ±1.25% (129 runs sampled)
> rerender same tree x 89,959 ops/sec ±0.30% (124 runs sampled)
> add large nested tree x 7,337 ops/sec ±1.63% (122 runs sampled)
> mutate styles/properties x 121 ops/sec ±1.35% (90 runs sampled)
> repeated add/removal x 3,078 ops/sec ±2.93% (83 runs sampled)
> Completed perf tests in 59106ms

</details>

~~I have not measured it precisely, but~~ also in real browsers the benchmark “mutate styles/properties” seems to show an improvement (about 10%?).
**(Edit)** results in real browsers: https://github.com/MithrilJS/mithril.js/pull/2985#issuecomment-2453864800

## Motivation and Context
Following #2983, I backported the latest benchmark scripts to v1.1.7, measured and compared the benchmarks with v2, and found that the style-related benchmark "mutate styles/properties" were significantly slower. Even though the many fixes and enhancements merged into v2, its performance seemed too slow.

I checked the code and one of the major causes seemed to be the use of regular expressions and replacements (i.e. `normalizeKey()` and `toLowerCase()`) in `updateStyle()` to always use `style.setProperty()` to support css vars.

## How Has This Been Tested?
- `npm run test`
  - The cssFloat normalization test has been removed in this PR as it is no longer needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
