### PR TITLE
Release - v2.2.14

### DIFF
--- a/render/domFor.js
+++ b/render/domFor.js
@@ -2,12 +2,12 @@
 
 var delayedRemoval = new WeakMap
 
-function *domFor(vnode, object = {}) {
+function *domFor(vnode) {
 	// To avoid unintended mangling of the internal bundler,
 	// parameter destructuring is not used here.
 	var dom = vnode.dom
 	var domSize = vnode.domSize
-	var generation = object.generation
+	var generation = delayedRemoval.get(dom)
 	if (dom != null) do {
 		var nextSibling = dom.nextSibling
 

--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -62,6 +62,9 @@ function execSelector(state, vnode) {
 		attrs = Object.assign({type: attrs.type}, attrs)
 	}
 
+	// This reduces the complexity of the evaluation of "is" within the render function.
+	vnode.is = attrs.is
+
 	vnode.attrs = attrs
 
 	return vnode

--- a/render/render.js
+++ b/render/render.js
@@ -614,7 +614,7 @@ module.exports = function() {
 			generation = currentRender
 			for (var dom of domFor(vnode)) delayedRemoval.set(dom, generation)
 			if (stateResult != null) {
-				stateResult.finally(function () {
+				Promise.resolve(stateResult).finally(function () {
 					// eslint-disable-next-line no-bitwise
 					if (mask & 1) {
 						// eslint-disable-next-line no-bitwise
@@ -628,7 +628,7 @@ module.exports = function() {
 				})
 			}
 			if (attrsResult != null) {
-				attrsResult.finally(function () {
+				Promise.resolve(attrsResult).finally(function () {
 					// eslint-disable-next-line no-bitwise
 					if (mask & 2) {
 						// eslint-disable-next-line no-bitwise

--- a/render/render.js
+++ b/render/render.js
@@ -426,7 +426,7 @@ module.exports = function() {
 	}
 	function updateHTML(parent, old, vnode, ns, nextSibling) {
 		if (old.children !== vnode.children) {
-			removeDOM(parent, old, undefined)
+			removeDOM(parent, old)
 			createHTML(parent, vnode, ns, nextSibling)
 		}
 		else {

--- a/render/render.js
+++ b/render/render.js
@@ -591,34 +591,32 @@ module.exports = function() {
 		if (result == null) return
 
 		var generation = currentRender
-		if (counter.v++ === 1) {
-			for (var dom of domFor(vnode)) delayedRemoval.set(dom, generation)
-		}
+		for (var dom of domFor(vnode)) delayedRemoval.set(dom, generation)
+		counter.v++
 
 		Promise.resolve(result).finally(function () {
 			checkState(vnode, original)
-			tryResumeRemove(parent, vnode, generation, counter)
+			tryResumeRemove(parent, vnode, counter)
 		})
 	}
-	function tryResumeRemove(parent, vnode, generation, counter) {
+	function tryResumeRemove(parent, vnode, counter) {
 		if (--counter.v === 0) {
 			onremove(vnode)
-			removeDOM(parent, vnode, generation)
+			removeDOM(parent, vnode)
 		}
 	}
 	function removeNode(parent, vnode) {
 		var counter = {v: 1}
 		if (typeof vnode.tag !== "string" && typeof vnode.state.onbeforeremove === "function") tryBlockRemove(parent, vnode, vnode.state, counter)
 		if (vnode.attrs && typeof vnode.attrs.onbeforeremove === "function") tryBlockRemove(parent, vnode, vnode.attrs, counter)
-		tryResumeRemove(parent, vnode, undefined, counter)
+		tryResumeRemove(parent, vnode, counter)
 	}
-	function removeDOM(parent, vnode, generation) {
+	function removeDOM(parent, vnode) {
 		if (vnode.dom == null) return
 		if (vnode.domSize == null) {
-			// don't allocate for the common case
-			if (delayedRemoval.get(vnode.dom) === generation) parent.removeChild(vnode.dom)
+			parent.removeChild(vnode.dom)
 		} else {
-			for (var dom of domFor(vnode, {generation})) parent.removeChild(dom)
+			for (var dom of domFor(vnode)) parent.removeChild(dom)
 		}
 	}
 

--- a/render/tests/manual/case-handling.html
+++ b/render/tests/manual/case-handling.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <p>This is a test for special case-handling of attribute and style properties. (#2988).</p>
+        <p>Open your browser's Developer Console and follow these steps:</p>
+        <ol>
+            <li>Check the background color of the "foo" below.</li>
+            <ul>
+                <li>If it is light green, it is correct. The style has been updated properly.</li>
+                <li>If it is red or yellow, the style has not been updated properly.</li>
+            </ul>
+            <li>Check the logs displayed in the console.</li>
+            <ul>
+                <li>If the attribute has been updated correctly, you should see the following message: "If you see this message, the update process is correct."</li>
+                <li>If "null" is displayed, the attribute has not been updated properly.</li>
+            </ul>
+        </ol>
+
+        <div id="root" style="background-color: red;"></div>
+        <script src="../../../mithril.js"></script>
+        <script>
+            // data-*** is NOT case-sensitive
+            // style properties have two cases (camelCase and dash-case)
+            var a = m("div#a", {"data-sampleId": "If you see this message, something is wrong.", style: {backgroundColor: "yellow"}}, "foo")
+            var b = m("div#a", {"data-sampleid": "If you see this message, the update process is correct.", style: {"background-color": "lightgreen"}}, "foo")
+
+            // background color is yellow
+            m.render(document.getElementById("root"), a)
+
+            // background color is lightgreen?
+            m.render(document.getElementById("root"), b)
+
+            // data-sampleid is "If you see this message, the update process is correct."?
+            console.log(document.querySelector("#a").getAttribute("data-sampleid"))
+        </script>
+    </body>
+</html>

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -80,8 +80,8 @@ o.spec("attributes", function() {
 			o(spies[0].callCount).equals(0)
 			o(spies[2].callCount).equals(0)
 			o(spies[3].calls).deepEquals([{this: spies[3].elem, args: ["custom", "x"]}])
-			o(spies[4].calls).deepEquals([{this: spies[4].elem, args: ["custom", "x"]}])
-			o(spies[5].calls).deepEquals([{this: spies[5].elem, args: ["custom", "x"]}])
+			o(spies[4].calls).deepEquals([{this: spies[4].elem, args: ["is", "something-special"]}, {this: spies[4].elem, args: ["custom", "x"]}])
+			o(spies[5].calls).deepEquals([{this: spies[5].elem, args: ["is", "something-special"]}, {this: spies[5].elem, args: ["custom", "x"]}])
 		})
 
 		o("when vnode is customElement with property, custom setAttribute not called", function(){
@@ -124,8 +124,8 @@ o.spec("attributes", function() {
 			o(spies[1].callCount).equals(0)
 			o(spies[2].callCount).equals(0)
 			o(spies[3].callCount).equals(0)
-			o(spies[4].callCount).equals(0)
-			o(spies[5].callCount).equals(0)
+			o(spies[4].callCount).equals(1) // setAttribute("is", "something-special") is called
+			o(spies[5].callCount).equals(1) // setAttribute("is", "something-special") is called
 			o(getters[0].callCount).equals(0)
 			o(getters[1].callCount).equals(0)
 			o(getters[2].callCount).equals(0)

--- a/render/tests/test-domFor.js
+++ b/render/tests/test-domFor.js
@@ -114,6 +114,384 @@ o.spec("domFor(vnode)", function() {
 			done()
 		})
 	})
+	o("works multiple vnodes with onbeforeremove (1/3)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve B
+			thenCBB()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterA = domFor(A)
+				o(iterA.next().value.nodeName).equals("A1")
+				o(iterA.next().value.nodeName).equals("A2")
+				o(iterA.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve C
+				thenCBC()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("A1")
+					o(root.childNodes[1].nodeName).equals("A2")
+
+					const iterA = domFor(A)
+					o(iterA.next().value.nodeName).equals("A1")
+					o(iterA.next().value.nodeName).equals("A2")
+					o(iterA.next().done).deepEquals(true)
+
+					// resolve A
+					thenCBA()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (2/3)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve C
+			thenCBC()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("B1")
+				o(root.childNodes[3].nodeName).equals("B2")
+
+				const iterB = domFor(B)
+				o(iterB.next().value.nodeName).equals("B1")
+				o(iterB.next().value.nodeName).equals("B2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterA = domFor(A)
+				o(iterA.next().value.nodeName).equals("A1")
+				o(iterA.next().value.nodeName).equals("A2")
+				o(iterA.next().done).deepEquals(true)
+
+				// resolve A
+				thenCBA()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("B1")
+					o(root.childNodes[1].nodeName).equals("B2")
+
+					const iterB = domFor(B)
+					o(iterB.next().value.nodeName).equals("B1")
+					o(iterB.next().value.nodeName).equals("B2")
+					o(iterB.next().done).deepEquals(true)
+
+					// resolve B
+					thenCBB()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (3/3)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve A
+			thenCBA()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("B1")
+				o(root.childNodes[1].nodeName).equals("B2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterB = domFor(B)
+				o(iterB.next().value.nodeName).equals("B1")
+				o(iterB.next().value.nodeName).equals("B2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve B
+				thenCBB()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("C1")
+					o(root.childNodes[1].nodeName).equals("C2")
+					
+					const iterC = domFor(C)
+					o(iterC.next().value.nodeName).equals("C1")
+					o(iterC.next().value.nodeName).equals("C2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve C
+					thenCBC()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
 	components.forEach(function(cmp){
 		const {kind, create: createComponent} = cmp
 		o.spec(kind, function(){

--- a/render/tests/test-domFor.js
+++ b/render/tests/test-domFor.js
@@ -114,7 +114,7 @@ o.spec("domFor(vnode)", function() {
 			done()
 		})
 	})
-	o("works multiple vnodes with onbeforeremove (1/3)", function (done) {
+	o("works multiple vnodes with onbeforeremove (#3007, 1/6, BCA)", function (done) {
 		let thenCBA, thenCBB, thenCBC
 		const onbeforeremoveA = o.spy(function onbeforeremove(){
 			return {then(resolve){thenCBA = resolve}}
@@ -240,7 +240,7 @@ o.spec("domFor(vnode)", function() {
 			})
 		})
 	})
-	o("works multiple vnodes with onbeforeremove (2/3)", function (done) {
+	o("works multiple vnodes with onbeforeremove (#3007, 2/6, CAB)", function (done) {
 		let thenCBA, thenCBB, thenCBC
 		const onbeforeremoveA = o.spy(function onbeforeremove(){
 			return {then(resolve){thenCBA = resolve}}
@@ -366,7 +366,7 @@ o.spec("domFor(vnode)", function() {
 			})
 		})
 	})
-	o("works multiple vnodes with onbeforeremove (3/3)", function (done) {
+	o("works multiple vnodes with onbeforeremove (#3007, 3/6, ABC)", function (done) {
 		let thenCBA, thenCBB, thenCBC
 		const onbeforeremoveA = o.spy(function onbeforeremove(){
 			return {then(resolve){thenCBA = resolve}}
@@ -484,6 +484,384 @@ o.spec("domFor(vnode)", function() {
 
 					// resolve C
 					thenCBC()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (#3007, 4/6, ACB)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve A
+			thenCBA()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("B1")
+				o(root.childNodes[1].nodeName).equals("B2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterB = domFor(B)
+				o(iterB.next().value.nodeName).equals("B1")
+				o(iterB.next().value.nodeName).equals("B2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve C
+				thenCBC()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("B1")
+					o(root.childNodes[1].nodeName).equals("B2")
+					
+					const iterC = domFor(B)
+					o(iterC.next().value.nodeName).equals("B1")
+					o(iterC.next().value.nodeName).equals("B2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve B
+					thenCBB()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (#3007, 5/6, BAC)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve B
+			thenCBB()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterB = domFor(A)
+				o(iterB.next().value.nodeName).equals("A1")
+				o(iterB.next().value.nodeName).equals("A2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve A
+				thenCBA()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("C1")
+					o(root.childNodes[1].nodeName).equals("C2")
+					
+					const iterC = domFor(C)
+					o(iterC.next().value.nodeName).equals("C1")
+					o(iterC.next().value.nodeName).equals("C2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve C
+					thenCBC()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (#3007, 6/6, CBA)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve C
+			thenCBC()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("B1")
+				o(root.childNodes[3].nodeName).equals("B2")
+
+				const iterB = domFor(A)
+				o(iterB.next().value.nodeName).equals("A1")
+				o(iterB.next().value.nodeName).equals("A2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(B)
+				o(iterC.next().value.nodeName).equals("B1")
+				o(iterC.next().value.nodeName).equals("B2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve B
+				thenCBB()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("A1")
+					o(root.childNodes[1].nodeName).equals("A2")
+					
+					const iterC = domFor(A)
+					o(iterC.next().value.nodeName).equals("A1")
+					o(iterC.next().value.nodeName).equals("A2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve A
+					thenCBA()
 					callAsync(function(){
 						o(root.childNodes.length).equals(0)
 						done()

--- a/render/tests/test-onbeforeremove.js
+++ b/render/tests/test-onbeforeremove.js
@@ -122,6 +122,23 @@ o.spec("onbeforeremove", function() {
 			done()
 		})
 	})
+	o("handles thenable objecs (#2592)", function(done) {
+		var remove = function() {return {then: function(resolve) {resolve()}}}
+		var vnodes = m("div", {key: 1, onbeforeremove: remove}, "a")
+		var updated = []
+
+		render(root, vnodes)
+		render(root, updated)
+
+		o(root.childNodes.length).equals(1)
+		o(root.firstChild.firstChild.nodeValue).equals("a")
+
+		callAsync(function() {
+			o(root.childNodes.length).equals(0)
+
+			done()
+		})
+	})
 	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){
 			var createComponent = cmp.create

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -388,4 +388,178 @@ o.spec("updateElement", function() {
 		o(root.childNodes.length).equals(3)
 		o(x).notEquals(y) // this used to be a recycling pool test
 	})
+	o.spec("element node with `is` attribute", function() {
+		o("recreate element node with `is` attribute (set `is`)", function() {
+			var vnode = m("a")
+			var updated = m("a", {is: "bar"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node without `is` attribute (remove `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals(null)
+		})
+		o("recreate element node with `is` attribute (same tag, different `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a", {is: "bar"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node with `is` attribute (different tag, same `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("b", {is: "foo"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("foo")
+		})
+		o("recreate element node with `is` attribute (different tag, different `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("b", {is: "bar"})
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a", {is: "foo"}, "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+		o("recreate element node with `is` attribute (set `is`, CSS selector)", function() {
+			var vnode = m("a")
+			var updated = m("a[is=bar]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node without `is` attribute (remove `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals(null)
+		})
+		o("recreate element node with `is` attribute (same tag, different `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a[is=bar]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("recreate element node with `is` attribute (different tag, same `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("b[is=foo]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("foo")
+		})
+		o("recreate element node with `is` attribute (different tag, different `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("b[is=bar]")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).notEquals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("B")
+			o(updated.dom.getAttribute("is")).equals("bar")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`, CSS selector)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a[is=foo]", "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`, from attrs to CSS selector)", function() {
+			var vnode = m("a", {is: "foo"})
+			var updated = m("a[is=foo]", "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+		o("keep element node with `is` attribute (same tag, same `is`, from CSS selector to attrs)", function() {
+			var vnode = m("a[is=foo]")
+			var updated = m("a", {is: "foo"}, "x")
+
+			render(root, vnode)
+			render(root, updated)
+			
+			o(vnode.dom).equals(root.firstChild)
+			o(updated.dom).equals(root.firstChild)
+			o(updated.dom.nodeName).equals("A")
+			o(updated.dom.getAttribute("is")).equals("foo")
+			o(updated.dom.firstChild.nodeValue).equals("x")
+		})
+	})
 })

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,7 +1,7 @@
 "use strict"
 
 function Vnode(tag, key, attrs, children, text, dom) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, domSize: undefined, state: undefined, events: undefined, instance: undefined}
+	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, is: undefined, domSize: undefined, state: undefined, events: undefined, instance: undefined}
 }
 Vnode.normalize = function(node) {
 	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)


### PR DESCRIPTION

# Release v2.2.14

<a name="changeSummary-start"></a>

- #2988
- #3007
- #3005

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [Improve handling of is-elements and Fix tiny bugs of setAttr()/updateStyle() (@kfule)](https://github.com/MithrilJS/mithril.js/pull/2988)

Fixes a few tiny bugs in attributes and style properties updates, and improves handling of is-elements in updateNode().
#### [domFor: always get generation from delayedRemoval instead of parameter (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3007)

The `generation` of domFor is no longer passed as a parameter.  This allows domFor to work well in onbeforeremove and onremove and reduces the amount of code.
#### [render: wrap stateResult and attrsResult in Promise.resolve(), fix #2592 (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3005)

This PR wraps the return value of onbeforeremove in Promise.resolve().  This ensures that thenable objects are also always processed asynchronously.  fix #2592.
               
<a name="changelog-end"></a>
           
           
           
        