### PR TITLE
Replace console.error with reportError (further fixes #2621)

### DIFF
--- a/api/mount-redraw.js
+++ b/api/mount-redraw.js
@@ -10,7 +10,7 @@ module.exports = function(render, schedule) {
 	function sync() {
 		for (offset = 0; offset < subscriptions.length; offset += 2) {
 			try { render(subscriptions[offset], Vnode(subscriptions[offset + 1]), redraw) }
-			catch (e) { console.error(e) }
+			catch (e) { reportError(e) }
 		}
 		offset = -1
 	}

--- a/api/mount-redraw.js
+++ b/api/mount-redraw.js
@@ -2,7 +2,7 @@
 
 var Vnode = require("../render/vnode")
 
-module.exports = function(render, schedule, console) {
+module.exports = function(render, schedule) {
 	var subscriptions = []
 	var pending = false
 	var offset = -1

--- a/api/router.js
+++ b/api/router.js
@@ -74,7 +74,7 @@ module.exports = function($window, mountRedraw) {
 		Object.assign(data.params, $window.history.state)
 
 		function reject(e) {
-			console.error(e)
+			reportError(e)
 			route.set(fallbackRoute, null, {replace: true})
 		}
 

--- a/api/tests/test-mountRedraw.js
+++ b/api/tests/test-mountRedraw.js
@@ -11,21 +11,23 @@ var h = require("../../render/hyperscript")
 
 o.spec("mount/redraw", function() {
 	var root, m, throttleMock, consoleMock, $document, errors
+	var realError = console.error
 	o.beforeEach(function() {
 		var $window = domMock()
-		consoleMock = {error: o.spy()}
+		console.error = consoleMock = o.spy()
 		throttleMock = throttleMocker()
 		root = $window.document.body
-		m = mountRedraw(coreRenderer($window), throttleMock.schedule, consoleMock)
+		m = mountRedraw(coreRenderer($window), throttleMock.schedule)
 		$document = $window.document
 		errors = []
 	})
 
 	o.afterEach(function() {
-		o(consoleMock.error.calls.map(function(c) {
+		o(consoleMock.calls.map(function(c) {
 			return c.args[0]
 		})).deepEquals(errors)
 		o(throttleMock.queueLength()).equals(0)
+		console.error = realError
 	})
 
 	o("shouldn't error if there are no renderers", function() {

--- a/api/tests/test-mountRedraw.js
+++ b/api/tests/test-mountRedraw.js
@@ -10,11 +10,11 @@ var coreRenderer = require("../../render/render")
 var h = require("../../render/hyperscript")
 
 o.spec("mount/redraw", function() {
-	var root, m, throttleMock, consoleMock, $document, errors
-	var realError = console.error
+	var root, m, throttleMock, $document, errors
+	var realError = global.reportError
 	o.beforeEach(function() {
 		var $window = domMock()
-		console.error = consoleMock = o.spy()
+		global.reportError = o.spy()
 		throttleMock = throttleMocker()
 		root = $window.document.body
 		m = mountRedraw(coreRenderer($window), throttleMock.schedule)
@@ -23,11 +23,11 @@ o.spec("mount/redraw", function() {
 	})
 
 	o.afterEach(function() {
-		o(consoleMock.calls.map(function(c) {
+		o(global.reportError.calls.map(function(c) {
 			return c.args[0]
 		})).deepEquals(errors)
 		o(throttleMock.queueLength()).equals(0)
-		console.error = realError
+		global.reportError = realError
 	})
 
 	o("shouldn't error if there are no renderers", function() {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -79,7 +79,7 @@ o.spec("route", function() {
 
 					root = $window.document.body
 
-					mountRedraw = apiMountRedraw(coreRenderer($window), throttleMock.schedule, console)
+					mountRedraw = apiMountRedraw(coreRenderer($window), throttleMock.schedule)
 					route = apiRouter($window, mountRedraw)
 					route.prefix = prefix
 					console.error = function() {

--- a/api/tests/test-router.js
+++ b/api/tests/test-router.js
@@ -69,6 +69,7 @@ o.spec("route", function() {
 
 				// In case it doesn't get reset
 				var realError = console.error
+				var realReportError = global.reportError
 
 				o.beforeEach(function() {
 					currentTest = nextID++
@@ -92,6 +93,7 @@ o.spec("route", function() {
 					o(throttleMock.queueLength()).equals(0)
 					currentTest = -1 // doesn't match any test
 					console.error = realError
+					global.reportError = realReportError
 				})
 
 				o("throws on invalid `root` DOM node", function() {
@@ -1175,7 +1177,7 @@ o.spec("route", function() {
 					var renderCount = 0
 					var spy = o.spy()
 					var error = new Error("error")
-					var errorSpy = console.error = o.spy()
+					var errorSpy = global.reportError = o.spy()
 
 					var resolver = {
 						onmatch: lock(function() {
@@ -2089,11 +2091,11 @@ o.spec("route", function() {
 					}
 
 					// Errors thrown during redrawing of mounted components are caught in m.mount()
-					// and console.error is called.
-					// Therefore, spy is used to confirm that console.error is not called
+					// and reportError is called.
+					// Therefore, spy is used to confirm that reportError is not called
 					// when it is first mounted.
-					var spy = o.spy(console.error)
-					console.error = spy
+					var spy = o.spy()
+					global.reportError = spy
 
 					$window.location.href = prefix + "/"
 					o(function(){

--- a/api/tests/test-routerGetSet.js
+++ b/api/tests/test-routerGetSet.js
@@ -22,7 +22,7 @@ o.spec("route.get/route.set", function() {
 
 					root = $window.document.body
 
-					mountRedraw = apiMountRedraw(coreRenderer($window), throttleMock.schedule, console)
+					mountRedraw = apiMountRedraw(coreRenderer($window), throttleMock.schedule)
 					route = apiRouter($window, mountRedraw)
 					route.prefix = prefix
 				})

--- a/mount-redraw.js
+++ b/mount-redraw.js
@@ -2,4 +2,4 @@
 
 var render = require("./render")
 
-module.exports = require("./api/mount-redraw")(render, typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : null, typeof console !== "undefined" ? console : null)
+module.exports = require("./api/mount-redraw")(render, typeof requestAnimationFrame !== "undefined" ? requestAnimationFrame : null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In this PR, console.error, which outputs the caught errors, has been replaced with reportError.
This PR will always forward errors during redrawing to window.onerror. This further fixes #2621, which was partially fixed in #3030.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want to fix #2621 completely.
The reportError API is a relatively new API, but it has been implemented in all supported browsers (except IE11) and should be able to better address this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test` 
- Some of the relevant tests were updated.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
