### PR TITLE
chore: only include some files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A framework for building brilliant applications",
   "author": "Leo Horie",
   "license": "MIT",
+  "main": "mithril.js",
   "unpkg": "mithril.min.js",
   "jsdelivr": "mithril.min.js",
   "repository": "github:MithrilJS/mithril.js",
@@ -31,5 +32,10 @@
     "ospec": "4.2.1",
     "rimraf": "^6.0.1",
     "terser": "^5.7.2"
-  }
+  },
+  "files": [
+    "mithril.*",
+    "stream.js",
+    "stream/*.js"
+  ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Only include some files:
- `mithril.js`
- `mithril.min.js`
- `stream.js`
- `stream/stream.js`
- `stream/stream.min.js`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I see if you bring some unnecessary files and folder like `.github`, `docs`, and other to npm registry, so i exclude it.

I think if this can be a breaking change, but because i ONLY exclude undocumented files, i think if this is safe.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My change requires a documentation update, and I've opened a pull request to update it already:
- [ ] I have read https://mithril.js.org/contributing.html.
