### PR TITLE
Fix `nextSibling` bugs and refactor `updateNodes()` and its fuzzer

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -274,7 +274,7 @@ module.exports = function() {
 		else {
 			var isOldKeyed = old[0] != null && old[0].key != null
 			var isKeyed = vnodes[0] != null && vnodes[0].key != null
-			var start = 0, oldStart = 0
+			var start = 0, oldStart = 0, o, v
 			if (isOldKeyed !== isKeyed) {
 				removeNodes(parent, old, 0, old.length)
 				createNodes(parent, vnodes, 0, vnodes.length, hooks, nextSibling, ns)
@@ -299,7 +299,7 @@ module.exports = function() {
 				if (vnodes.length > commonLength) createNodes(parent, vnodes, start, vnodes.length, hooks, nextSibling, ns)
 			} else {
 				// keyed diff
-				var oldEnd = old.length - 1, end = vnodes.length - 1, map, o, v, oe, ve, topSibling
+				var oldEnd = old.length - 1, end = vnodes.length - 1, oe, ve, topSibling
 
 				// bottom-up
 				while (oldEnd >= oldStart && end >= start) {
@@ -347,11 +347,11 @@ module.exports = function() {
 				else if (oldStart > oldEnd) createNodes(parent, vnodes, start, end + 1, hooks, nextSibling, ns)
 				else {
 					// inspired by ivi https://github.com/ivijs/ivi/ by Boris Kaul
-					var originalNextSibling = nextSibling, vnodesLength = end - start + 1, oldIndices = new Array(vnodesLength), li=0, i=0, pos = 2147483647, matched = 0, map, lisIndices
-					for (i = 0; i < vnodesLength; i++) oldIndices[i] = -1
+					var originalNextSibling = nextSibling, pos = 2147483647, matched = 0
+					var oldIndices = new Array(end - start + 1).fill(-1)
 					var map = Object.create(null)
 					for (var i = start; i <= end; i++) map[vnodes[i].key] = i
-					for (i = oldEnd; i >= oldStart; i--) {
+					for (var i = oldEnd; i >= oldStart; i--) {
 						oe = old[i]
 						var newIndex = map[oe.key]
 						if (newIndex != null) {
@@ -371,22 +371,22 @@ module.exports = function() {
 						if (pos === -1) {
 							// the indices of the indices of the items that are part of the
 							// longest increasing subsequence in the oldIndices list
-							lisIndices = makeLisIndices(oldIndices)
-							li = lisIndices.length - 1
-							for (i = end; i >= start; i--) {
-								v = vnodes[i]
-								if (oldIndices[i-start] === -1) createNode(parent, v, hooks, ns, nextSibling)
+							var lisIndices = makeLisIndices(oldIndices)
+							var li = lisIndices.length - 1
+							for (var i = end; i >= start; i--) {
+								ve = vnodes[i]
+								if (oldIndices[i-start] === -1) createNode(parent, ve, hooks, ns, nextSibling)
 								else {
 									if (lisIndices[li] === i - start) li--
-									else moveDOM(parent, v, nextSibling)
+									else moveDOM(parent, ve, nextSibling)
 								}
-								if (v.dom != null) nextSibling = vnodes[i].dom
+								if (ve.dom != null) nextSibling = ve.dom
 							}
 						} else {
-							for (i = end; i >= start; i--) {
-								v = vnodes[i]
-								if (oldIndices[i-start] === -1) createNode(parent, v, hooks, ns, nextSibling)
-								if (v.dom != null) nextSibling = vnodes[i].dom
+							for (var i = end; i >= start; i--) {
+								ve = vnodes[i]
+								if (oldIndices[i-start] === -1) createNode(parent, ve, hooks, ns, nextSibling)
+								if (ve.dom != null) nextSibling = ve.dom
 							}
 						}
 					}

--- a/render/render.js
+++ b/render/render.js
@@ -291,9 +291,9 @@ module.exports = function() {
 					o = old[start]
 					v = vnodes[start]
 					if (o === v || o == null && v == null) continue
-					else if (o == null) createNode(parent, v, hooks, ns, getNextSibling(old, start + 1, nextSibling))
+					else if (o == null) createNode(parent, v, hooks, ns, getNextSibling(old, start + 1, old.length, nextSibling))
 					else if (v == null) removeNode(parent, o)
-					else updateNode(parent, o, v, hooks, getNextSibling(old, start + 1, nextSibling), ns)
+					else updateNode(parent, o, v, hooks, getNextSibling(old, start + 1, old.length, nextSibling), ns)
 				}
 				if (old.length > commonLength) removeNodes(parent, old, start, old.length)
 				if (vnodes.length > commonLength) createNodes(parent, vnodes, start, vnodes.length, hooks, nextSibling, ns)
@@ -316,13 +316,13 @@ module.exports = function() {
 					v = vnodes[start]
 					if (o.key !== v.key) break
 					oldStart++, start++
-					if (o !== v) updateNode(parent, o, v, hooks, getNextSibling(old, oldStart, nextSibling), ns)
+					if (o !== v) updateNode(parent, o, v, hooks, getNextSibling(old, oldStart, oldEnd + 1, nextSibling), ns)
 				}
 				// swaps and list reversals
 				while (oldEnd >= oldStart && end >= start) {
 					if (start === end) break
 					if (o.key !== ve.key || oe.key !== v.key) break
-					topSibling = getNextSibling(old, oldStart, nextSibling)
+					topSibling = getNextSibling(old, oldStart, oldEnd, nextSibling)
 					moveDOM(parent, oe, topSibling)
 					if (oe !== v) updateNode(parent, oe, v, hooks, topSibling, ns)
 					if (++start <= --end) moveDOM(parent, o, nextSibling)
@@ -533,8 +533,8 @@ module.exports = function() {
 		return result
 	}
 
-	function getNextSibling(vnodes, i, nextSibling) {
-		for (; i < vnodes.length; i++) {
+	function getNextSibling(vnodes, i, end, nextSibling) {
+		for (; i < end; i++) {
 			if (vnodes[i] != null && vnodes[i].dom != null) return vnodes[i].dom
 		}
 		return nextSibling

--- a/render/render.js
+++ b/render/render.js
@@ -349,8 +349,9 @@ module.exports = function() {
 					// inspired by ivi https://github.com/ivijs/ivi/ by Boris Kaul
 					var originalNextSibling = nextSibling, vnodesLength = end - start + 1, oldIndices = new Array(vnodesLength), li=0, i=0, pos = 2147483647, matched = 0, map, lisIndices
 					for (i = 0; i < vnodesLength; i++) oldIndices[i] = -1
+					var map = Object.create(null)
+					for (var i = start; i <= end; i++) map[vnodes[i].key] = i
 					for (i = oldEnd; i >= oldStart; i--) {
-						if (map == null) map = getKeyMap(vnodes, start, end + 1)
 						oe = old[i]
 						var newIndex = map[oe.key]
 						if (newIndex != null) {
@@ -474,17 +475,6 @@ module.exports = function() {
 			if (old.instance != null) removeNode(parent, old.instance)
 			vnode.domSize = 0
 		}
-	}
-	function getKeyMap(vnodes, start, end) {
-		var map = Object.create(null)
-		for (; start < end; start++) {
-			var vnode = vnodes[start]
-			if (vnode != null) {
-				var key = vnode.key
-				if (key != null) map[key] = start
-			}
-		}
-		return map
 	}
 	// Lifted from ivi https://github.com/ivijs/ivi/
 	// takes a list of unique numbers (-1 is special and can

--- a/render/render.js
+++ b/render/render.js
@@ -275,17 +275,17 @@ module.exports = function() {
 			var isOldKeyed = old[0] != null && old[0].key != null
 			var isKeyed = vnodes[0] != null && vnodes[0].key != null
 			var start = 0, oldStart = 0
-			if (!isOldKeyed) while (oldStart < old.length && old[oldStart] == null) oldStart++
-			if (!isKeyed) while (start < vnodes.length && vnodes[start] == null) start++
 			if (isOldKeyed !== isKeyed) {
-				removeNodes(parent, old, oldStart, old.length)
-				createNodes(parent, vnodes, start, vnodes.length, hooks, nextSibling, ns)
+				removeNodes(parent, old, 0, old.length)
+				createNodes(parent, vnodes, 0, vnodes.length, hooks, nextSibling, ns)
 			} else if (!isKeyed) {
 				// Don't index past the end of either list (causes deopts).
 				var commonLength = old.length < vnodes.length ? old.length : vnodes.length
 				// Rewind if necessary to the first non-null index on either side.
 				// We could alternatively either explicitly create or remove nodes when `start !== oldStart`
 				// but that would be optimizing for sparse lists which are more rare than dense ones.
+				while (oldStart < old.length && old[oldStart] == null) oldStart++
+				while (start < vnodes.length && vnodes[start] == null) start++
 				start = start < oldStart ? start : oldStart
 				for (; start < commonLength; start++) {
 					o = old[start]

--- a/render/render.js
+++ b/render/render.js
@@ -349,15 +349,15 @@ module.exports = function() {
 					// inspired by ivi https://github.com/ivijs/ivi/ by Boris Kaul
 					var originalNextSibling = nextSibling, vnodesLength = end - start + 1, oldIndices = new Array(vnodesLength), li=0, i=0, pos = 2147483647, matched = 0, map, lisIndices
 					for (i = 0; i < vnodesLength; i++) oldIndices[i] = -1
-					for (i = end; i >= start; i--) {
-						if (map == null) map = getKeyMap(old, oldStart, oldEnd + 1)
-						ve = vnodes[i]
-						var oldIndex = map[ve.key]
-						if (oldIndex != null) {
-							pos = (oldIndex < pos) ? oldIndex : -1 // becomes -1 if nodes were re-ordered
-							oldIndices[i-start] = oldIndex
-							oe = old[oldIndex]
-							old[oldIndex] = null
+					for (i = oldEnd; i >= oldStart; i--) {
+						if (map == null) map = getKeyMap(vnodes, start, end + 1)
+						oe = old[i]
+						var newIndex = map[oe.key]
+						if (newIndex != null) {
+							pos = (newIndex < pos) ? newIndex : -1 // becomes -1 if nodes were re-ordered
+							oldIndices[newIndex-start] = i
+							ve = vnodes[newIndex]
+							old[i] = null
 							if (oe !== ve) updateNode(parent, oe, ve, hooks, nextSibling, ns)
 							if (ve.dom != null) nextSibling = ve.dom
 							matched++

--- a/render/tests/test-updateNodes.js
+++ b/render/tests/test-updateNodes.js
@@ -1169,6 +1169,51 @@ o.spec("updateNodes", function() {
 		o(root.appendChild.callCount + root.insertBefore.callCount).equals(5)
 		o(tagNames).deepEquals(expectedTagNames)
 	})
+	o("update keyed element vnodes with another tag (#3059)", function() {
+		var e = function(k) {return m(k, {key: k})} // element vnode
+		var p = function(k) {return m(k + "p", {key: k})} // element vnode (another tag)
+
+		const o1 = [e("k1"),e("k2"),e("k3"),e("k4")]
+		const v1 = [p("k2"),e("k4"),e("k3")]
+
+		// create
+		render(root, v1)
+		o(Array.from(root.childNodes).map(function(n) {return n.nodeName})).deepEquals(["K2P", "K4", "K3"])
+
+		// update
+		render(root, [])
+		render(root, o1)
+		render(root, v1)
+		o(Array.from(root.childNodes).map(function(n) {return n.nodeName})).deepEquals(["K2P", "K4", "K3"])
+	})
+	o("update keyed element vnodes with dom and keyed fragment vnodes without dom (1) (#3059)", function() {
+		o(function() {
+			var e = function(k) {return m(k, {key: k})} // element vnode (with dom)
+			var f = function(k) {return m("[", {key: k})} // fragment vnode (without dom)
+
+			var o1 = [f("k1"),e("k2")]
+			var v1 = [e("k1"),e("a"),f("k2")]
+
+			render(root, o1)
+			render(root, v1)
+
+			o(Array.from(root.childNodes).map(function(n) {return n.nodeName})).deepEquals(["K1", "A"])
+		}).notThrows(Error)
+	})
+	o("update keyed element vnodes with dom and keyed fragment vnodes without dom (2) (#3059)", function() {
+		o(function() {
+			var e = function(k) {return m(k, {key: k})} // element vnode (with dom)
+			var f = function(k) {return m("[", {key: k})} // fragment vnode (without dom)
+
+			var o1 = [f("k1"),f("k2"),e("k3")]
+			var v1 = [e("k1"),f("k3"),e("k2")]
+
+			render(root, o1)
+			render(root, v1)
+
+			o(Array.from(root.childNodes).map(function(n) {return n.nodeName})).deepEquals(["K1", "K2"])
+		}).notThrows(Error)
+	})
 
 	components.forEach(function(cmp){
 		o.spec(cmp.kind, function(){

--- a/render/tests/test-updateNodesFuzzer.js
+++ b/render/tests/test-updateNodesFuzzer.js
@@ -25,15 +25,17 @@ o.spec("updateNodes keyed list Fuzzer", function() {
 		var tests = 250
 
 		while (tests--) {
-			var test = fuzzTest(c.delMax, c.movMax, c.insMax)
+			const test = fuzzTest(c.delMax, c.movMax, c.insMax)
 			o(i++ + ": " + test.list.join() + " -> " + test.updated.join(), function() {
 				render(root, test.list.map(function(x){return m(x, {key: x})}))
 				addSpies(root)
 				render(root, test.updated.map(function(x){return m(x, {key: x})}))
 
-				if (root.appendChild.callCount + root.insertBefore.callCount !== test.expected.creations + test.expected.moves) console.log(test, {aC: root.appendChild.callCount, iB: root.insertBefore.callCount}, [].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()}))
+				// FIXME: This does not take into account the "swaps and list reversals" heuristic in updateNodes().
+				// if (root.appendChild.callCount + root.insertBefore.callCount !== test.expected.creations + test.expected.moves) console.log(test, {aC: root.appendChild.callCount, iB: root.insertBefore.callCount}, [].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()}))
 
-				o(root.appendChild.callCount + root.insertBefore.callCount).equals(test.expected.creations + test.expected.moves)("moves")
+				// ditto
+				// o(root.appendChild.callCount + root.insertBefore.callCount).equals(test.expected.creations + test.expected.moves)("moves")
 				o(root.removeChild.callCount).equals(test.expected.deletions)("deletions")
 				o([].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()})).deepEquals(test.updated)
 			})

--- a/render/tests/test-updateNodesFuzzer.js
+++ b/render/tests/test-updateNodesFuzzer.js
@@ -33,9 +33,12 @@ o.spec("updateNodes keyed list Fuzzer", function() {
 				render(root, test.updated.map(function(x){return m(x, {key: x})}))
 
 				// FIXME: This does not take into account the "swaps and list reversals" heuristic in updateNodes().
+				// Here, we’re checking whether the number of node moves matches the theoretical value derived from the LIS.
+				// However, in updateNodes(), when patterns such as swaps or reversed lists are detected,
+				// nodes are moved before the LIS-based reordering is applied.
+				// Once these heuristic moves occur, the actual number of moves no longer matches the LIS-based theoretical value.
 				// if (root.appendChild.callCount + root.insertBefore.callCount !== test.expected.creations + test.expected.moves) console.log(test, {aC: root.appendChild.callCount, iB: root.insertBefore.callCount}, [].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()}))
-
-				// ditto
+				//
 				// o(root.appendChild.callCount + root.insertBefore.callCount).equals(test.expected.creations + test.expected.moves)("moves")
 				o(root.removeChild.callCount).equals(test.expected.deletions)("deletions")
 				o([].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()})).deepEquals(test.updated)

--- a/render/tests/test-updateNodesFuzzer.js
+++ b/render/tests/test-updateNodesFuzzer.js
@@ -26,7 +26,8 @@ o.spec("updateNodes keyed list Fuzzer", function() {
 
 		while (tests--) {
 			const test = fuzzTest(c.delMax, c.movMax, c.insMax)
-			o(i++ + ": " + test.list.join() + " -> " + test.updated.join(), function() {
+			const id = i++
+			o(id + ": " + test.list.join() + " -> " + test.updated.join(), function() {
 				render(root, test.list.map(function(x){return m(x, {key: x})}))
 				addSpies(root)
 				render(root, test.updated.map(function(x){return m(x, {key: x})}))
@@ -38,6 +39,29 @@ o.spec("updateNodes keyed list Fuzzer", function() {
 				// o(root.appendChild.callCount + root.insertBefore.callCount).equals(test.expected.creations + test.expected.moves)("moves")
 				o(root.removeChild.callCount).equals(test.expected.deletions)("deletions")
 				o([].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()})).deepEquals(test.updated)
+			})
+			o(id + ": including tag changes", function() {
+				// change some tags before and after the update
+				var list = test.list.map(function(x){return m(x + (Math.random() > 0.5 ? "_" : ""), {key: x})})
+				var updated = test.updated.map(function(x){return m(x, {key: x})})
+				var str = list.map(function(v) {return v.tag}).join() + " -> " + updated.map(function(v) {return v.tag}).join()
+
+				render(root, list)
+				render(root, updated)
+
+				o([].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()})).deepEquals(test.updated)(str)
+			})
+			o(id + ": including empty fragments (without dom)", function() {
+				// change some vnodes to empty fragments without DOM before and after the update
+				var list = test.list.map(function(x){return m(Math.random() > 0.5 ? x : "[", {key: x})})
+				var updated = test.updated.map(function(x){return m(Math.random() > 0.5 ? x : "[", {key: x})})
+				var expected = updated.map(function(v){return v.tag}).filter(function(x){return x !== "["})
+				var str = list.map(function(v) {return v.tag + "." + v.key}).join() + " -> " + updated.map(function(v) {return v.tag + "." + v.key}).join()
+
+				render(root, list)
+				render(root, updated)
+
+				o([].map.call(root.childNodes, function(n){return n.nodeName.toLowerCase()})).deepEquals(expected)(str)
 			})
 		}
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes `nextSibling`-related bugs in `updateNodes()` and updates updateNodesFuzzer to better cover these cases. It also refactors `updateNodes()` to simplify the logic and improve maintainability.

## Description
<!--- Describe your changes in detail -->
This PR makes the following changes related to `updateNodes()`.
- Fix for bugs related to nextSibling
- Fix for updateNodesFuzzer and addition of test cases
- Refactoring including adjusting variable declaration positions and names
  - This change reduces the bundle size to 8,899 bytes gzipped.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR fixes the following issues related to the way `nextSibling` is set, which I noticed while reading the `updateNodes()` code. (The cases below are simplified versions of those found by the fuzzer.)
Additionally, since updateNodesFuzzer also appeared to have problems, I fixed those issues as well and added additional test cases.

case 1 ([flems](https://flems.io/mithril@2.3.8#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgCsEAaEAYwHs0AXGWvKtOGgAgCdLK2BeVgE0rkArjlr4ARpX4BPADpoFTFqxis+ACgDWASnUA+Vlm0lWwLTBmJWWgL57WjpwHpnq2GLYA3NNJhLqFQAHdVZtPR5DYy1WAGpWORAgxNNzS2s7PVd3GE9WHz8wjF8aAAsYdlYaDABzHQUA5jZKAEZQ5BgNRK0WxJ0STu6AJj6BrpAtAGZRwYmAFj6AXUaVLza+ZCct1iDxrRGQftmtBcOx7unD5cU0bPJ2GAw6BSx8B7R+Co1OblM1+rQykosHwUEoNQ0AEF2OwMDJ8GBOMYfjR8ORStB+AA5PxwHT4LAYXZoAysND4XyfLHYGA6LJuTYAcgA0kMAAqM0wsuac1gsyaM1iLVhUGEwcg0Bq3NzCIL8J7+NCvd6fdjfLg0UzIRYA5X0VXq36sVq6t76r4ov4tAFAkFgiHQ2HwxGUZEatEYqDY3H4wnE0nkykwak4OmsbJM5k8rnMgUx9mC4UQQGUMUSkC2Ra2IA))
```js
const root = document.body

const e = (k) => m(k, {key: k})       // element vnode
const p = (k) => m(k + "p", {key: k}) // element vnode (another tag)

const o1 = [e("k1"),e("k2"),e("k3"),e("k4")]
const v1 = [        p("k2"),e("k4"),e("k3")]

// create
m.render(root, v1)
console.log(Array.from(root.childNodes).map(n => n.nodeName)) // [ 'K2P', 'K4', 'K3' ] correct

// update
m.render(root, [])
m.render(root, o1)
m.render(root, v1)
console.log(Array.from(root.childNodes).map(n => n.nodeName)) // [ 'K4', 'K3', 'K2P' ] incorrect
```

case 2 ([flems](https://flems.io/mithril@2.3.8#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgCsEAaEAYwHs0AXGWvKtOGgAgCdLK2BeVgE0rkArjlr4ARpX4BPADpoFTFqxis+ACgDWASnUA+Vlm0lWwLTBmJWWgL57WrAPRPVsMWwBuaaWo0B3CBoACwFKLB0lahUwdVZtPR5DYzkQZFTTc0trOz0XVjB2DABzD1ZvX3jAkMphNkEIhSjmNkoARjjkMA1UrTbUnVNHYdUekC0AJgGAXWaVTw6+ZBgxvoGSFdSMde7eqZAdWcU0LHx2en4Ydg1OblN2yJOzi6ubrhpTBbzXADlffAgzCuNAAQjAwJRztYAMLBaD8Vg0SisQFwYGsCTgyFqCBwVg+NgYVjkOFQBGUWIhXH43wgWzTWxAA))
```js
const root = document.body

const e = (k) => m(k, {key: k})   // element vnode (with dom)
const f = (k) => m("[", {key: k}) // fragment vnode (without dom)

const o1 = [f("k1"),       e("k2")]
const v1 = [e("k1"),e("a"),f("k2")]

m.render(root, o1)
m.render(root, v1) // Node.insertBefore: Child to insert before is not a child of this node
```

case 3 ([flems](https://flems.io/mithril@2.3.8#0=N4IgZglgNgpgziAXAbVAOwIYFsZJAOgCsEAaEAYwHs0AXGWvKtOGgAgCdLK2BeVgE0rkArjlr4ARpX4BPADpoFTFqxis+ACgDWASnUA+Vlm0lWwLTBmJWWgL57WrAPRPVsMWwBuaaWo0B3CBoACwFKLB0lahUwdVZtPR5DYzkQZFTTc0trOz0XVjB2DABzD1ZvX3jAkMphNkEIhSjmNkoARjjkMA1UrTbUnRJu3oAmAZIYHpAtAGYBgF1mlU8OvmRJ3v6QQeHpue2Jqa0x7cXFNCx8dnp+GHYNTm5TdsiLq5u7h64aUxW81wAcr58BBmHcaAAhGBgSjXawAYWC0H4rBolFYoLg4NYEmhsLUEDgrB8bAwrHISKgKMosRChOJvhAtnmtiAA))
```js
const root = document.body

const e = (k) => m(k, {key: k})   // element vnode (with dom)
const f = (k) => m("[", {key: k}) // fragment vnode (without dom)

const o1 = [f("k1"),f("k2"),e("k3")]
const v1 = [e("k1"),f("k3"),e("k2")]

m.render(root, o1)
m.render(root, v1) // Node.insertBefore: Child to insert before is not a child of this node
```

Since these cases occur only with keyed vnodes and involve very rare patterns - such as fragments that do not correspond to DOM nodes or tag changes that cause node deletions and insertions - the bugs likely did not surface very often.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`
I have also confirmed the above flems case fix.

As for the fuzzer, I’ve confirmed that it is tested with different patterns, and that even after increasing the number of runs, all tests still pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
