### PR TITLE
Allow additional async redraw even if the first redraw is skipped

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -626,6 +626,7 @@ module.exports = function() {
 		if (typeof vnode.tag !== "string") {
 			if (vnode.instance != null) onremove(vnode.instance)
 		} else {
+			if (vnode.events != null) vnode.events._ = null
 			var children = vnode.children
 			if (Array.isArray(children)) {
 				for (var i = 0; i < children.length; i++) {
@@ -810,12 +811,12 @@ module.exports = function() {
 		var result
 		if (typeof handler === "function") result = handler.call(ev.currentTarget, ev)
 		else if (typeof handler.handleEvent === "function") handler.handleEvent(ev)
-		var eventRedraw = this._
-		if (eventRedraw) {
-			if (ev.redraw !== false) eventRedraw()
+		var self = this
+		if (self._ != null) {
+			if (ev.redraw !== false) (0, self._)()
 			if (result != null && typeof result.then === "function") {
 				Promise.resolve(result).then(function () {
-					if (ev.redraw !== false) eventRedraw()
+					if (self._ != null && ev.redraw !== false) (0, self._)()
 				})
 			}
 		}

--- a/render/render.js
+++ b/render/render.js
@@ -811,8 +811,8 @@ module.exports = function() {
 		if (typeof handler === "function") result = handler.call(ev.currentTarget, ev)
 		else if (typeof handler.handleEvent === "function") handler.handleEvent(ev)
 		var eventRedraw = this._
-		if (eventRedraw && ev.redraw !== false) {
-			eventRedraw()
+		if (eventRedraw) {
+			if (ev.redraw !== false) eventRedraw()
 			if (result != null && typeof result.then === "function") {
 				Promise.resolve(result).then(function () {
 					if (ev.redraw !== false) eventRedraw()

--- a/render/tests/test-event.js
+++ b/render/tests/test-event.js
@@ -848,6 +848,38 @@ o.spec("event", function() {
 			})
 		})
 	})
+	o("async function (event.redraw = false, await Promise, event.redraw = true)", function(done) {
+		var thenCB
+		var div = m("div", {onclick: async function (ev) {
+			// set event.redraw = false to prevent sync redraw
+			ev.redraw = false
+			await new Promise(function(resolve){thenCB = resolve})
+			// set event.redraw = true to enable async redraw
+			ev.redraw = true
+		}})
+		var e = $window.document.createEvent("MouseEvents")
+		e.initEvent("click", true, true)
+
+		render(root, div)
+		div.dom.dispatchEvent(e)
+
+		o(redraw.callCount).equals(0)
+
+		callAsync(function() {
+			// not resolved yet
+			o(redraw.callCount).equals(0)
+
+			// resolve
+			thenCB()
+			callAsync(function() {
+				o(redraw.callCount).equals(1)
+				o(redraw.this).equals(undefined)
+				o(redraw.args.length).equals(0)
+
+				done()
+			})
+		})
+	})
 	o("async function (multiple await)", function(done) {
 		var thenCB1, thenCB2
 		var div = m("div", {onclick: async function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR allows asynchronous redraw processing even if the first redraw is skipped by setting `event.redraw=false` before await in the async function.
Also, this PR avoids redraw after the dom or component is removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is intended to address the following cases of [zulip](https://mithril.zulipchat.com/#narrow/channel/324076-general/topic/Should.20async.20event.20handlers.20be.20a.20semver.20major.20change.3F/with/516572123)

> If it was set to `false` before the first await and then `true` after it, the first redraw should be skipped, but the second one shouldn't.

In #3020 , I didn't consider the case where `event.redraw` would later be `true`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test` with additional test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
