### PR TITLE
Improve handling of is-elements and Fix tiny bugs of setAttr()/updateStyle()

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -8,8 +8,7 @@ var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["
 var selectorCache = Object.create(null)
 
 function isEmpty(object) {
-	for (var key in object) if (hasOwn.call(object, key)) return false
-	return true
+	return Object.keys(object).length === 0
 }
 
 function compileSelector(selector) {

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -8,7 +8,8 @@ var selectorParser = /(?:(^|#|\.)([^#\.\[\]]+))|(\[(.+?)(?:\s*=\s*("|'|)((?:\\["
 var selectorCache = Object.create(null)
 
 function isEmpty(object) {
-	return Object.keys(object).length === 0
+	for (var key in object) if (hasOwn.call(object, key)) return false
+	return true
 }
 
 function compileSelector(selector) {

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -62,6 +62,9 @@ function execSelector(state, vnode) {
 		attrs = Object.assign({type: attrs.type}, attrs)
 	}
 
+	// This reduces the complexity of the evaluation of "is" within the render function.
+	if (hasOwn.call(attrs, "is")) vnode.is = attrs.is
+
 	vnode.attrs = attrs
 
 	return vnode

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -63,7 +63,7 @@ function execSelector(state, vnode) {
 	}
 
 	// This reduces the complexity of the evaluation of "is" within the render function.
-	if (hasOwn.call(attrs, "is")) vnode.is = attrs.is
+	if (attrs.is != null) vnode.is = attrs.is
 
 	vnode.attrs = attrs
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -63,7 +63,7 @@ function execSelector(state, vnode) {
 	}
 
 	// This reduces the complexity of the evaluation of "is" within the render function.
-	if (attrs.is != null) vnode.is = attrs.is
+	vnode.is = attrs.is
 
 	vnode.attrs = attrs
 

--- a/render/render.js
+++ b/render/render.js
@@ -114,7 +114,7 @@ module.exports = function() {
 	function createElement(parent, vnode, hooks, ns, nextSibling) {
 		var tag = vnode.tag
 		var attrs = vnode.attrs
-		var is = attrs && attrs.is
+		var is = vnode.is
 
 		ns = getNameSpace(vnode) || ns
 
@@ -408,7 +408,15 @@ module.exports = function() {
 					case "#": updateText(old, vnode); break
 					case "<": updateHTML(parent, old, vnode, ns, nextSibling); break
 					case "[": updateFragment(parent, old, vnode, hooks, nextSibling, ns); break
-					default: updateElement(old, vnode, hooks, ns)
+					default: {
+						if (old.is === vnode.is) {
+							updateElement(old, vnode, hooks, ns)
+						} else {
+							// createElement() does not call initial lifecycles, so createNode() is called here
+							removeNode(parent, old)
+							createNode(parent, vnode, hooks, ns, nextSibling)
+						}
+					}
 				}
 			}
 			else updateComponent(parent, old, vnode, hooks, nextSibling, ns)

--- a/render/render.js
+++ b/render/render.js
@@ -739,7 +739,7 @@ module.exports = function() {
 		// Filter out namespaced keys
 		return ns === undefined && (
 			// If it's a custom element, just keep it.
-			vnode.tag.indexOf("-") > -1 || vnode.attrs != null && vnode.attrs.is ||
+			vnode.tag.indexOf("-") > -1 || vnode.is ||
 			// If it's a normal element, let's try to avoid a few browser bugs.
 			key !== "href" && key !== "list" && key !== "form" && key !== "width" && key !== "height"// && key !== "type"
 			// Defer the property check until *after* we check everything.

--- a/render/render.js
+++ b/render/render.js
@@ -643,7 +643,7 @@ module.exports = function() {
 		}
 	}
 	function setAttr(vnode, key, old, value, ns) {
-		if (key === "key" || key === "is" || value == null || isLifecycleMethod(key) || (old === value && !isFormAttribute(vnode, key)) && typeof value !== "object") return
+		if (key === "key" || value == null || isLifecycleMethod(key) || (old === value && !isFormAttribute(vnode, key)) && typeof value !== "object") return
 		if (key[0] === "o" && key[1] === "n") return updateEvent(vnode, key, value)
 		if (key.slice(0, 6) === "xlink:") vnode.dom.setAttributeNS("http://www.w3.org/1999/xlink", key.slice(6), value)
 		else if (key === "style") updateStyle(vnode.dom, old, value)
@@ -676,7 +676,7 @@ module.exports = function() {
 		}
 	}
 	function removeAttr(vnode, key, old, ns) {
-		if (key === "key" || key === "is" || old == null || isLifecycleMethod(key)) return
+		if (key === "key" || old == null || isLifecycleMethod(key)) return
 		if (key[0] === "o" && key[1] === "n") updateEvent(vnode, key, undefined)
 		else if (key === "style") updateStyle(vnode.dom, old, null)
 		else if (

--- a/render/render.js
+++ b/render/render.js
@@ -710,20 +710,22 @@ module.exports = function() {
 		if ("selectedIndex" in attrs) setAttr(vnode, "selectedIndex", null, attrs.selectedIndex, undefined)
 	}
 	function updateAttrs(vnode, old, attrs, ns) {
-		if (old && old === attrs) {
-			console.warn("Don't reuse attrs object, use new object for every redraw, this will throw in next major")
-		}
-		if (attrs != null) {
-			for (var key in attrs) {
-				setAttr(vnode, key, old && old[key], attrs[key], ns)
-			}
-		}
+		// Some attributes may NOT be case-sensitive (e.g. data-***),
+		// so removal should be done first to prevent accidental removal for newly setting values.
 		var val
 		if (old != null) {
+			if (old === attrs) {
+				console.warn("Don't reuse attrs object, use new object for every redraw, this will throw in next major")
+			}
 			for (var key in old) {
 				if (((val = old[key]) != null) && (attrs == null || attrs[key] == null)) {
 					removeAttr(vnode, key, val, ns)
 				}
+			}
+		}
+		if (attrs != null) {
+			for (var key in attrs) {
+				setAttr(vnode, key, old && old[key], attrs[key], ns)
 			}
 		}
 	}
@@ -767,19 +769,21 @@ module.exports = function() {
 			}
 		} else {
 			// Both old & new are (different) objects.
+			// Remove style properties that no longer exist
+			// Style properties may have two cases(dash-case and camelCase),
+			// so removal should be done first to prevent accidental removal for newly setting values.
+			for (var key in old) {
+				if (old[key] != null && style[key] == null) {
+					if (key.includes("-")) element.style.removeProperty(key)
+					else element.style[key] = ""
+				}
+			}
 			// Update style properties that have changed
 			for (var key in style) {
 				var value = style[key]
 				if (value != null && (value = String(value)) !== String(old[key])) {
 					if (key.includes("-")) element.style.setProperty(key, value)
 					else element.style[key] = value
-				}
-			}
-			// Remove style properties that no longer exist
-			for (var key in old) {
-				if (old[key] != null && style[key] == null) {
-					if (key.includes("-")) element.style.removeProperty(key)
-					else element.style[key] = ""
 				}
 			}
 		}

--- a/render/render.js
+++ b/render/render.js
@@ -758,7 +758,7 @@ module.exports = function() {
 			element.style = style
 		} else if (old == null || typeof old !== "object") {
 			// `old` is missing or a string, `style` is an object.
-			element.style.cssText = ""
+			element.style = ""
 			// Add new style properties
 			for (var key in style) {
 				var value = style[key]

--- a/render/render.js
+++ b/render/render.js
@@ -396,7 +396,7 @@ module.exports = function() {
 	}
 	function updateNode(parent, old, vnode, hooks, nextSibling, ns) {
 		var oldTag = old.tag, tag = vnode.tag
-		if (oldTag === tag) {
+		if (oldTag === tag && old.is === vnode.is) {
 			vnode.state = old.state
 			vnode.events = old.events
 			if (shouldNotUpdate(vnode, old)) return
@@ -408,15 +408,7 @@ module.exports = function() {
 					case "#": updateText(old, vnode); break
 					case "<": updateHTML(parent, old, vnode, ns, nextSibling); break
 					case "[": updateFragment(parent, old, vnode, hooks, nextSibling, ns); break
-					default: {
-						if (old.is === vnode.is) {
-							updateElement(old, vnode, hooks, ns)
-						} else {
-							// createElement() does not call initial lifecycles, so createNode() is called here
-							removeNode(parent, old)
-							createNode(parent, vnode, hooks, ns, nextSibling)
-						}
-					}
+					default: updateElement(old, vnode, hooks, ns)
 				}
 			}
 			else updateComponent(parent, old, vnode, hooks, nextSibling, ns)

--- a/render/tests/manual/case-handling.html
+++ b/render/tests/manual/case-handling.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <p>This is a test for special case-handling of attribute and style properties. (#2988).</p>
+        <p>Open your browser's Developer Console and follow these steps:</p>
+        <ol>
+            <li>Check the background color of the "foo" below.</li>
+            <ul>
+                <li>If it is light green, it is correct. The style has been updated properly.</li>
+                <li>If it is red or yellow, the style has not been updated properly.</li>
+            </ul>
+            <li>Check the logs displayed in the console.</li>
+            <ul>
+                <li>If the attribute has been updated correctly, you should see the following message: "If you see this message, the update process is correct."</li>
+                <li>If "null" is displayed, the attribute has not been updated properly.</li>
+            </ul>
+        </ol>
+
+        <div id="root" style="background-color: red;"></div>
+        <script src="../../../mithril.js"></script>
+        <script>
+            // data-*** is NOT case-sensitive
+            // style properties have two cases (camelCase and dash-case)
+            var a = m("div#a", {"data-sampleId": "If you see this message, something is wrong.", style: {backgroundColor: "yellow"}}, "foo")
+            var b = m("div#a", {"data-sampleid": "If you see this message, the update process is correct.", style: {"background-color": "lightgreen"}}, "foo")
+
+            // background color is yellow
+            m.render(document.getElementById("root"), a)
+
+            // background color is lightgreen?
+            m.render(document.getElementById("root"), b)
+
+            // data-sampleid is "If you see this message, the update process is correct."?
+            console.log(document.querySelector("#a").getAttribute("data-sampleid"))
+        </script>
+    </body>
+</html>

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -80,8 +80,8 @@ o.spec("attributes", function() {
 			o(spies[0].callCount).equals(0)
 			o(spies[2].callCount).equals(0)
 			o(spies[3].calls).deepEquals([{this: spies[3].elem, args: ["custom", "x"]}])
-			o(spies[4].calls).deepEquals([{this: spies[4].elem, args: ["custom", "x"]}])
-			o(spies[5].calls).deepEquals([{this: spies[5].elem, args: ["custom", "x"]}])
+			o(spies[4].calls).deepEquals([{this: spies[4].elem, args: ["is", "something-special"]}, {this: spies[4].elem, args: ["custom", "x"]}])
+			o(spies[5].calls).deepEquals([{this: spies[5].elem, args: ["is", "something-special"]}, {this: spies[5].elem, args: ["custom", "x"]}])
 		})
 
 		o("when vnode is customElement with property, custom setAttribute not called", function(){
@@ -124,8 +124,8 @@ o.spec("attributes", function() {
 			o(spies[1].callCount).equals(0)
 			o(spies[2].callCount).equals(0)
 			o(spies[3].callCount).equals(0)
-			o(spies[4].callCount).equals(0)
-			o(spies[5].callCount).equals(0)
+			o(spies[4].callCount).equals(1) // setAttribute("is", "something-special") is called
+			o(spies[5].callCount).equals(1) // setAttribute("is", "something-special") is called
 			o(getters[0].callCount).equals(0)
 			o(getters[1].callCount).equals(0)
 			o(getters[2].callCount).equals(0)

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -388,4 +388,178 @@ o.spec("updateElement", function() {
 		o(root.childNodes.length).equals(3)
 		o(x).notEquals(y) // this used to be a recycling pool test
 	})
+	o.spec("element node with `is` attribute", function() {
+		o("recreate element node with `is` attribute (set `is`)", function() {
+			var vnode = m("a")
+			var updated = m("a", {is: "bar"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node without `is` attribute (remove `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals(null)
+		})
+		o("recreate element node with `is` attribute (same tag, different `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a", {is: "bar"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node with `is` attribute (different tag, same `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("b", {is: "foo"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("foo")
+		})
+		o("recreate element node with `is` attribute (different tag, different `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("b", {is: "bar"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a", {is: "foo"}, "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+		o("recreate element node with `is` attribute (set `is`, CSS selector)", function() {
+			var vnode = m("a")
+			var updated = m("a[is=bar]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node without `is` attribute (remove `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals(null)
+		})
+		o("recreate element node with `is` attribute (same tag, different `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a[is=bar]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node with `is` attribute (different tag, same `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("b[is=foo]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("foo")
+		})
+		o("recreate element node with `is` attribute (different tag, different `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("b[is=bar]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a[is=foo]", "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`, from attrs to CSS selector)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a[is=foo]", "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`, from CSS selector to attrs)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a", {is: "foo"}, "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+	})
 })

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,7 +1,7 @@
 "use strict"
 
-function Vnode(tag, key, attrs, children, text, dom) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: undefined, events: undefined, instance: undefined}
+function Vnode(tag, key, attrs, children, text, dom, is) {
+	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, is: is, domSize: undefined, state: undefined, events: undefined, instance: undefined}
 }
 Vnode.normalize = function(node) {
 	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,7 +1,7 @@
 "use strict"
 
-function Vnode(tag, key, attrs, children, text, dom, is) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, is: is, domSize: undefined, state: undefined, events: undefined, instance: undefined}
+function Vnode(tag, key, attrs, children, text, dom) {
+	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, is: undefined, domSize: undefined, state: undefined, events: undefined, instance: undefined}
 }
 Vnode.normalize = function(node) {
 	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a few tiny bugs in attributes and style properties updates, and improves handling of is-elements in updateNode().

## Description
<!--- Describe your changes in detail -->
- removes `key === "is"` from `setAttr()` to fix 2799 https://github.com/MithrilJS/mithril.js/issues/2799#issuecomment-2464260940
  - Also, for code consistency, the `key === "is"` is removed from removeAttr() as well. 
  - In addition, is-elements handling in updateNode() has been improved.
- swaps set and removal order in updateAttrs()/updateStyle() to prevent accidental removal for newly setting values
- removes cssText property access as #2811 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found a strange behavior in the process of #2985, although it rarely happens (https://github.com/MithrilJS/mithril.js/pull/2985#issuecomment-2459950783). And there seems to be a similar trivial issue in `updateAttrs()` ([flems](https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J4AOmgD0kgAQATDMQwBaAFTqZEODIByAeQAqM6hjgxlZtHAjEIANxgTpMuMQCesGQAcATrS8wPrbwMoQYDjLEAO60xqYhABQmOFAAwvEyGGhy8qaEyiZmAJQSdhg+mTIAvDJYCWIgcvYNFDLADQpKFthesACScg2IMg1gtLQtLu6ww8AARhjUANYA5n4ArtmptFC0PsMNPjCDbOwj4OMNJWhlFXPVtfWNzZRtHYoqcD2wECcHIAsfJNXB4YLMGgtlmtaJs5AUdnshuc5lB1o5Tq1RpcQNcnLJIasNtljAiKloZEdBmgsPgjtlAgk5LRqOscAx8HNaHI3K0MLipPjFoSYcS6Lsydo0LRiDIUWiKAqJDS6XIGUyWWziByuTzZfznJ1Pt8YL9NJLpcjyg18DaJEI4DsYPhditGczWSJ8ABHNE+NwAZRgsGoxD2Tyadiu+BWMGIAEFiMQfBA5utGOGPt0sL0TScitdKCAzMHbPQEDwAIwAJkQAGYq2wOCBMDg8PhqHABDR6IxmDw2ABdKhQCBoJbl1DNrh4LA2QjJqAAASr+AADPgACyF9Y+cg8EjELxwRDSTZeVbt2hYSSz4jz6DLtebm9zhf4WdofD8QvuAJ4ODUMmXiiFQxYwCGEBlngq6IKuygwVWADs9YAJyDqwQA).)
This could be solved by simply swapping the order of set and removal probably without creating new bugs and perf issues.

Also, I am not very familiar with custom elements, but it seemed to me that the #2799 issue could be solved by simply removing `key === "is"` from `setAttr()`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `npm run test` including test code fix for custom elements
  - Sorry, but I did not make any changes to domMock because the changes seemed more complicated than the bug fix code.
- I have also confirmed that the issues are not reproduced in flems above using fixed bundle.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
