### PR TITLE
[refactor] Remove redundant code related to text vnodes

### DIFF
--- a/render/render.js
+++ b/render/render.js
@@ -863,7 +863,6 @@ module.exports = function() {
 		// unlike special "attributes" internally.
 		vnode.attrs = old.attrs
 		vnode.children = old.children
-		vnode.text = old.text
 		return true
 	}
 

--- a/render/render.js
+++ b/render/render.js
@@ -419,7 +419,7 @@ module.exports = function() {
 		}
 	}
 	function updateText(old, vnode) {
-		if (old.children.toString() !== vnode.children.toString()) {
+		if (old.children !== vnode.children) {
 			old.dom.nodeValue = vnode.children
 		}
 		vnode.dom = old.dom

--- a/render/trust.js
+++ b/render/trust.js
@@ -4,5 +4,5 @@ var Vnode = require("../render/vnode")
 
 module.exports = function(html) {
 	if (html == null) html = ""
-	return Vnode("<", undefined, undefined, html, undefined, undefined)
+	return Vnode("<", undefined, undefined, html)
 }

--- a/render/vnode.js
+++ b/render/vnode.js
@@ -1,13 +1,13 @@
 "use strict"
 
-function Vnode(tag, key, attrs, children, text, dom) {
-	return {tag: tag, key: key, attrs: attrs, children: children, text: text, dom: dom, is: undefined, domSize: undefined, state: undefined, events: undefined, instance: undefined}
+function Vnode(tag, key, attrs, children) {
+	return {tag: tag, key: key, attrs: attrs, children: children, dom: undefined, is: undefined, domSize: undefined, state: undefined, events: undefined, instance: undefined}
 }
 Vnode.normalize = function(node) {
-	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node), undefined, undefined)
+	if (Array.isArray(node)) return Vnode("[", undefined, undefined, Vnode.normalizeChildren(node))
 	if (node == null || typeof node === "boolean") return null
 	if (typeof node === "object") return node
-	return Vnode("#", undefined, undefined, String(node), undefined, undefined)
+	return Vnode("#", undefined, undefined, String(node))
 }
 Vnode.normalizeChildren = function(input) {
 	// Preallocate the array length (initially holey) and fill every index immediately in order.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR removes the following redundant code:
- `vnode.text`-related code, which has not been used internally since #2670.
- The `toString()` calls used to compare old and new strings in `updateText`. Both strings have already been normalized via `String()`.

`npm run test` passes as-is.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is expected to slightly improve bundle size and performance.
In addition, the `vnode.text`-related code appears very early in the mithril.js build bundle; removing it also improves readability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm run test`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [x] I have read https://mithril.js.org/contributing.html.
