### PR TITLE
test-perf: Load Benckmark.js first in Node.js

### DIFF
--- a/performance/test-perf.js
+++ b/performance/test-perf.js
@@ -43,6 +43,7 @@ if (isDOM) {
 	window.rootElem = null
 } else {
 	/* eslint-disable global-require */
+	Benchmark = require("benchmark")
 	global.window = require("../test-utils/browserMock")()
 	global.document = window.document
 	// We're benchmarking renders, not our throttling.
@@ -51,7 +52,6 @@ if (isDOM) {
 	}
 	global.m = require("../index.js")
 	global.rootElem = null
-	Benchmark = require("benchmark")
 	/* eslint-enable global-require */
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Since Node21, global.navigator has been implemented, and together with browserMock, Benchmark.js incorrectly identifies the execution environment as a browser. It causes error on `npm run perf` in newer nodejs.
If Benchmark.js is loaded before browserMock, the misidentification will be avoided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have run `npm run perf` in some environments and found that the newer nodejs versions have an error.
The problem seemed to be caused by benchmark.js misidentifying the execution environment as a browser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `npm run perf` on node22 and confirmed that no errors occurred.
Of course, node 18 and 20 do not cause errors. Also, benchmark results should not be affected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
