### PR TITLE
domFor: always get generation from delayedRemoval instead of parameter

### DIFF
--- a/render/domFor.js
+++ b/render/domFor.js
@@ -2,12 +2,12 @@
 
 var delayedRemoval = new WeakMap
 
-function *domFor(vnode, object = {}) {
+function *domFor(vnode) {
 	// To avoid unintended mangling of the internal bundler,
 	// parameter destructuring is not used here.
 	var dom = vnode.dom
 	var domSize = vnode.domSize
-	var generation = object.generation
+	var generation = delayedRemoval.get(dom)
 	if (dom != null) do {
 		var nextSibling = dom.nextSibling
 

--- a/render/render.js
+++ b/render/render.js
@@ -426,7 +426,7 @@ module.exports = function() {
 	}
 	function updateHTML(parent, old, vnode, ns, nextSibling) {
 		if (old.children !== vnode.children) {
-			removeDOM(parent, old, undefined)
+			removeDOM(parent, old)
 			createHTML(parent, vnode, ns, nextSibling)
 		}
 		else {

--- a/render/render.js
+++ b/render/render.js
@@ -591,34 +591,32 @@ module.exports = function() {
 		if (result == null) return
 
 		var generation = currentRender
-		if (counter.v++ === 1) {
-			for (var dom of domFor(vnode)) delayedRemoval.set(dom, generation)
-		}
+		for (var dom of domFor(vnode)) delayedRemoval.set(dom, generation)
+		counter.v++
 
 		Promise.resolve(result).finally(function () {
 			checkState(vnode, original)
-			tryResumeRemove(parent, vnode, generation, counter)
+			tryResumeRemove(parent, vnode, counter)
 		})
 	}
-	function tryResumeRemove(parent, vnode, generation, counter) {
+	function tryResumeRemove(parent, vnode, counter) {
 		if (--counter.v === 0) {
 			onremove(vnode)
-			removeDOM(parent, vnode, generation)
+			removeDOM(parent, vnode)
 		}
 	}
 	function removeNode(parent, vnode) {
 		var counter = {v: 1}
 		if (typeof vnode.tag !== "string" && typeof vnode.state.onbeforeremove === "function") tryBlockRemove(parent, vnode, vnode.state, counter)
 		if (vnode.attrs && typeof vnode.attrs.onbeforeremove === "function") tryBlockRemove(parent, vnode, vnode.attrs, counter)
-		tryResumeRemove(parent, vnode, undefined, counter)
+		tryResumeRemove(parent, vnode, counter)
 	}
-	function removeDOM(parent, vnode, generation) {
+	function removeDOM(parent, vnode) {
 		if (vnode.dom == null) return
 		if (vnode.domSize == null) {
-			// don't allocate for the common case
-			if (delayedRemoval.get(vnode.dom) === generation) parent.removeChild(vnode.dom)
+			parent.removeChild(vnode.dom)
 		} else {
-			for (var dom of domFor(vnode, {generation})) parent.removeChild(dom)
+			for (var dom of domFor(vnode)) parent.removeChild(dom)
 		}
 	}
 

--- a/render/tests/test-domFor.js
+++ b/render/tests/test-domFor.js
@@ -114,6 +114,384 @@ o.spec("domFor(vnode)", function() {
 			done()
 		})
 	})
+	o("works multiple vnodes with onbeforeremove (1/3)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve B
+			thenCBB()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterA = domFor(A)
+				o(iterA.next().value.nodeName).equals("A1")
+				o(iterA.next().value.nodeName).equals("A2")
+				o(iterA.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve C
+				thenCBC()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("A1")
+					o(root.childNodes[1].nodeName).equals("A2")
+
+					const iterA = domFor(A)
+					o(iterA.next().value.nodeName).equals("A1")
+					o(iterA.next().value.nodeName).equals("A2")
+					o(iterA.next().done).deepEquals(true)
+
+					// resolve A
+					thenCBA()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (2/3)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve C
+			thenCBC()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("B1")
+				o(root.childNodes[3].nodeName).equals("B2")
+
+				const iterB = domFor(B)
+				o(iterB.next().value.nodeName).equals("B1")
+				o(iterB.next().value.nodeName).equals("B2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterA = domFor(A)
+				o(iterA.next().value.nodeName).equals("A1")
+				o(iterA.next().value.nodeName).equals("A2")
+				o(iterA.next().done).deepEquals(true)
+
+				// resolve A
+				thenCBA()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("B1")
+					o(root.childNodes[1].nodeName).equals("B2")
+
+					const iterB = domFor(B)
+					o(iterB.next().value.nodeName).equals("B1")
+					o(iterB.next().value.nodeName).equals("B2")
+					o(iterB.next().done).deepEquals(true)
+
+					// resolve B
+					thenCBB()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (3/3)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve A
+			thenCBA()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("B1")
+				o(root.childNodes[1].nodeName).equals("B2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterB = domFor(B)
+				o(iterB.next().value.nodeName).equals("B1")
+				o(iterB.next().value.nodeName).equals("B2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve B
+				thenCBB()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("C1")
+					o(root.childNodes[1].nodeName).equals("C2")
+					
+					const iterC = domFor(C)
+					o(iterC.next().value.nodeName).equals("C1")
+					o(iterC.next().value.nodeName).equals("C2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve C
+					thenCBC()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
 	components.forEach(function(cmp){
 		const {kind, create: createComponent} = cmp
 		o.spec(kind, function(){

--- a/render/tests/test-domFor.js
+++ b/render/tests/test-domFor.js
@@ -114,7 +114,7 @@ o.spec("domFor(vnode)", function() {
 			done()
 		})
 	})
-	o("works multiple vnodes with onbeforeremove (1/3)", function (done) {
+	o("works multiple vnodes with onbeforeremove (#3007, 1/6, BCA)", function (done) {
 		let thenCBA, thenCBB, thenCBC
 		const onbeforeremoveA = o.spy(function onbeforeremove(){
 			return {then(resolve){thenCBA = resolve}}
@@ -240,7 +240,7 @@ o.spec("domFor(vnode)", function() {
 			})
 		})
 	})
-	o("works multiple vnodes with onbeforeremove (2/3)", function (done) {
+	o("works multiple vnodes with onbeforeremove (#3007, 2/6, CAB)", function (done) {
 		let thenCBA, thenCBB, thenCBC
 		const onbeforeremoveA = o.spy(function onbeforeremove(){
 			return {then(resolve){thenCBA = resolve}}
@@ -366,7 +366,7 @@ o.spec("domFor(vnode)", function() {
 			})
 		})
 	})
-	o("works multiple vnodes with onbeforeremove (3/3)", function (done) {
+	o("works multiple vnodes with onbeforeremove (#3007, 3/6, ABC)", function (done) {
 		let thenCBA, thenCBB, thenCBC
 		const onbeforeremoveA = o.spy(function onbeforeremove(){
 			return {then(resolve){thenCBA = resolve}}
@@ -484,6 +484,384 @@ o.spec("domFor(vnode)", function() {
 
 					// resolve C
 					thenCBC()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (#3007, 4/6, ACB)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve A
+			thenCBA()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("B1")
+				o(root.childNodes[1].nodeName).equals("B2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterB = domFor(B)
+				o(iterB.next().value.nodeName).equals("B1")
+				o(iterB.next().value.nodeName).equals("B2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve C
+				thenCBC()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("B1")
+					o(root.childNodes[1].nodeName).equals("B2")
+					
+					const iterC = domFor(B)
+					o(iterC.next().value.nodeName).equals("B1")
+					o(iterC.next().value.nodeName).equals("B2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve B
+					thenCBB()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (#3007, 5/6, BAC)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve B
+			thenCBB()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("C1")
+				o(root.childNodes[3].nodeName).equals("C2")
+
+				const iterB = domFor(A)
+				o(iterB.next().value.nodeName).equals("A1")
+				o(iterB.next().value.nodeName).equals("A2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(C)
+				o(iterC.next().value.nodeName).equals("C1")
+				o(iterC.next().value.nodeName).equals("C2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve A
+				thenCBA()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("C1")
+					o(root.childNodes[1].nodeName).equals("C2")
+					
+					const iterC = domFor(C)
+					o(iterC.next().value.nodeName).equals("C1")
+					o(iterC.next().value.nodeName).equals("C2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve C
+					thenCBC()
+					callAsync(function(){
+						o(root.childNodes.length).equals(0)
+						done()
+					})
+				})
+			})
+		})
+	})
+	o("works multiple vnodes with onbeforeremove (#3007, 6/6, CBA)", function (done) {
+		let thenCBA, thenCBB, thenCBC
+		const onbeforeremoveA = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBA = resolve}}
+		})
+		const onbeforeremoveB = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBB = resolve}}
+		})
+		const onbeforeremoveC = o.spy(function onbeforeremove(){
+			return {then(resolve){thenCBC = resolve}}
+		})
+		// to avoid updating internal nodes only, vnodes have key attributes
+		const A = fragment({key: 1, onbeforeremove: onbeforeremoveA}, [m("a1"), m("a2")])
+		const B = fragment({key: 2, onbeforeremove: onbeforeremoveB}, [m("b1"), m("b2")])
+		const C = fragment({key: 3, onbeforeremove: onbeforeremoveC}, [m("c1"), m("c2")])
+
+		render(root, [A])
+		o(onbeforeremoveA.callCount).equals(0)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [B])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(0)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [C])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(0)
+
+		render(root, [])
+		o(onbeforeremoveA.callCount).equals(1)
+		o(onbeforeremoveB.callCount).equals(1)
+		o(onbeforeremoveC.callCount).equals(1)
+
+		// not resolved
+		o(root.childNodes.length).equals(6)
+		o(root.childNodes[0].nodeName).equals("A1")
+		o(root.childNodes[1].nodeName).equals("A2")
+		o(root.childNodes[2].nodeName).equals("B1")
+		o(root.childNodes[3].nodeName).equals("B2")
+		o(root.childNodes[4].nodeName).equals("C1")
+		o(root.childNodes[5].nodeName).equals("C2")
+
+		const iterA = domFor(A)
+		o(iterA.next().value.nodeName).equals("A1")
+		o(iterA.next().value.nodeName).equals("A2")
+		o(iterA.next().done).deepEquals(true)
+
+		const iterB = domFor(B)
+		o(iterB.next().value.nodeName).equals("B1")
+		o(iterB.next().value.nodeName).equals("B2")
+		o(iterB.next().done).deepEquals(true)
+
+		const iterC = domFor(C)
+		o(iterC.next().value.nodeName).equals("C1")
+		o(iterC.next().value.nodeName).equals("C2")
+		o(iterC.next().done).deepEquals(true)
+
+		callAsync(function(){
+			// not resolved yet
+			o(root.childNodes.length).equals(6)
+			o(root.childNodes[0].nodeName).equals("A1")
+			o(root.childNodes[1].nodeName).equals("A2")
+			o(root.childNodes[2].nodeName).equals("B1")
+			o(root.childNodes[3].nodeName).equals("B2")
+			o(root.childNodes[4].nodeName).equals("C1")
+			o(root.childNodes[5].nodeName).equals("C2")
+	
+			const iterA = domFor(A)
+			o(iterA.next().value.nodeName).equals("A1")
+			o(iterA.next().value.nodeName).equals("A2")
+			o(iterA.next().done).deepEquals(true)
+	
+			const iterB = domFor(B)
+			o(iterB.next().value.nodeName).equals("B1")
+			o(iterB.next().value.nodeName).equals("B2")
+			o(iterB.next().done).deepEquals(true)
+	
+			const iterC = domFor(C)
+			o(iterC.next().value.nodeName).equals("C1")
+			o(iterC.next().value.nodeName).equals("C2")
+			o(iterC.next().done).deepEquals(true)
+
+			// resolve C
+			thenCBC()
+			callAsync(function(){
+				o(root.childNodes.length).equals(4)
+				o(root.childNodes[0].nodeName).equals("A1")
+				o(root.childNodes[1].nodeName).equals("A2")
+				o(root.childNodes[2].nodeName).equals("B1")
+				o(root.childNodes[3].nodeName).equals("B2")
+
+				const iterB = domFor(A)
+				o(iterB.next().value.nodeName).equals("A1")
+				o(iterB.next().value.nodeName).equals("A2")
+				o(iterB.next().done).deepEquals(true)
+
+				const iterC = domFor(B)
+				o(iterC.next().value.nodeName).equals("B1")
+				o(iterC.next().value.nodeName).equals("B2")
+				o(iterC.next().done).deepEquals(true)
+
+				// resolve B
+				thenCBB()
+				callAsync(function(){
+					o(root.childNodes.length).equals(2)
+					o(root.childNodes[0].nodeName).equals("A1")
+					o(root.childNodes[1].nodeName).equals("A2")
+					
+					const iterC = domFor(A)
+					o(iterC.next().value.nodeName).equals("A1")
+					o(iterC.next().value.nodeName).equals("A2")
+					o(iterC.next().done).deepEquals(true)
+
+					// resolve A
+					thenCBA()
 					callAsync(function(){
 						o(root.childNodes.length).equals(0)
 						done()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `generation` of domFor is no longer passed as a parameter.
This allows domFor to work well in onbeforeremove and onremove and reduces the amount of code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#3005 did not properly take into account that domFor is public API.
This PR fixes these problems (https://github.com/MithrilJS/mithril.js/pull/3005#issuecomment-2628779554):
- The domFor in onremove() does not work well during delayed removal. ([flems](https://flems.io/#0=N4IgtglgJlA2CmIBcBWADAOjQDgDQgDMIEBnZAbVADsBDMRJEDAKzPwGMB7KgF3l+SEArlXY8I3AARR4sGgE8AFGBIBKScAA6VTTwBO8HkL1VJVeAHdJABT2dIJeIoMlOsAG7xJAXgB8GyUceABUIek4hHmd4Vw94XEkVdQBfVW1k7W0EHkl3CBIIACMEH0l9IXhtMAwwCN5FKE52IXpeDELOKHkE4DzLJElFdT9Jcm1JXPyikoAyGcTFTRAoCHclnvGJyW5C+AJOAwNazwHFdypO+GH-LVMtia4qWPgMWE4Ac0WQHb2D+CPOCclmk7vd9npBu4aBDGmBtgREhhYQAxA5nC4yVTqW73e6PZ6vD4NezqAD0pMkAAc9BBePAoJt7hlQVsDEYTNJZApFABGND8kFM3CM7ZUAEnSEYq4+G4ih7cAlvT5Lbji+BIYFyyTgyHQ6T2eGIlFo86XLEaLXyp5uF5K4lgMkUi45am0vgMlkTZlMzbJBJLfacYHCu5gL6FSI8bjrDTcdiwCDsADWp2uGjyBWKXm8kgAhBnpvBkn7JEtKUISAALTVUAC6qW0IHwjgQYgkT0EACYAMxINAgZK1-AJqhJshISggWj0QSQHiVmmwJsgYxLxiVng8SkkJDkkSUpPvDBcMCkucL4gAAU7GBvPO7Z4g88XNVpLDYIB48kpDBAJHYNKUjwA71kAA))
- When there is onbeforeremove() in both vnode.state and vnode.attrs, domFor in onbeforeremove() in the latter vnode.attrs does not work well (since 3005.) ([flems](https://flems.io/#0=N4IgtglgJlA2CmIBcBWADAOjQDgDQgDMIEBnZAbVADsBDMRJEDAKzPwGMB7KgF3l+SEArlXY8I3AARR4sGgE8AFGBIBKScAA6VTTwBO8HkL1VJVeAHdJABT2dIJeIoMlOsAG7xJAXgB8GyUceABUIek4hHmd4Vw94XEkVdQBfVW1k7W0uKhIeSQBhewAHHw1MnncISyRJRXU-RMVNECgId2aE5oJOTmbVXHLuACN4boMDME5PGsV3Kk4Zev8tU0k1gHoAKm01tbHa9xo9aXtJTgJEjCh7ADFOPVn5xfUV3d3s2PgMWE4Ac0VrmB1Ot1pIinoILx4FAdrsMqs1pt1rC1gYjCZpLIFIoAIxofFpVbw+HaBB5SokCBDBClfRCeDaMAYSYiKLXdhCei8DBDBbyBLASrVWpLSTkWEUqk0gBk0sahTARQFKLOVBGY3gEym8BmcwW8FFrzekn2syOJzAZwuTMBdweeueZQRxo+bi+P3+gOBoPmeXBkL4MOda3hxskaOMphkciUeIJKtDklSA1WYCaICGkR43A6Gm47FgEHYAGsZobJdSvN5JABCCsIZLJTogIpCEgACz62gAuqltCB8I4EGIJDlBAAmbBINAgZLd-CFqjFshISggWj0QSQHjtiGwAACAGYsFgALTmAAePAwADYAJwDkDGWCCds8HhFEhIEEiIrF34YFwYDrNuu7EEeJ5oOe8BXred4gRAO57sykIsGwIA8PIRQMCAJDsBCRQ8LOvZAA))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test` including new tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
