### PR TITLE
Release - v2.3.0

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,14 @@
+name: Notify release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Send workflow dispatch to docs
+      run: gh --repo MithrilJS/docs workflow run package-update.yml -f package=mithril
+      env:
+        GH_TOKEN: ${{ secrets.DOCS_UPDATE_TOKEN }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,0 +1,20 @@
+name: Update release PR
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  update-pr:
+    concurrency: prr:pre-release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - run: npm ci
+    - run: npm run build
+    - run: npx pr-release pr --verbose --target release --source main --compact --verbose --minimize-semver-change
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,4 +1,4 @@
-name: Update release PR
+name: Publish prerelease and update PR
 
 on:
   workflow_call:
@@ -18,3 +18,10 @@ jobs:
     - run: npx pr-release pr --verbose --target release --source main --compact --verbose --minimize-semver-change
       env:
         GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    # The following will publish a prerelease to npm
+    - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      name: Setup NPM Auth
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: npx pr-release infer-prerelease --preid=next --target release --source main --verbose --publish --minimize-semver-change
+      name: Publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,22 +20,4 @@ jobs:
   publish-prerelease:
     needs: run-tests
     if: ${{ github.event_name == 'push' }}
-    concurrency: prr:pre-release
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 20
-    - run: npm ci
-    - run: npm run build
-    - run: npx pr-release pr --verbose --target release --source main --compact --verbose --minimize-semver-change
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-    # The following will publish a prerelease to npm
-    - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-      name: Setup NPM Auth
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: npx pr-release infer-prerelease --preid=next --target release --source main --verbose --publish --minimize-semver-change
-      name: Publish
+    uses: ./.github/workflows/publish-prerelease.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,22 @@ jobs:
   publish-prerelease:
     needs: run-tests
     if: ${{ github.event_name == 'push' }}
-    uses: ./.github/workflows/publish-prerelease.yml
+    concurrency: prr:pre-release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - run: npm ci
+    - run: npm run build
+    - run: npx pr-release pr --verbose --target release --source main --compact --verbose --minimize-semver-change
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    # The following will publish a prerelease to npm
+    - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      name: Setup NPM Auth
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - run: npx pr-release infer-prerelease --preid=next --target release --source main --verbose --publish --minimize-semver-change
+      name: Publish

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm Version](https://img.shields.io/npm/v/mithril.svg)](https://www.npmjs.com/package/mithril) &nbsp;
 [![License](https://img.shields.io/npm/l/mithril.svg)](https://github.com/MithrilJS/mithril.js/blob/main/LICENSE) &nbsp;
 [![npm Downloads](https://img.shields.io/npm/dm/mithril.svg)](https://www.npmjs.com/package/mithril) &nbsp;
-[![Build Status](https://img.shields.io/github/actions/workflow/status/MithrilJS/mithril.js/.github%2Fworkflows%2Ftest-main-push.yml)](https://www.npmjs.com/package/mithril) &nbsp;
+[![Build Status](https://img.shields.io/github/actions/workflow/status/MithrilJS/mithril.js/.github%2Fworkflows%2Ftest.yml?branch=main&event=push)](https://www.npmjs.com/package/mithril) &nbsp;
 [![Donate at OpenCollective](https://img.shields.io/opencollective/all/mithriljs.svg?colorB=brightgreen)](https://opencollective.com/mithriljs) &nbsp;
 [![Zulip, join chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://mithril.zulipchat.com/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1159,10 +1159,11 @@
       "dev": true
     },
     "node_modules/glob": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^4.0.1",
@@ -3373,9 +3374,9 @@
       "dev": true
     },
     "glob": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+      "integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
       "dev": true,
       "requires": {
         "foreground-child": "^3.1.0",

--- a/render/render.js
+++ b/render/render.js
@@ -626,6 +626,7 @@ module.exports = function() {
 		if (typeof vnode.tag !== "string") {
 			if (vnode.instance != null) onremove(vnode.instance)
 		} else {
+			if (vnode.events != null) vnode.events._ = null
 			var children = vnode.children
 			if (Array.isArray(children)) {
 				for (var i = 0; i < children.length; i++) {
@@ -810,12 +811,12 @@ module.exports = function() {
 		var result
 		if (typeof handler === "function") result = handler.call(ev.currentTarget, ev)
 		else if (typeof handler.handleEvent === "function") handler.handleEvent(ev)
-		var eventRedraw = this._
-		if (eventRedraw) {
-			if (ev.redraw !== false) eventRedraw()
+		var self = this
+		if (self._ != null) {
+			if (ev.redraw !== false) (0, self._)()
 			if (result != null && typeof result.then === "function") {
 				Promise.resolve(result).then(function () {
-					if (ev.redraw !== false) eventRedraw()
+					if (self._ != null && ev.redraw !== false) (0, self._)()
 				})
 			}
 		}

--- a/render/render.js
+++ b/render/render.js
@@ -811,8 +811,8 @@ module.exports = function() {
 		if (typeof handler === "function") result = handler.call(ev.currentTarget, ev)
 		else if (typeof handler.handleEvent === "function") handler.handleEvent(ev)
 		var eventRedraw = this._
-		if (eventRedraw && ev.redraw !== false) {
-			eventRedraw()
+		if (eventRedraw) {
+			if (ev.redraw !== false) eventRedraw()
 			if (result != null && typeof result.then === "function") {
 				Promise.resolve(result).then(function () {
 					if (ev.redraw !== false) eventRedraw()

--- a/render/render.js
+++ b/render/render.js
@@ -814,7 +814,7 @@ module.exports = function() {
 		if (eventRedraw && ev.redraw !== false) {
 			eventRedraw()
 			if (result != null && typeof result.then === "function") {
-				Promise.resolve(result).finally(function () {
+				Promise.resolve(result).then(function () {
 					if (ev.redraw !== false) eventRedraw()
 				})
 			}

--- a/render/render.js
+++ b/render/render.js
@@ -810,7 +810,15 @@ module.exports = function() {
 		var result
 		if (typeof handler === "function") result = handler.call(ev.currentTarget, ev)
 		else if (typeof handler.handleEvent === "function") handler.handleEvent(ev)
-		if (this._ && ev.redraw !== false) (0, this._)()
+		var eventRedraw = this._
+		if (eventRedraw && ev.redraw !== false) {
+			eventRedraw()
+			if (result != null && typeof result.then === "function") {
+				Promise.resolve(result).finally(function () {
+					if (ev.redraw !== false) eventRedraw()
+				})
+			}
+		}
 		if (result === false) {
 			ev.preventDefault()
 			ev.stopPropagation()

--- a/render/tests/.eslintrc.js
+++ b/render/tests/.eslintrc.js
@@ -1,0 +1,16 @@
+"use strict"
+
+module.exports = {
+	"extends": "../../.eslintrc.js",
+	"env": {
+		"browser": null,
+		"node": true,
+		"es2022": true,
+	},
+	"parserOptions": {
+		"ecmaVersion": 2022,
+	},
+	"rules": {
+		"no-process-env": "off",
+	},
+};

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -525,7 +525,7 @@ o.spec("event", function() {
 			})
 		})
 	})
-	o.spec("reject", function() {
+	o.spec("do not asynchronous redraw when returned Promise is rejected", function() {
 		var error
 		o.beforeEach(function(){
 			error = console.error
@@ -544,14 +544,14 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 	
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
 	
 			callAsync(function() {
-				o(redraw.callCount).equals(2)
-				o(redraw.this).equals(undefined)
-				o(redraw.args.length).equals(0)
+				// do not async redraw
+				o(redraw.callCount).equals(1)
 
 				// called console.error
 				o(consoleSpy.callCount).equals(1)
@@ -572,6 +572,7 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
@@ -583,9 +584,8 @@ o.spec("event", function() {
 				// reject
 				rejectCB("error")
 				callAsync(function() {
-					o(redraw.callCount).equals(2)
-					o(redraw.this).equals(undefined)
-					o(redraw.args.length).equals(0)
+					// do not async redraw
+					o(redraw.callCount).equals(1)
 
 					// called console.error
 					o(consoleSpy.callCount).equals(1)
@@ -607,6 +607,7 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
@@ -618,9 +619,8 @@ o.spec("event", function() {
 				// reject
 				rejectCB("error")
 				callAsync(function() {
-					o(redraw.callCount).equals(2)
-					o(redraw.this).equals(undefined)
-					o(redraw.args.length).equals(0)
+					// do not async redraw
+					o(redraw.callCount).equals(1)
 
 					// called console.error
 					o(consoleSpy.callCount).equals(1)
@@ -643,6 +643,7 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
@@ -654,9 +655,8 @@ o.spec("event", function() {
 				// resolve (and throw Error)
 				thenCB()
 				callAsync(function() {
-					o(redraw.callCount).equals(2)
-					o(redraw.this).equals(undefined)
-					o(redraw.args.length).equals(0)
+					// do not async redraw
+					o(redraw.callCount).equals(1)
 
 					// called console.error
 					o(consoleSpy.callCount).equals(1)
@@ -679,6 +679,7 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
@@ -690,9 +691,8 @@ o.spec("event", function() {
 				// resolve (and throw Error)
 				thenCB()
 				callAsync(function() {
-					o(redraw.callCount).equals(2)
-					o(redraw.this).equals(undefined)
-					o(redraw.args.length).equals(0)
+					// do not async redraw
+					o(redraw.callCount).equals(1)
 
 					// called console.error
 					o(consoleSpy.callCount).equals(1)
@@ -714,6 +714,7 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
@@ -725,9 +726,8 @@ o.spec("event", function() {
 				// reject
 				rejectCB("error")
 				callAsync(function() {
-					o(redraw.callCount).equals(2)
-					o(redraw.this).equals(undefined)
-					o(redraw.args.length).equals(0)
+					// do not async redraw
+					o(redraw.callCount).equals(1)
 
 					// called console.error
 					o(consoleSpy.callCount).equals(1)
@@ -749,6 +749,7 @@ o.spec("event", function() {
 			render(root, div)
 			div.dom.dispatchEvent(e)
 
+			// sync redraw
 			o(redraw.callCount).equals(1)
 			o(redraw.this).equals(undefined)
 			o(redraw.args.length).equals(0)
@@ -760,9 +761,8 @@ o.spec("event", function() {
 				// resolve
 				rejectCB("error")
 				callAsync(function() {
-					o(redraw.callCount).equals(2)
-					o(redraw.this).equals(undefined)
-					o(redraw.args.length).equals(0)
+					// do not async redraw
+					o(redraw.callCount).equals(1)
 
 					// called console.error
 					o(consoleSpy.callCount).equals(1)

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -848,6 +848,38 @@ o.spec("event", function() {
 			})
 		})
 	})
+	o("async function (event.redraw = false, await Promise, event.redraw = true)", function(done) {
+		var thenCB
+		var div = m("div", {onclick: async function (ev) {
+			// set event.redraw = false to prevent sync redraw
+			ev.redraw = false
+			await new Promise(function(resolve){thenCB = resolve})
+			// set event.redraw = true to enable async redraw
+			ev.redraw = true
+		}})
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+
+		render(root, div)
+		div.dom.dispatchEvent(e)
+
+		o(redraw.callCount).equals(0)
+
+		callAsync(function() {
+			// not resolved yet
+			o(redraw.callCount).equals(0)
+
+			// resolve
+			thenCB()
+			callAsync(function() {
+				o(redraw.callCount).equals(1)
+				o(redraw.this).equals(undefined)
+				o(redraw.args.length).equals(0)
+
+				done()
+			})
+		})
+	})
 	o("async function (multiple await)", function(done) {
 		var thenCB1, thenCB2
 		var div = m("div", {onclick: async function () {


### PR DESCRIPTION

# Release v2.3.0

<a name="changeSummary-start"></a>

- #3021
- #3020
- #3019
- #3015

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Minor Changes

#### [feat: Make redraws when Promises returned by event handlers are completed (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3020)

This PR allows redraw on completion of the async event handler.  This PR makes redraws when Promises returned by event handlers are completed.
               
### Patch Changes

#### [Allow additional async redraw even if the first redraw is skipped (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3021)

This PR allows asynchronous redraw processing even if the first redraw is skipped by setting `event.redraw=false` before await in the async function.
#### [Bump glob from 11.0.1 to 11.0.2 in the normal group (@dependabot[bot])](https://github.com/MithrilJS/mithril.js/pull/3019)

Bumps the normal group with 1 update: [glob](https://github.com/isaacs/node-glob).  Updates `glob` from 11.0.1 to 11.0.2.  Commits.  fd61f24 11.0.2.
#### [Fix badge for build status (@kfule)](https://github.com/MithrilJS/mithril.js/pull/3015)

The URL for the Shields.io badge for build status has been corrected.
               
<a name="changelog-end"></a>
           
           
           
           
           
           
           
           
        