### PR TITLE
render: wrap stateResult and attrsResult in Promise.resolve(), fix #2592

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -614,7 +614,7 @@ module.exports = function() {
 			generation = currentRender
 			for (var dom of domFor(vnode)) delayedRemoval.set(dom, generation)
 			if (stateResult != null) {
-				stateResult.finally(function () {
+				Promise.resolve(stateResult).finally(function () {
 					// eslint-disable-next-line no-bitwise
 					if (mask & 1) {
 						// eslint-disable-next-line no-bitwise
@@ -628,7 +628,7 @@ module.exports = function() {
 				})
 			}
 			if (attrsResult != null) {
-				attrsResult.finally(function () {
+				Promise.resolve(attrsResult).finally(function () {
 					// eslint-disable-next-line no-bitwise
 					if (mask & 2) {
 						// eslint-disable-next-line no-bitwise

--- a/render/tests/test-onbeforeremove.js
+++ b/render/tests/test-onbeforeremove.js
@@ -122,6 +122,23 @@ o.spec("onbeforeremove", function() {
 			done()
 		})
 	})
+	o("handles thenable objecs (#2592)", function(done) {
+		var remove = function() {return {then: function(resolve) {resolve()}}}
+		var vnodes = m("div", {key: 1, onbeforeremove: remove}, "a")
+		var updated = []
+
+		render(root, vnodes)
+		render(root, updated)
+
+		o(root.childNodes.length).equals(1)
+		o(root.firstChild.firstChild.nodeValue).equals("a")
+
+		callAsync(function() {
+			o(root.childNodes.length).equals(0)
+
+			done()
+		})
+	})
 	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR wraps the return value of onbeforeremove in Promise.resolve(). This ensures that thenable objects are also always processed asynchronously.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix #2592.
The current implementation of mithril calls finally() instead of then() in onbeforeremove process, so that returning a simple thenable object in onbeforeremove will throw an error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `npm run test` including additional and modified tests.
  - In this PR, I modified the onremove complex test to pass. The test as a whole seemed to assume a synchronous process, including onbeforeremove.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
