### PR TITLE
Use new pr-release prerelease hook (Fixes #2987)

### DIFF
--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -20,14 +20,11 @@ jobs:
         node-version: 20
     - run: npm ci
     - run: npm run build
-    - run: npx pr-release merge --target release --source main --commit --force --clean --changelog ./docs/recent-changes.md --compact --minimize-semver-change
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-    - run: bash scripts/set-versioned-branch.sh release
-    # The following will publish the release to npm
     - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       name: Setup NPM Auth
       env:
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: npm publish
-      name: Publish
+    - run: npx pr-release merge --target release --source main --commit --force --clean --changelog ./docs/recent-changes.md --compact --minimize-semver-change --prerelease="npm publish"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    - run: bash scripts/set-versioned-branch.sh release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Per @dead-claudia's suggestion, pr-release now allows you to invoke a custom command before creating the github release.  If the command fails the process exits with a non zero code and the github release is never created.

## Motivation and Context

This makes it clear that if a github release is created a corresponding npm release with the same tag also exists.

Note I haven't documented this feature as I'm improving documentation and making internal upgrades on another branch.

## How Has This Been Tested?

- Created a test private repo and going through the pr/merge cycle a few times in CI and with the local debugger.
- Deployed pr-release itself using the same process `--prerelease="npm publish"` ([CI](https://github.com/JAForbes/pr-release/actions/runs/11927810216/job/33243786643), [npm](https://www.npmjs.com/package/pr-release/v/0.18.23), [github release](https://github.com/JAForbes/pr-release/releases/tag/v0.18.23))

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [X] I have read https://mithril.js.org/contributing.html.
