### PR TITLE
Release - v2.2.15

### DIFF
--- a/performance/test-perf.js
+++ b/performance/test-perf.js
@@ -43,6 +43,7 @@ if (isDOM) {
 	window.rootElem = null
 } else {
 	/* eslint-disable global-require */
+	Benchmark = require("benchmark")
 	global.window = require("../test-utils/browserMock")()
 	global.document = window.document
 	// We're benchmarking renders, not our throttling.
@@ -51,7 +52,6 @@ if (isDOM) {
 	}
 	global.m = require("../index.js")
 	global.rootElem = null
-	Benchmark = require("benchmark")
 	/* eslint-enable global-require */
 }
 

--- a/render/render.js
+++ b/render/render.js
@@ -730,7 +730,7 @@ module.exports = function() {
 		}
 	}
 	function isFormAttribute(vnode, attr) {
-		return attr === "value" || attr === "checked" || attr === "selectedIndex" || attr === "selected" && vnode.dom === activeElement(vnode.dom) || vnode.tag === "option" && vnode.dom.parentNode === activeElement(vnode.dom)
+		return attr === "value" || attr === "checked" || attr === "selectedIndex" || attr === "selected" && (vnode.dom === activeElement(vnode.dom) || vnode.tag === "option" && vnode.dom.parentNode === activeElement(vnode.dom))
 	}
 	function isLifecycleMethod(attr) {
 		return attr === "oninit" || attr === "oncreate" || attr === "onupdate" || attr === "onremove" || attr === "onbeforeremove" || attr === "onbeforeupdate"

--- a/render/tests/test-attributes.js
+++ b/render/tests/test-attributes.js
@@ -527,19 +527,65 @@ o.spec("attributes", function() {
 				m("option", {value: ""})
 			)
 		}
-		/* FIXME
-		   This incomplete test is meant for testing #1916.
-		   However it cannot be completed until #1978 is addressed
-		   which is a lack a working select.selected / option.selected
-		   attribute. Ask @dead-claudia.
+		o("render select options with `selected` (#1916)", function() {
+			var select1 = m("select", [m("option"), m("option")])
+			var select2 = m("select", [m("option", {selected: false}), m("option", {selected: true})])
+			var select3 = m("select", [m("option", {selected: false}), m("option", {selected: true})])
+			var select4 = m("select", [m("option", {selected: false}), m("option", {selected: true})])
+			var select5 = m("select", [m("option", {selected: true}), m("option", {selected: false})])
+			var select6 = m("select", [m("option", {selected: true}), m("option", {selected: false})])
+			var select7 = m("select", [m("option", {selected: true}), m("option", {selected: false})])
 
-		o("render select options", function() {
-			var select = m("select", {selectedIndex: 0},
-				m("option", {value: "1", selected: ""})
-			)
-			render(root, select)
+			// selected: [undefined,undefined]
+			// DomMock can't set/read `option.selected` when the option doesn't have a `select` parent,
+			// so call render() without `option.selected` first.
+			render(root, select1)
+			var el = root.firstChild
+			o(el.selectedIndex).equals(0)
+			o(el.childNodes[0].selected).equals(true)
+			o(el.childNodes[1].selected).equals(false)
+
+			// selected: [undefined,undefined] -> [false,true] (changed -> update by render)
+			render(root, select2)
+			o(el.selectedIndex).equals(1)
+			o(el.childNodes[0].selected).equals(false)
+			o(el.childNodes[1].selected).equals(true)
+
+			// selected: [false,true] -> [false,true] (unchanged, not focused -> not update by render)
+			el.selectedIndex = 0 // set 0 without render
+			render(root, select3)
+			o(el.selectedIndex).equals(0) // unchanged
+			o(el.childNodes[0].selected).equals(true)
+			o(el.childNodes[1].selected).equals(false)
+
+			// selected: [false,true] -> [false,true] (unchanged, focused -> update by render)
+			el.focus()
+			render(root, select4)
+			o(el.selectedIndex).equals(1)
+			o(el.childNodes[0].selected).equals(false)
+			o(el.childNodes[1].selected).equals(true)
+
+			// selected: [false,true] -> [true,false] (changed -> update by render)
+			render(root, select5)
+			o(el.selectedIndex).equals(0)
+			o(el.childNodes[0].selected).equals(true)
+			o(el.childNodes[1].selected).equals(false)
+			
+			// selected: [true,false] -> [true,false] (unchanged, not focused -> not update by render)
+			el.selectedIndex = 1 // set 1 without render
+			root.focus()
+			render(root, select6)
+			o(el.selectedIndex).equals(1) // unchanged
+			o(el.childNodes[0].selected).equals(false)
+			o(el.childNodes[1].selected).equals(true)
+
+			// selected: [true,false] -> [true,false] (unchanged, focused -> update by render)
+			el.focus()
+			render(root, select7)
+			o(el.selectedIndex).equals(0)
+			o(el.childNodes[0].selected).equals(true)
+			o(el.childNodes[1].selected).equals(false)
 		})
-		*/
 		o("can be set as text", function() {
 			var a = makeSelect()
 			var b = makeSelect("2")


### PR DESCRIPTION

# Release v2.2.15

<a name="changeSummary-start"></a>

- #3011
- #3008

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [[refactor] Limit the condition of the option tag to `selected` attribute in isFormAttribute() (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3011)

This PR limits the evaluation of whether a tag is `option` to only when setting the `selected` attribute.
#### [test-perf: Load Benckmark.js first in Node.js (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3008)

Since Node21, global.navigator has been implemented, and together with browserMock, Benchmark.js incorrectly identifies the execution environment as a browser.
               
<a name="changelog-end"></a>
           
           
        