### PR TITLE
fix(request): stringify non-string XHR error responses

### DIFF
--- a/request/request.js
+++ b/request/request.js
@@ -96,6 +96,12 @@ module.exports = function($window, oncompletion) {
 							var completeErrorResponse = function() {
 								try { message = ev.target.responseText }
 								catch (e) { message = response }
+								// Error() stringifies non-strings poorly (e.g. [object Object]);
+								// responseText is also unavailable for responseType json/arraybuffer/etc.
+								if (typeof message !== "string") {
+									try { message = JSON.stringify(message) }
+									catch (stringifyError) { message = String(message) }
+								}
 								var error = new Error(message)
 								error.code = ev.target.status
 								error.response = response

--- a/request/tests/test-request.js
+++ b/request/tests/test-request.js
@@ -620,7 +620,7 @@ o.spec("request", function() {
 			})
 			request({method: "GET", url: "/item"}).catch(function(e) {
 				o(e instanceof Error).equals(true)
-				o(e.message).equals("[object Object]")
+				o(e.message).equals(JSON.stringify({error: "error"}))
 				o(e.response).deepEquals({error: "error"})
 				o(e.code).equals(500)
 			}).then(done)


### PR DESCRIPTION
## Summary
When `responseType` is `json` (the default) or another non-text type, reading `responseText` throws and the catch path passed the parsed response object into `new Error(...)`. That produced an unhelpful `"[object Object]"` message even though `error.response` already held the body.

This stringifies non-string error messages with `JSON.stringify` (falling back to `String(...)`) so `error.message` stays readable for JSON error bodies and other non-text response types.

Fixes #2802

## Test plan
- [x] Updated the existing failure-case assertion that expected `"[object Object]"`
- [x] Ran `npx ospec request/tests/test-request.js` (117 assertions passed)