### PR TITLE
updateStyle(): Make it possible to update element styles for the same style object

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -749,16 +749,16 @@ module.exports = function() {
 
 	//style
 	function updateStyle(element, old, style) {
-		if (old === style) {
-			// Styles are equivalent, do nothing.
-		} else if (style == null) {
+		// The case `old` and `style` are the same string has already skipped in setAttr().
+		if (style == null) {
 			// New style is missing, just clear it.
 			element.style = ""
 		} else if (typeof style !== "object") {
 			// New style is a string, let engine deal with patching.
 			element.style = style
-		} else if (old == null || typeof old !== "object") {
+		} else if (old == null || typeof old !== "object" || old === style) {
 			// `old` is missing or a string, `style` is an object.
+			// `old` and `style` are the same object (in this case, conciliation between objects does not work well.)
 			element.style = ""
 			// Add new style properties
 			for (var key in style) {

--- a/render/tests/test-updateElement.js
+++ b/render/tests/test-updateElement.js
@@ -193,6 +193,19 @@ o.spec("updateElement", function() {
 
 		o(updated.dom.style.color).equals("red")
 	})
+	o("re-render element styles for the same style object", function() {
+		var style = {color: "gold"}
+		var vnode = m("a", {style: style})
+
+		render(root, vnode)
+
+		// modify the same object
+		style.color = "red"
+		var updated = m("a", {style: style})
+		render(root, updated)
+
+		o(updated.dom.style.color).equals("red")
+	})
 	o("setting style to `null` removes all styles", function() {
 		var vnode = m("p", {style: "background-color: red"})
 		var updated = m("p", {style: null})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR addresses the case in #2915 where styles are not updated by the same style object.

## Description
<!--- Describe your changes in detail -->
In this PR, if the old and new style objects are the same, clear the style and then re-set the properties. This is the same process as when updating from a null or string style to an object style.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This same style object case is taken into account in v1 and works fine ([flems v1.1.7](https://flems.io/mithril@1.1.7#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J5YxAARxiAT1gSAvBOAAdNBIkB3CABNihRBIDkARgAMZgA4APIxTUbCMCAHMShowGYrt++okARhjUANYuAE60AK5oOh4AxAAsAGwAHABMAEKJdmqsANxqalj4WNEMABQ6tNRROAz4AbQ6MhTKDhIAbhAwmoYVAJSKAHwSyB0aWBVGEGiWUcR27f4aGrKWMB7hGGguMLkrq1izhiZ+q0cY1obpFucXEvSz88SGYDHUxBD0g8pSsrB8No9IRFBIAAYAEmA+ggcHwnQwUCiMFYNnBElYE0xA3uk2mOggnSWwH+chgOOxAHoqVMjITiW1SdJyYYWfJWANqbSCUSSWTYIZSfgReyKaxOR0ALp5Ab5DSUEBwGCwT7fNAIHgmACsiE86TYHBAmBweHw1DgAho9EYzB4bClrCAA).)
https://github.com/MithrilJS/mithril.js/blob/35ab329291f810febb80c08b498855b7832c93d9/render/render.js#L564

In v2, however, the style updates were skipped completely for the same style object ([flems v2.3.0](https://flems.io/mithril@2.3.0#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J5YxAARxiAT1gSAvBOAAdNBIkB3CABNihRBIDkARgAMZgA4APIxTUbCMCAHMShowGYrt++okARhjUANYuAE60AK5oOh4AxAAsAGwAHABMAEKJdmqsANxqalj4WNEMABQ6tNRROAz4AbQ6MhTKDhIAbhAwmoYVAJSKAHwSyB0aWBVGEGiWUcR27f4aGrKWMB7hGGguMLkrq1izhiZ+q0cY1obpFucXEvSz88SGYDHUxBD0g8pSsrB8No9IRFBIAAYAEmA+ggcHwnQwUCiMFYNnBElYE0xA3uk2mOggnSWwH+chgOOxAHoqVMjITiW1SdJyYYWfJWANqbSCUSSWTYIZSfgReyKaxOR0ALp5Ab5DSUEBwGCwT7fNAIHgmACsiE86TYHBAmBweHw1DgAho9EYzB4bClrCAA).) It appears to have been omitted in the v2 changes (https://github.com/MithrilJS/mithril.js/commit/8134c51a4870de1eab9da71887c98773c6721901). This case has no note in the documentation and no warning like the same `attrs`.

The case of reusing objects may not be preferable. However, I think this case works well and is better to fix than warnings or documentation.
In the performance context, skipping style updates would also be possible with string styles or class, which would be better for performance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test` with additional test
I also confirmed that the bundle file works fine with the above flems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
