### PR TITLE
updateStyle(): use setProperty() when css vars and dashed-properties, fixes #2989

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -794,7 +794,7 @@ module.exports = function() {
 			for (var key in style) {
 				var value = style[key]
 				if (value != null) {
-					if (key[0] === "-" && key[1] === "-") element.style.setProperty(key, String(value))
+					if (key.includes("-")) element.style.setProperty(key, String(value))
 					else element.style[key] = String(value)
 				}
 			}
@@ -804,14 +804,14 @@ module.exports = function() {
 			for (var key in style) {
 				var value = style[key]
 				if (value != null && (value = String(value)) !== String(old[key])) {
-					if (key[0] === "-" && key[1] === "-") element.style.setProperty(key, value)
+					if (key.includes("-")) element.style.setProperty(key, value)
 					else element.style[key] = value
 				}
 			}
 			// Remove style properties that no longer exist
 			for (var key in old) {
 				if (old[key] != null && style[key] == null) {
-					if (key[0] === "-" && key[1] === "-") element.style.removeProperty(key)
+					if (key.includes("-")) element.style.removeProperty(key)
 					else element.style[key] = ""
 				}
 			}

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -257,6 +257,79 @@ o.spec("updateElement", function() {
 
 		}
 	})
+	o("use style property setter only when cameCase keys", function() {
+		var spySetProperty = o.spy()
+		var spyRemoveProperty = o.spy()
+		var spyDashed1 = o.spy()
+		var spyDashed2 = o.spy()
+		var spyDashed3 = o.spy()
+		var spyCamelCase1 = o.spy()
+		var spyCamelCase2 = o.spy()
+
+		var f = $window.document.createElement
+		$window.document.createElement = function(tag, is){
+			var el = f(tag, is)
+
+			var style = {}
+			Object.defineProperties(style, {
+				setProperty: {value: spySetProperty},
+				removeProperty: {value: spyRemoveProperty},
+				/* eslint-disable accessor-pairs */
+				"background-color": {set: spyDashed1},
+				"-webkit-border-radius": {set: spyDashed2},
+				"--foo": {set: spyDashed3},
+				backgroundColor: {set: spyCamelCase1},
+				color: {set: spyCamelCase2}
+				/* eslint-enable accessor-pairs */
+			})
+
+			Object.defineProperty(el, "style", {value: style})
+			return el
+		}
+
+		// sets dashed properties
+		render(root, m("a", {
+			style: {
+				"background-color": "red",
+				"-webkit-border-radius": "10px",
+				"--foo": "bar"
+			}
+		}))
+
+		// sets camelCase properties and removes dashed properties
+		render(root, m("a", {
+			style: {
+				backgroundColor: "green",
+				color: "red",
+			}
+		}))
+
+		// updates "color" and removes "backgroundColor"
+		render(root, m("a", {style: {color: "blue"}}))
+
+		// setProperty (for dashed properties)
+		o(spySetProperty.callCount).equals(3)
+		o(spySetProperty.calls[0].args).deepEquals(["background-color", "red"])
+		o(spySetProperty.calls[1].args).deepEquals(["-webkit-border-radius", "10px"])
+		o(spySetProperty.calls[2].args).deepEquals(["--foo", "bar"])
+
+		// removeProperty (for dashed properties)
+		o(spyRemoveProperty.callCount).equals(3)
+		o(spyRemoveProperty.calls[0].args).deepEquals(["background-color"])
+		o(spyRemoveProperty.calls[1].args).deepEquals(["-webkit-border-radius"])
+		o(spyRemoveProperty.calls[2].args).deepEquals(["--foo"])
+
+		// property setter (for camelCase properties)
+		o(spyDashed1.callCount).equals(0)
+		o(spyDashed2.callCount).equals(0)
+		o(spyDashed3.callCount).equals(0)
+		o(spyCamelCase1.callCount).equals(2) // set and remove
+		o(spyCamelCase2.callCount).equals(2) // set and update
+		o(spyCamelCase1.calls[0].args).deepEquals(["green"])
+		o(spyCamelCase1.calls[1].args).deepEquals([""])
+		o(spyCamelCase2.calls[0].args).deepEquals(["red"])
+		o(spyCamelCase2.calls[1].args).deepEquals(["blue"])
+	})
 	o("replaces el", function() {
 		var vnode = m("a")
 		var updated = m("b")

--- a/test-utils/domMock.js
+++ b/test-utils/domMock.js
@@ -284,12 +284,18 @@ module.exports = function(options) {
 					getPropertyValue: {value: function(key){
 						return style[key]
 					}},
-					removeProperty: {value: function(key){
-						style[key] = style[camelCase(key)] = ""
-					}},
-					setProperty: {value: function(key, value){
-						style[key] = style[camelCase(key)] = value
-					}}
+					removeProperty: {
+						writable: true,
+						value: function(key){
+							style[key] = style[camelCase(key)] = ""
+						}
+					},
+					setProperty: {
+						writable: true,
+						value: function(key, value){
+							style[key] = style[camelCase(key)] = value
+						}
+					}
 				})
 				var events = {}
 				var element = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
This PR changes updateStyle() to use setProperty() for dashed-properties.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR maybe fixes #2989

Current mithril (v2.2.10) doesn't seem to work well when using something like domMock, which doesn't have enough support for dashed-properties.
It may not be a browser that Mithril officially supports. But the fix is clear and has little or no impact on performance as discussed in #2985.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
