### PR TITLE
set trailing slash optional in route matching

### DIFF
--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -225,6 +225,30 @@ o.spec("route", function() {
 					)
 				})
 
+				o("remove trailing slash to match route if it is before rest operator match (...) ", function() {
+					$window.location.href = prefix + "/test/d/"
+					route(root, "/test/:a...", {
+						"/test/:a" : {
+							view: lock(function(vnode) {
+								return JSON.stringify(route.param()) + " " +
+									JSON.stringify(vnode.attrs) + " " +
+									route.get()
+							})
+						},
+						"/test/:a..." : {
+							view: lock(function(vnode) {
+								return JSON.stringify(route.param()) + " " +
+									JSON.stringify(vnode.attrs) + " " +
+									route.get()
+							})
+						},
+					})
+
+					o(root.firstChild.nodeValue).equals(
+						'{"a":"d"} {"a":"d"} /test/d/'
+					)
+				})
+
 				o("handles route with search", function() {
 					$window.location.href = prefix + "/test?a=b&c=d"
 					route(root, "/test", {

--- a/pathname/compileTemplate.js
+++ b/pathname/compileTemplate.js
@@ -24,7 +24,7 @@ module.exports = function(template) {
 			if (extra === ".") return "([^/]+)\\."
 			return "([^/]+)" + (extra || "")
 		}
-	) + "$")
+	) + "\\/?$")
 	return function(data) {
 		// First, check the params. Usually, there isn't any, and it's just
 		// checking a static set.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Regexp has been updated to set trailing slash has optional in route matching.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
link to issue 3024. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test has been added. The previous change to keep trailing slash when it match with rest operator is still working.
This is removing the previoous breaking change of always keeping the trailing slash.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [X] I have read https://mithril.js.org/contributing.html.
