### PR TITLE
Performance Improvements for `Vnode.normalizeChildren()`

### DIFF
--- a/render/hyperscript.js
+++ b/render/hyperscript.js
@@ -1,5 +1,6 @@
 "use strict"
 
+var isNormalizationDeferred = require("./isNormalizationDeferred")
 var Vnode = require("../render/vnode")
 var hyperscriptVnode = require("./hyperscriptVnode")
 var hasOwn = require("../util/hasOwn")
@@ -94,6 +95,8 @@ function hyperscript(selector, attrs, ...children) {
 	if (typeof selector === "string") {
 		vnode.children = Vnode.normalizeChildren(vnode.children)
 		if (selector !== "[") return execSelector(selectorCache[selector] || compileSelector(selector), vnode)
+	} else {
+		vnode.children[isNormalizationDeferred] = true
 	}
 
 	if (vnode.attrs == null) vnode.attrs = {}

--- a/render/isNormalizationDeferred.js
+++ b/render/isNormalizationDeferred.js
@@ -1,0 +1,3 @@
+"use strict"
+
+module.exports = Symbol()

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -15,23 +15,20 @@ Vnode.normalizeChildren = function(input) {
 	// Normalize children in place for performance
 	// if vnodes are NOT component vnodes.
 	var children = input[isNormalizationDeferred] ? [] : input
-	if (input.length) {
-		var isKeyed = input[0] != null && input[0].key != null
-		// Note: this is a *very* perf-sensitive check.
-		// Fun fact: merging the loop like this is somehow faster than splitting
-		// it, noticeably so.
-		for (var i = 1; i < input.length; i++) {
-			if ((input[i] != null && input[i].key != null) !== isKeyed) {
-				throw new TypeError(
-					isKeyed && (input[i] == null || typeof input[i] === "boolean")
-						? "In fragments, vnodes must either all have keys or none have keys. You may wish to consider using an explicit keyed empty fragment, m.fragment({key: ...}), instead of a hole."
-						: "In fragments, vnodes must either all have keys or none have keys."
-				)
-			}
-		}
-		for (var i = 0; i < input.length; i++) {
-			children[i] = Vnode.normalize(input[i])
-		}
+	// Count the number of keyed normalized vnodes for consistency check.
+	// Note: this is a perf-sensitive check.
+	// Fun fact: merging the loop like this is somehow faster than splitting
+	// the check within updateNodes(), noticeably so.
+	var numKeyed = 0
+	for (var i = 0; i < input.length; i++) {
+		children[i] = Vnode.normalize(input[i])
+		if (children[i] != null && children[i].key != null) numKeyed++
+	}
+	if (numKeyed !== 0 && numKeyed !== input.length) {
+		throw new TypeError(children.includes(null)
+			? "In fragments, vnodes must either all have keys or none have keys. You may wish to consider using an explicit keyed empty fragment, m.fragment({key: ...}), instead of a hole."
+			: "In fragments, vnodes must either all have keys or none have keys."
+		)
 	}
 	return children
 }

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,5 +1,7 @@
 "use strict"
 
+var isNormalizationDeferred = require("./isNormalizationDeferred")
+
 function Vnode(tag, key, attrs, children, text, dom) {
 	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, is: undefined, domSize: undefined, state: undefined, events: undefined, instance: undefined}
 }
@@ -10,7 +12,9 @@ Vnode.normalize = function(node) {
 	return Vnode("#", undefined, undefined, String(node), undefined, undefined)
 }
 Vnode.normalizeChildren = function(input) {
-	var children = []
+	// Normalize children in place for performance
+	// if vnodes are NOT component vnodes.
+	var children = input[isNormalizationDeferred] ? [] : input
 	if (input.length) {
 		var isKeyed = input[0] != null && input[0].key != null
 		// Note: this is a *very* perf-sensitive check.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improves `Vnode.normalizeChildren()` performance by merging loops, reducing comparisons, and performing key consistency checks after normalization without breaking existing behavior.

## Description
<!--- Describe your changes in detail -->
This change improves the performance of `Vnode.normalizeChildren()` by:
- avoiding unnecessary array re-creation
- optimizing loops and consistency checks

### Performance Results

| `npm run perf` (on my laptop, node v22) | [#3041](https://github.com/MithrilJS/mithril.js/pull/3041#issuecomment-3216130054) (ops/sec) | this PR (ops/sec) | Performance Gain |
|----------------------------|-------------------|----------------------|------------------|
| construct large vnode tree | 25,949            | 29,585               | +14.0%       |
| rerender identical vnode   | 4,677,364         | 5,031,685            | +7.6%        |
| rerender same tree         | 100,954           | 105,471              | +4.5%        |
| rerender same tree (with selector-generated attrs)     | 131,815           | 143,874              | +9.1%        |
| add large nested tree      | 8,277             | 8,647                | +4.5%        |
| mutate styles/properties   | 139               | 149                  | +7.2%        |
| repeated add/removal       | 2,949             | 2,987                | +1.3%        |

Based on [the results of #3041](https://github.com/MithrilJS/mithril.js/pull/3041#issuecomment-3216130054), this change improves performance by about 5–10%.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Earlier, I found that performance could be improved by avoiding array re-creation and removing consistency checks, [as in v1](https://github.com/MithrilJS/mithril.js/blob/35ab329291f810febb80c08b498855b7832c93d9/render/vnode.js#L11-L16).
However, that approach clearly broke the current behavior, so I did not include it in #3041.

After further investigation, it turned out that similar performance improvements could be achieved without breaking the current behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
