### PR TITLE
router: delay mounting RouterRoot until the first route is resolved (fixes #2621)

### DIFF
--- a/api/router.js
+++ b/api/router.js
@@ -42,10 +42,10 @@ module.exports = function($window, mountRedraw) {
 			// Therefore, the following early return is not needed.
 			// if (!hasBeenResolved) return
 
+			var vnode = Vnode(component, attrs.key, attrs)
+			if (currentResolver) return currentResolver.render(vnode)
 			// Wrap in a fragment to preserve existing key semantics
-			var vnode = [Vnode(component, attrs.key, attrs)]
-			if (currentResolver) vnode = currentResolver.render(vnode[0])
-			return vnode
+			return [vnode]
 		},
 	}
 

--- a/api/router.js
+++ b/api/router.js
@@ -28,16 +28,20 @@ module.exports = function($window, mountRedraw) {
 	var ready = false
 	var hasBeenResolved = false
 
-	var compiled, fallbackRoute
+	var dom, compiled, fallbackRoute
 
 	var currentResolver, component, attrs, currentPath, lastUpdate
 
 	var RouterRoot = {
 		onremove: function() {
+			ready = hasBeenResolved = false
 			$window.removeEventListener("popstate", fireAsync, false)
 		},
 		view: function() {
-			if (!hasBeenResolved) return
+			// The route has already been resolved.
+			// Therefore, the following early return is not needed.
+			// if (!hasBeenResolved) return
+
 			// Wrap in a fragment to preserve existing key semantics
 			var vnode = [Vnode(component, attrs.key, attrs)]
 			if (currentResolver) vnode = currentResolver.render(vnode[0])
@@ -90,7 +94,7 @@ module.exports = function($window, mountRedraw) {
 						if (hasBeenResolved) mountRedraw.redraw()
 						else {
 							hasBeenResolved = true
-							mountRedraw.redraw.sync()
+							mountRedraw.mount(dom, RouterRoot)
 						}
 					}
 					// There's no understating how much I *wish* I could
@@ -148,11 +152,13 @@ module.exports = function($window, mountRedraw) {
 				throw new ReferenceError("Default route doesn't match any known routes.")
 			}
 		}
+		dom = root
 
 		$window.addEventListener("popstate", fireAsync, false)
 
 		ready = true
-		mountRedraw.mount(root, RouterRoot)
+
+		// The RouterRoot component is mounted when the route is first resolved.
 		resolveRoute()
 	}
 	route.set = function(path, data, options) {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1969,6 +1969,43 @@ o.spec("route", function() {
 					o(root.childNodes[0].childNodes.length).equals(0)
 				})
 
+				o("route component is mounted after the route is initially resolved (render, synchronous)", function() {
+					var Component = {
+						render: lock(function() {
+							// the first rendered vnode is cleared
+							o(root.childNodes.length).equals(0)
+							return m("span")
+						})
+					}
+
+					// initial root node
+					root.textContent = "foo"
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0].nodeName).equals("#text")
+					o(root.childNodes[0].nodeValue).equals("foo")
+
+					// render another vnode first
+					var render = coreRenderer($window)
+					var vnode = m("a", "loading...")
+					render(root, vnode)
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0].nodeName).equals("A")
+					o(root.childNodes[0].firstChild.nodeName).equals("#text")
+					o(root.childNodes[0].firstChild.nodeValue).equals("loading...")
+
+					// call route() (mount synchronously)
+					$window.location.href = prefix + "/"
+					route(root, "/", {
+						"/" : Component
+					})
+
+					// route component is mounted and the first rendered vnode is cleared
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0]).notEquals(vnode.dom)
+					o(root.childNodes[0].nodeName).equals("SPAN")
+					o(root.childNodes[0].childNodes.length).equals(0)
+				})
+
 				o("route component is mounted after the route is initially resolved (onmatch, asynchronous)", function() {
 					var Component = {
 						view: lock(function() {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1935,6 +1935,8 @@ o.spec("route", function() {
 				o("route component is mounted after the route is initially resolved (synchronous)", function() {
 					var Component = {
 						view: lock(function() {
+							// the first rendered vnode is cleared
+							o(root.childNodes.length).equals(0)
 							return m("span")
 						})
 					}
@@ -1976,7 +1978,18 @@ o.spec("route", function() {
 
 					var resolver = {
 						onmatch: lock(function() {
+							// the first rendered vnode is not yet cleared
+							o(root.childNodes.length).equals(1)
+							o(root.childNodes[0]).equals(vnode.dom)
+							o(root.childNodes[0].nodeName).equals("A")
+							o(root.childNodes[0].firstChild.nodeName).equals("#text")
+							o(root.childNodes[0].firstChild.nodeValue).equals("loading...")
 							return Component
+						}),
+						render: lock(function(vnode) {
+							// the first rendered vnode is cleared
+							o(root.childNodes.length).equals(0)
+							return vnode
 						})
 					}
 

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -1939,10 +1939,20 @@ o.spec("route", function() {
 						})
 					}
 
+					// initial root node
+					root.textContent = "foo"
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0].nodeName).equals("#text")
+					o(root.childNodes[0].nodeValue).equals("foo")
+
 					// render another vnode first
 					var render = coreRenderer($window)
-					render(root, m("a"))
-					o(root.firstChild.nodeName).equals("A")
+					var vnode = m("a", "loading...")
+					render(root, vnode)
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0].nodeName).equals("A")
+					o(root.childNodes[0].firstChild.nodeName).equals("#text")
+					o(root.childNodes[0].firstChild.nodeValue).equals("loading...")
 
 					// call route() (mount synchronously)
 					$window.location.href = prefix + "/"
@@ -1951,7 +1961,10 @@ o.spec("route", function() {
 					})
 
 					// route component is mounted and the first rendered vnode is cleared
-					o(root.firstChild.nodeName).equals("SPAN")
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0]).notEquals(vnode.dom)
+					o(root.childNodes[0].nodeName).equals("SPAN")
+					o(root.childNodes[0].childNodes.length).equals(0)
 				})
 
 				o("route component is mounted after the route is initially resolved (onmatch, asynchronous)", function() {
@@ -1967,10 +1980,20 @@ o.spec("route", function() {
 						})
 					}
 
+					// initial root node
+					root.textContent = "foo"
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0].nodeName).equals("#text")
+					o(root.childNodes[0].nodeValue).equals("foo")
+
 					// render another vnode first
 					var render = coreRenderer($window)
-					render(root, m("a"))
-					o(root.firstChild.nodeName).equals("A")
+					var vnode = m("a", "loading...")
+					render(root, vnode)
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0].nodeName).equals("A")
+					o(root.childNodes[0].firstChild.nodeName).equals("#text")
+					o(root.childNodes[0].firstChild.nodeValue).equals("loading...")
 
 					// call route() (mount asynchronously)
 					$window.location.href = prefix + "/"
@@ -1979,11 +2002,18 @@ o.spec("route", function() {
 					})
 
 					// the first rendered vnode is not yet cleared
-					o(root.firstChild.nodeName).equals("A")
+					o(root.childNodes.length).equals(1)
+					o(root.childNodes[0]).equals(vnode.dom)
+					o(root.childNodes[0].nodeName).equals("A")
+					o(root.childNodes[0].firstChild.nodeName).equals("#text")
+					o(root.childNodes[0].firstChild.nodeValue).equals("loading...")
 
 					return waitCycles(1).then(function() {
 						// route component is mounted and the first rendered vnode is cleared
-						o(root.firstChild.nodeName).equals("SPAN")
+						o(root.childNodes.length).equals(1)
+						o(root.childNodes[0]).notEquals(vnode.dom)
+						o(root.childNodes[0].nodeName).equals("SPAN")
+						o(root.childNodes[0].childNodes.length).equals(0)
 					})
 				})
 

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -2013,8 +2013,14 @@ o.spec("route", function() {
 						})
 					}
 
+					// check for the order of calling onmatch and render
+					var count = 0
+
 					var resolver = {
 						onmatch: lock(function() {
+							count += 1
+							o(count).equals(1)
+
 							// the first rendered vnode is not yet cleared
 							o(root.childNodes.length).equals(1)
 							o(root.childNodes[0]).equals(vnode.dom)
@@ -2024,6 +2030,9 @@ o.spec("route", function() {
 							return Component
 						}),
 						render: lock(function(vnode) {
+							count += 1
+							o(count).equals(2)
+
 							// the first rendered vnode is cleared
 							o(root.childNodes.length).equals(0)
 							return vnode
@@ -2058,12 +2067,17 @@ o.spec("route", function() {
 					o(root.childNodes[0].firstChild.nodeName).equals("#text")
 					o(root.childNodes[0].firstChild.nodeValue).equals("loading...")
 
+					// The count of route resolver method calls is still 0
+					o(count).equals(0)
+
 					return waitCycles(1).then(function() {
 						// route component is mounted and the first rendered vnode is cleared
 						o(root.childNodes.length).equals(1)
 						o(root.childNodes[0]).notEquals(vnode.dom)
 						o(root.childNodes[0].nodeName).equals("SPAN")
 						o(root.childNodes[0].childNodes.length).equals(0)
+
+						o(count).equals(2)
 					})
 				})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR delays the initial mounting of the router component until after the route has been resolved.
Since the component that displays nothing is no longer mounted first, the following improvements are made.
- Errors are no longer caught by `m.mount` when the actual component is first rendered, and #2621 is fixed.
- Since the root DOM is not manipulated until the actual mounting, it makes easy to display something like "loading..." when using `onmatch` (cf. #2490).

In addition, cleanup code has been added to RouterRoot's `onremove` to pass the test.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #2621, and enables "loading..." like #2490

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test` with new tests

I have also confirmed that replacing the bundle improved the behavior of the following flems.
- [flems #2621](https://flems.io/#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgAsAXLKEAGhAGMB7NYmBvEAXwvW10QICsEqdBk2J4A7hDQATWmPz0YAJ0W1FAAgC8anHDgYA5jE0A+NcAA6aNWqFxasfFFr6AFAHJkE6bPlolKxQBdNwpteD1DAEpLVktLW2I1AFkATwBhWiwABwUGTTUXSJMzS2s0WjgAUQAPCDhiSX0AMQBXNGoG+kK1AHoetX9VUrVhsDaOiHo1ADcIGDECoosrazVFGGIWxSssd0IARhC1NwAVeAa0fQHlVTg3aJXYleH1ze2zGbmFp6fLLHwVC1GC4ZNQWjgGPgAEa0KQpUJuHpHZbWRFuRDJdKZHJ+BgxSKUEBwGCwCb0BA8fYAFkQAHYALTUxAABjYHBAmBweHw1F0hKEjGYPDYgSoUEkAGsKagOVw8FgIMRCIpoIStuQeCRiFk4Ig+m0shL9DzMj0FUqVVAAAIAJnwzPwVLNiuV0HwCrQ+H4hOIKSy3CJ1BVWVErECrCAA)
  - Replacing with the new bundle will cause the error to be forwarded to `window.onerror`.
- [flems like #2490](https://flems.io/mithril@2.3.2#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgCsEAaEAYwHs0AXGWvKtOGgAgGFKsAHa+tgLytgAHTSsJrAG4QYAd0SswAVzTkaEagAoAlMLGTDrAE4way4+KxaA5ABMIUmyVY2AFjChRKrOZWNQdjY6BpIAvmJhANxiYgD0cawAym6UcqzeGA5oAOa+btAwvkWZdqx2GDQYYlj4pmh2MMZadpTkyji0+ABGlHYAni7W9o7OrqUQufjTwToxaDV1lMp0LW0d-D19g65xk40AHmOi4pI2ew0wR4onRpLUWJXkbooqahraerd3RkxwlLB8N4crYHk83L4MHBWOQMF4YEE5rFTj9JKZzJZWGh5KwAArGLgQOAwLRvdSaNBaUz-KBSGAuUyEGDqL6hVF3Yk0AAqEBwyxoVPgALpLgAjAAGSVIlHssI6fA0DyUskfSmsmXstFmCziTg8Pi0eaaiRyo0-CIyi1ykBkYmwcnUBCIEAAdkQ4pAYQAumEgA)
  - Replacing with the new bundle will cause "loading..." to be displayed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
