### PR TITLE
Release - v2.3.5

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -9,7 +9,7 @@ jobs:
     concurrency: prr:pre-release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: main
     - uses: actions/setup-node@v4

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-node@v4
       with:
         node-version: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     concurrency: prr:pre-release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: actions/setup-node@v4
       with:
         node-version: 20


### PR DESCRIPTION

# Release v2.3.5

<a name="changeSummary-start"></a>

- #3039

<a name="changeSummary-end"></a>
        
## Changelog

<a name="changelog-start"></a>
### Patch Changes

#### [Bump actions/checkout from 4 to 5 in the normal group (@dependabot[bot])](https://github.com/MithrilJS/mithril.js/pull/3039)

Bumps the normal group with 1 update: [actions/checkout](https://github.com/actions/checkout).  Updates `actions/checkout` from 4 to 5.  Release notes.
   
<a name="changelog-end"></a>
           
        